### PR TITLE
feat(v1.13.0): add harness falsification suite and npm run compliance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "bigpowers",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "agent skills for spec-driven, test-first software development by solo developers.",
   "main": "index.js",
   "scripts": {
     "sync": "bash scripts/sync-skills.sh",
-    "install": "bash scripts/install.sh"
+    "install": "bash scripts/install.sh",
+    "compliance": "bash scripts/audit-compliance.sh"
   },
   "keywords": [
     "ai",

--- a/specs/PLAN.md
+++ b/specs/PLAN.md
@@ -1,43 +1,38 @@
-# Plan: v1.12.1 — CONVENTIONS.md Hardening
+# Plan: v1.13.0 — Harness Falsification + npm integration
 
 ## Context
 
-The Claude-judged audit (2026-05-18) scored 75% (67/89). The conventions.feature and cleancode.feature
-test CONVENTIONS.md directly and found 10 missing mandates. Adding them to CONVENTIONS.md is the
-highest-WSJF action remaining (8.7): minimal effort, ~8 additional audit passes.
-Target file: CONVENTIONS.md (currently 101 lines). No other files touched.
+The compliance harness (audit-compliance.sh) has no self-tests — there is no proof that a broken
+step actually triggers FAIL. v1.13.0 adds falsification suites (intentionally bad fixtures that
+MUST fail), wires `npm run compliance` for one-command invocation, and bumps package.json version
+to 1.13.0.
 
 ## Steps
 
-1. Add **Boy Scout Rule** to Code Style section: "Leave every file you touch at least as clean as you found it." → verify: `grep -c "Boy Scout" CONVENTIONS.md`
+1. Add `npm run compliance` script to package.json that runs all feature files through the harness
+   → verify: `node -e "const p=require('./package.json'); console.log(p.scripts.compliance)" | grep audit-compliance`
 
-2. Add **G25 — No magic strings or numbers** to Code Style section: named constants only, no bare string literals or numeric literals in logic. → verify: `grep -c "G25\|magic string\|magic number" CONVENTIONS.md`
+2. Bump package.json version to 1.13.0
+   → verify: `node -e "console.log(require('./package.json').version)" | grep 1.13.0`
 
-3. Add **G28 — Boolean logic in named functions** to Code Style section: complex boolean expressions must be extracted into a named predicate function. → verify: `grep -c "G28\|boolean\|predicate" CONVENTIONS.md`
+3. Create `specs/audit/falsification/` directory with `harness-falsification.feature` — one scenario
+   whose step intentionally exits non-zero, proving the harness honours FAIL
+   → verify: `[ -f specs/audit/falsification/harness-falsification.feature ] && echo ok`
 
-4. Add **N7 — Names describe side-effects** to Code Style section: if a function sends email, writes a file, or mutates state, the name must say so. → verify: `grep -c "N7\|side.effect" CONVENTIONS.md`
+4. Create `specs/audit/steps/then-this-step-always-fails.sh` that exits 1 with a clear message
+   → verify: `bash specs/audit/steps/then-this-step-always-fails.sh; [ $? -eq 1 ] && echo "exits 1 correctly"`
 
-5. Add **C5 — No commented-out code** to Comments section: dead code must be deleted, not commented out. → verify: `grep -c "C5\|commented.out\|comment.*dead" CONVENTIONS.md`
+5. Run the falsification feature through the harness and confirm it reports FAIL
+   → verify: `bash scripts/audit-compliance.sh specs/audit/falsification/harness-falsification.feature 2>&1 | grep "FAIL: 1"`
 
-6. Add **Exceptions over error codes** to Code Style section: throw/raise exceptions rather than returning numeric or boolean error codes. → verify: `grep -c "exception\|error code" CONVENTIONS.md`
-
-7. Add **G9/F4 — Remove dead code** to Code Style section: unused functions, unreachable branches, and stale imports must be deleted. → verify: `grep -c "G9\|F4\|dead code\|unused" CONVENTIONS.md`
-
-8. Add **T5 — Test boundary conditions** to Tests section: every test suite must cover exact edge values (empty, max, off-by-one). → verify: `grep -c "T5\|boundary" CONVENTIONS.md`
-
-9. Add **T8 — Test through public interfaces only** to Tests section: tests must assert on observable outcomes (API responses, return values, UI state) — never on internal state or private methods. → verify: `grep -c "T8\|public interface\|implementation detail" CONVENTIONS.md`
-
-10. Add **Verify mandate** to Tests section (or a new Verification section): every change must be verifiable with a single runnable command before marking a step done. → verify: `grep -c "verify\|runnable command" CONVENTIONS.md`
-
-11. Validate CONVENTIONS.md is well-formed and under 300 lines → verify: `wc -l CONVENTIONS.md && bash scripts/sync-skills.sh 2>&1 | tail -2`
+6. Run `npm run compliance` in dry-run mode against all real features to confirm end-to-end
+   → verify: `npm run compliance -- --dry-run 2>&1 | grep -c "FEATURE:"`
 
 ## Out of scope
 
-- Editing any SKILL.md files
-- Changing the audit feature files themselves
-- Adding T4 (ignored tests) — targeted for v1.16.0
+- LLM caching (deferred: risk of stale verdicts outweighs benefit at current volume)
+- New real feature files or step scripts beyond the falsification fixture
 
 ## Risks
 
-- File growth: CONVENTIONS.md is 101 lines; 10 additions will bring it to ~120 lines — well under the 300-line limit.
-- Wording must be tight enough to pass the Claude judge ("clearly satisfies the criterion") — cite heuristic codes (G25, N7, etc.) so the judge can match them directly.
+- npm run compliance runs all 8 features sequentially; missing step scripts already report FAIL gracefully, so no blocking risk.

--- a/specs/audit/falsification/harness-falsification.feature
+++ b/specs/audit/falsification/harness-falsification.feature
@@ -1,0 +1,8 @@
+Feature: Harness Falsification Test
+  As a compliance engineer
+  I want to verify that the harness correctly reports FAIL
+  So that a passing harness actually means something
+
+  Scenario: Intentional Failure
+    Given the codebase exists
+    Then this step always fails

--- a/specs/audit/steps/then-this-step-always-fails.sh
+++ b/specs/audit/steps/then-this-step-always-fails.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Falsification fixture — must always exit 1.
+# If the harness reports PASS for this step, the harness itself is broken.
+echo "FALSIFICATION: This step intentionally fails to verify the harness honours non-zero exit codes."
+exit 1


### PR DESCRIPTION
- Add npm run compliance script to package.json for one-command harness invocation
- Bump version to 1.13.0
- Add specs/audit/falsification/harness-falsification.feature: intentional FAIL fixture
- Add specs/audit/steps/then-this-step-always-fails.sh: exits 1, proves harness honours failures
- Falsification run confirms FAIL: 1 — harness is trustworthy

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
