### PR TITLE
feat(e31): wire npm run compliance as pre-release CI gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Compliance gate
+        run: npm run compliance
+
       - name: Release
         run: npm run release
         env:


### PR DESCRIPTION
## e31s02 — Compliance CI Gate

Adds `npm run compliance` as a blocking step in `publish.yml` before semantic-release.

### What it does
- Runs `npm run compliance` after `npm ci`, before `npm run release`
- If compliance fails, the release job fails — no publication
- Zero-config: uses existing npm script, no new dependencies

### Security
- Runs with existing `contents: write` permissions (no escalation)
- Compliance script is trusted (same repo)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires `npm run compliance` as a blocking CI gate in `publish.yml`, inserted between `npm ci` and `npm run release`. The compliance script chains `audit-compliance.sh` (Gherkin feature-file verification) and `validate-doctrine.sh` (invariant drift guard).

- The step placement is correct — it sits before semantic-release with no new permissions or dependencies.
- `audit-compliance.sh` exits 0 when the `specs/verifications/features` directory is missing or contains no `.feature` files, so the gate can be silently bypassed; the cosmetic \"GATE: FAIL (below 94%)\" line in stdout has no effect on the process exit code. `validate-doctrine.sh` uses `set -euo pipefail` and is unaffected by this gap.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the workflow wiring itself, but the compliance gate can silently pass without running any Gherkin checks if the features directory is absent.

The workflow change is minimal and correctly positioned — one new step, no permission escalation. The concern is in audit-compliance.sh: its exit-code logic only fires on failures, not on a zero-test run, so the gate can give a green result while performing no actual compliance verification. This affects the reliability of the gate under certain repo states but does not itself break the release pipeline today as long as feature files are present.

.github/workflows/publish.yml is straightforward; scripts/audit-compliance.sh (not in the diff but directly invoked) is where the zero-test exit-code gap lives and warrants a follow-up fix.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish.yml | Adds a blocking Compliance gate step (npm run compliance) between dependency install and semantic-release; step placement and permissions are correct, but the underlying audit script can exit 0 with no checks run. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant CI as release job
    participant NC as npm ci
    participant CG as Compliance gate
    participant AC as audit-compliance.sh
    participant VD as validate-doctrine.sh
    participant SR as npm run release

    GH->>CI: push to main
    CI->>NC: Install dependencies
    NC-->>CI: success
    CI->>CG: npm run compliance
    CG->>AC: bash scripts/audit-compliance.sh specs/verifications/features
    AC-->>CG: exit 0 (even if no .feature files found)
    CG->>VD: bash scripts/validate-doctrine.sh
    VD-->>CG: exit 0 or 1
    CG-->>CI: combined exit code
    CI->>SR: npm run release (semantic-release)
    SR-->>GH: publish npm + GitHub release
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant CI as release job
    participant NC as npm ci
    participant CG as Compliance gate
    participant AC as audit-compliance.sh
    participant VD as validate-doctrine.sh
    participant SR as npm run release

    GH->>CI: push to main
    CI->>NC: Install dependencies
    NC-->>CI: success
    CI->>CG: npm run compliance
    CG->>AC: bash scripts/audit-compliance.sh specs/verifications/features
    AC-->>CG: exit 0 (even if no .feature files found)
    CG->>VD: bash scripts/validate-doctrine.sh
    VD-->>CG: exit 0 or 1
    CG-->>CI: combined exit code
    CI->>SR: npm run release (semantic-release)
    SR-->>GH: publish npm + GitHub release
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(e31): wire npm run compliance as pr..."](https://github.com/danielvm-git/bigpowers/commit/72c5cdd154c582ad7904500afb549e128ffb6953) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41558376)</sub>

<!-- /greptile_comment -->