### PR TITLE
feat(e31): golden suite runner — deterministic gate orchestrator

### DIFF
--- a/scripts/run-golden-suite.sh
+++ b/scripts/run-golden-suite.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# run-golden-suite.sh — Deterministic golden suite runner
+#
+# Runs compliance → G-04 self-test in order, captures results,
+# writes timestamped YAML report. Supports --dry-run and --baseline.
+#
+# Usage:
+#   bash scripts/run-golden-suite.sh              # run all gates
+#   bash scripts/run-golden-suite.sh --dry-run    # print plan only
+#   bash scripts/run-golden-suite.sh --baseline   # run + pin baseline
+
+set -euo pipefail
+
+REPORT_DIR="specs/benchmarks/reports"
+BASELINE_FILE="$REPORT_DIR/BASELINE-GOLDEN.yaml"
+DRY_RUN=false
+BASELINE_MODE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --baseline) BASELINE_MODE=true ;;
+    *) echo "Unknown flag: $arg"; echo "Usage: run-golden-suite.sh [--dry-run] [--baseline]"; exit 2 ;;
+  esac
+done
+
+# ── Gate definitions ──────────────────────────────────────────────────
+# Each gate: name, command, optional: true (won't fail suite if missing)
+GATES=(
+  "compliance:npm run compliance:false"
+  "g04-selftest:bash scripts/golden-g04-selftest.sh:true"
+)
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+# ── Dry run ───────────────────────────────────────────────────────────
+
+if $DRY_RUN; then
+  echo "Golden Suite — DRY RUN"
+  echo "Gates (in order):"
+  for gate in "${GATES[@]}"; do
+    IFS=':' read -r name cmd optional <<< "$gate"
+    echo "  - $name: $cmd"
+  done
+  echo "Report: $REPORT_DIR/GOLDEN-YYYY-MM-DD.yaml"
+  echo "OK (dry run)"
+  exit 0
+fi
+
+# ── Setup ─────────────────────────────────────────────────────────────
+
+mkdir -p "$REPORT_DIR"
+
+TODAY=$(date +%Y-%m-%d)
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+GIT_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+
+if $BASELINE_MODE; then
+  REPORT_FILE="$BASELINE_FILE"
+else
+  REPORT_FILE="$REPORT_DIR/GOLDEN-${TODAY}.yaml"
+fi
+
+# ── Run gates ─────────────────────────────────────────────────────────
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+GATE_RESULTS=()
+
+for gate in "${GATES[@]}"; do
+  IFS=':' read -r name cmd is_optional <<< "$gate"
+
+  echo -n "[$name] "
+
+  # Check if command exists (for scripts)
+  main_cmd=$(echo "$cmd" | awk '{print $1}')
+  if [[ "$main_cmd" == "bash" ]]; then
+    script_path=$(echo "$cmd" | awk '{print $2}')
+    if [[ ! -f "$script_path" ]]; then
+      if [[ "$is_optional" == "true" ]]; then
+        echo -e "${YELLOW}SKIP${NC} (script not yet implemented)"
+        GATE_RESULTS+=("  - name: $name")
+        GATE_RESULTS+=("    exit_code: skipped")
+        GATE_RESULTS+=("    duration_seconds: 0")
+        GATE_RESULTS+=("    status: skipped")
+        GATE_RESULTS+=("    note: script not found: $script_path")
+        (( SKIP_COUNT += 1 ))
+        continue
+      else
+        echo -e "${RED}FAIL${NC} (script not found: $script_path)"
+        GATE_RESULTS+=("  - name: $name")
+        GATE_RESULTS+=("    exit_code: 127")
+        GATE_RESULTS+=("    duration_seconds: 0")
+        GATE_RESULTS+=("    status: fail")
+        GATE_RESULTS+=("    error: script not found: $script_path")
+        (( FAIL_COUNT += 1 ))
+        continue
+      fi
+    fi
+  fi
+
+  # Run the gate and capture output
+  START_TIME=$(date +%s%N)
+  GATE_OUTPUT=$(eval "$cmd" 2>&1) && GATE_EXIT=$? || GATE_EXIT=$?
+  END_TIME=$(date +%s%N)
+  DURATION_MS=$(( (END_TIME - START_TIME) / 1000000 ))
+  DURATION_SEC=$(echo "scale=2; $DURATION_MS / 1000" | bc 2>/dev/null || echo "0")
+
+  if [[ "$GATE_EXIT" -eq 0 ]]; then
+    echo -e "${GREEN}PASS${NC} (${DURATION_SEC}s)"
+    GATE_RESULTS+=("  - name: $name")
+    GATE_RESULTS+=("    exit_code: 0")
+    GATE_RESULTS+=("    duration_seconds: $DURATION_SEC")
+    GATE_RESULTS+=("    status: pass")
+    (( PASS_COUNT += 1 ))
+  else
+    echo -e "${RED}FAIL${NC} (${DURATION_SEC}s, exit $GATE_EXIT)"
+    GATE_RESULTS+=("  - name: $name")
+    GATE_RESULTS+=("    exit_code: $GATE_EXIT")
+    GATE_RESULTS+=("    duration_seconds: $DURATION_SEC")
+    GATE_RESULTS+=("    status: fail")
+    (( FAIL_COUNT += 1 ))
+  fi
+done
+
+# ── Summary ───────────────────────────────────────────────────────────
+
+TOTAL=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+  OVERALL="fail"
+else
+  OVERALL="pass"
+fi
+
+echo ""
+echo "──────────────────────────────────────────"
+echo -e "Suite: ${PASS_COUNT}/${TOTAL} passed"
+if [[ "$SKIP_COUNT" -gt 0 ]]; then
+  echo -e "       ${SKIP_COUNT} skipped (scripts not yet implemented)"
+fi
+echo -e "Overall: ${OVERALL}"
+echo "Report: $REPORT_FILE"
+echo "──────────────────────────────────────────"
+
+# ── Write report ──────────────────────────────────────────────────────
+
+PASS_RATE=$(echo "scale=2; $PASS_COUNT / $TOTAL" | bc 2>/dev/null || echo "0")
+
+cat > "$REPORT_FILE" << YAML_EOF
+timestamp: "$TIMESTAMP"
+git_commit: "$GIT_COMMIT"
+suite: "golden-deterministic"
+mode: "$([ "$BASELINE_MODE" = true ] && echo 'baseline' || echo 'daily')"
+gates:
+$(printf '%s\n' "${GATE_RESULTS[@]}")
+summary:
+  total: $TOTAL
+  passed: $PASS_COUNT
+  failed: $FAIL_COUNT
+  skipped: $SKIP_COUNT
+  pass_rate: $PASS_RATE
+  overall: "$OVERALL"
+YAML_EOF
+
+# ── Size budget (placeholder for e31s04) ──────────────────────────────
+
+if $BASELINE_MODE; then
+  echo "" >> "$REPORT_FILE"
+  echo "# Skill byte counts (baseline for e31s04 size budget)" >> "$REPORT_FILE"
+  echo "skill_sizes:" >> "$REPORT_FILE"
+  for skill_md in skills/*/SKILL.md; do
+    skill_name=$(basename "$(dirname "$skill_md")")
+    skill_bytes=$(wc -c < "$skill_md" | tr -d ' ')
+    echo "  $skill_name: $skill_bytes" >> "$REPORT_FILE"
+  done
+  echo "Baseline pinned: $REPORT_FILE"
+fi
+
+if [[ "$OVERALL" == "fail" ]]; then
+  exit 1
+fi
+exit 0

--- a/specs/benchmarks/reports/BASELINE-GOLDEN.yaml
+++ b/specs/benchmarks/reports/BASELINE-GOLDEN.yaml
@@ -1,0 +1,94 @@
+timestamp: "2026-07-03T03:57:19Z"
+git_commit: "34d0ce89c4a26915786bd9b45379e7f2c289cc06"
+suite: "golden-deterministic"
+mode: "baseline"
+gates:
+- name: compliance
+  exit_code: 0
+  duration_seconds: 16.74
+  status: pass   - name: g04-selftest
+  exit_code: 1
+  duration_seconds: .03
+  status: fail
+summary:
+  total: 2
+  passed: 1
+  failed: 1
+  skipped: 0
+  pass_rate: .50
+  overall: "fail"
+
+# Skill byte counts (baseline for e31s04 size budget)
+skill_sizes:
+  align-grid: 12066
+  assess-impact: 3090
+  audit-code: 5894
+  audit-plan: 3580
+  build-epic: 5171
+  change-request: 2574
+  commit-message: 3512
+  compose-workflow: 2130
+  craft-skill: 2755
+  deepen-architecture: 6069
+  define-language: 3965
+  define-success: 2748
+  delegate-task: 3244
+  deploy: 4090
+  design-interface: 3650
+  develop-tdd: 4543
+  diagnose-root: 1257
+  dispatch-agents: 3192
+  edit-document: 1214
+  elaborate-spec: 3994
+  enforce-first: 3425
+  evolve-skill: 1729
+  execute-plan: 2204
+  extract-design: 4084
+  fix-bug: 2283
+  grill-me: 1960
+  grill-with-docs: 1425
+  guard-git: 2828
+  hook-commits: 2478
+  inspect-quality: 4466
+  investigate-bug: 4974
+  kickoff-branch: 4500
+  map-codebase: 3415
+  migrate-spec: 5435
+  model-domain: 4746
+  orchestrate-project: 3678
+  organize-workspace: 3911
+  plan-refactor: 3034
+  plan-release: 5856
+  plan-work: 4044
+  publish-package: 2857
+  quick-fix: 4370
+  release-branch: 5055
+  request-review: 3533
+  research-first: 2391
+  reset-baseline: 780
+  respond-review: 2151
+  run-benchmark: 2607
+  run-evals: 1259
+  run-planning: 4661
+  scope-work: 3874
+  search-skills: 3288
+  security-review: 2979
+  seed-conventions: 3915
+  session-state: 5975
+  setup-environment: 1106
+  simulate-agents: 1243
+  slice-tasks: 4312
+  smoke-test: 2151
+  spike-prototype: 3305
+  stocktake-skills: 2349
+  survey-context: 5467
+  terse-mode: 2132
+  trace-requirement: 2477
+  using-bigpowers: 4732
+  validate-contracts: 3483
+  validate-fix: 3769
+  verify-work: 6044
+  visual-dashboard: 2042
+  wire-ci: 5066
+  wire-observability: 3231
+  write-document: 5119

--- a/specs/benchmarks/reports/GOLDEN-2026-07-03.yaml
+++ b/specs/benchmarks/reports/GOLDEN-2026-07-03.yaml
@@ -1,0 +1,20 @@
+timestamp: "2026-07-03T03:57:59Z"
+git_commit: "34d0ce89c4a26915786bd9b45379e7f2c289cc06"
+suite: "golden-deterministic"
+mode: "daily"
+gates:
+  - name: compliance
+    exit_code: 0
+    duration_seconds: 16.25
+    status: pass
+  - name: g04-selftest
+    exit_code: 1
+    duration_seconds: .03
+    status: fail
+summary:
+  total: 2
+  passed: 1
+  failed: 1
+  skipped: 0
+  pass_rate: .50
+  overall: "fail"


### PR DESCRIPTION
## e31s03 — Golden Suite Runner

`scripts/run-golden-suite.sh` — orchestrates deterministic gates.

### Features
- Runs `npm run compliance` → `golden-g04-selftest.sh` in order
- `--dry-run`: print plan without executing
- `--baseline`: pin results + skill byte counts to BASELINE-GOLDEN.yaml
- Timestamped YAML reports in `specs/benchmarks/reports/`
- Error handling: missing scripts, optional gates

### Current state
- compliance: PASS (16s)
- g04-selftest: FAIL (cursor 73 .mdc vs 72 skills — known context7.mdc finding)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `scripts/run-golden-suite.sh`, a bash orchestrator that runs compliance and g04-selftest gates in sequence, writes timestamped YAML reports, and supports `--dry-run` and `--baseline` modes. Two report files (the baseline pin and the first daily run) are committed alongside the script.

- The committed `BASELINE-GOLDEN.yaml` has malformed YAML on line 9 (`status: pass   - name: g04-selftest` on one line), making the gates list unparseable by any YAML library and corrupting the baseline the e31s04 size-budget step will depend on.
- `GATE_OUTPUT` is captured on every gate run but never referenced again, so all stdout/stderr from failing gates is silently discarded — the YAML report only records the exit code, providing no diagnostic information when debugging failures.
- Timing relies on `date +%s%N` (GNU coreutils nanoseconds), which is not supported on macOS and will produce garbled duration values on non-Linux hosts.

<h3>Confidence Score: 3/5</h3>

The baseline file that the entire suite is designed to pin is committed with corrupted YAML, and gate failure output is silently dropped — both need fixing before downstream e31s04 tooling relies on these artifacts.

The baseline YAML is structurally broken (two gate entries on one line), and the runner discards all gate output on failure, leaving reports with only an exit code and no diagnostic detail. These are present defects in the two core deliverables of the PR.

BASELINE-GOLDEN.yaml needs to be regenerated with correct newlines between gate entries; the gate output handling in run-golden-suite.sh line 108 should surface failure details in the report or terminal.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/run-golden-suite.sh | New 186-line bash orchestrator for the golden gate suite; captures gate output in GATE_OUTPUT but never uses it (silently discards failure diagnostics), uses non-portable date +%s%N for timing, and splits gate definitions on colons which will break if any command contains a colon. |
| specs/benchmarks/reports/BASELINE-GOLDEN.yaml | Committed baseline report; contains malformed YAML on line 9 where the compliance and g04-selftest gate entries are concatenated on one line without a newline, making the gates list unparseable by any YAML library. |
| specs/benchmarks/reports/GOLDEN-2026-07-03.yaml | First daily run report; YAML is well-formed and accurately reflects the known g04-selftest failure. Committing generated reports to source control appears intentional per the design (timestamped historical records). |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([run-golden-suite.sh]) --> B{--dry-run?}
    B -- yes --> C[Print gate plan and exit 0]
    B -- no --> D[mkdir reports / resolve REPORT_FILE]
    D --> E{--baseline?}
    E -- yes --> F[REPORT_FILE = BASELINE-GOLDEN.yaml]
    E -- no --> G[REPORT_FILE = GOLDEN-YYYY-MM-DD.yaml]
    F & G --> H[Loop over GATES array]
    H --> I{gate cmd is bash script?}
    I -- yes, missing --> J{optional?}
    J -- true --> K[SKIP]
    J -- false --> L[FAIL]
    I -- no or exists --> M[eval cmd / capture GATE_OUTPUT / GATE_EXIT]
    M --> N{GATE_EXIT == 0?}
    N -- yes --> O[PASS]
    N -- no --> P[FAIL / GATE_OUTPUT discarded]
    K & L & O & P --> Q{more gates?}
    Q -- yes --> H
    Q -- no --> R[Write YAML report via heredoc]
    R --> S{--baseline?}
    S -- yes --> T[Append skill_sizes]
    T --> U{OVERALL == fail?}
    S -- no --> U
    U -- yes --> V([exit 1])
    U -- no --> W([exit 0])
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([run-golden-suite.sh]) --> B{--dry-run?}
    B -- yes --> C[Print gate plan and exit 0]
    B -- no --> D[mkdir reports / resolve REPORT_FILE]
    D --> E{--baseline?}
    E -- yes --> F[REPORT_FILE = BASELINE-GOLDEN.yaml]
    E -- no --> G[REPORT_FILE = GOLDEN-YYYY-MM-DD.yaml]
    F & G --> H[Loop over GATES array]
    H --> I{gate cmd is bash script?}
    I -- yes, missing --> J{optional?}
    J -- true --> K[SKIP]
    J -- false --> L[FAIL]
    I -- no or exists --> M[eval cmd / capture GATE_OUTPUT / GATE_EXIT]
    M --> N{GATE_EXIT == 0?}
    N -- yes --> O[PASS]
    N -- no --> P[FAIL / GATE_OUTPUT discarded]
    K & L & O & P --> Q{more gates?}
    Q -- yes --> H
    Q -- no --> R[Write YAML report via heredoc]
    R --> S{--baseline?}
    S -- yes --> T[Append skill_sizes]
    T --> U{OVERALL == fail?}
    S -- no --> U
    U -- yes --> V([exit 1])
    U -- no --> W([exit 0])
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aspecs%2Fbenchmarks%2Freports%2FBASELINE-GOLDEN.yaml%3A9%0A**Malformed%20YAML%20%E2%80%94%20two%20gate%20entries%20collapsed%20onto%20one%20line**%0A%0ALine%209%20reads%20%60status%3A%20pass%20%20%20-%20name%3A%20g04-selftest%60%2C%20merging%20the%20end%20of%20the%20%60compliance%60%20entry%20and%20the%20start%20of%20%60g04-selftest%60%20without%20a%20newline.%20Any%20YAML%20parser%20will%20treat%20%60-%20name%3A%20g04-selftest%60%20as%20part%20of%20the%20%60status%60%20scalar%20value%20rather%20than%20as%20a%20second%20list%20item%2C%20silently%20corrupting%20the%20gate%20result%20data.%20The%20script's%20%60printf%20'%25s%5Cn'%20%22%24%7BGATE_RESULTS%5B%40%5D%7D%22%60%20in%20the%20heredoc%20on%20line%20159%20of%20the%20runner%20should%20have%20emitted%20the%20correct%20newlines%20%E2%80%94%20this%20file%20appears%20to%20have%20been%20committed%20with%20a%20manual%20edit%20gone%20wrong.%20It%20needs%20to%20be%20regenerated%20or%20hand-corrected%20before%20downstream%20tooling%20%28e31s04%20size%20budget%20reader%2C%20CI%20consumers%29%20parses%20it.%0A%0A%23%23%23%20Issue%202%20of%204%0Ascripts%2Frun-golden-suite.sh%3A108%0A**Gate%20output%20is%20captured%20but%20silently%20discarded**%0A%0A%60GATE_OUTPUT%60%20is%20assigned%20on%20this%20line%20%28capturing%20both%20stdout%20and%20stderr%20via%20%602%3E%261%60%29%20but%20is%20never%20referenced%20again%20%E2%80%94%20not%20in%20the%20YAML%20report%2C%20not%20in%20the%20terminal%20summary%2C%20and%20not%20in%20any%20error%20branch.%20When%20a%20gate%20fails%2C%20the%20only%20clue%20in%20the%20report%20is%20the%20non-zero%20%60exit_code%60%3B%20the%20actual%20error%20message%20or%20stack%20trace%20is%20lost.%20For%20a%20diagnostic%20tool%20whose%20whole%20job%20is%20explaining%20gate%20failures%2C%20this%20makes%20the%20runner%20unusable%20for%20root-cause%20analysis%3A%20you'd%20have%20to%20re-run%20the%20failing%20gate%20manually%20to%20see%20what%20went%20wrong.%0A%0A%23%23%23%20Issue%203%20of%204%0Ascripts%2Frun-golden-suite.sh%3A107-110%0A**%60date%20%2B%25s%25N%60%20is%20a%20Linux-only%20GNU%20coreutils%20extension**%0A%0A%60%25N%60%20%28nanoseconds%29%20is%20not%20supported%20by%20%60date%60%20on%20macOS%20or%20BSD.%20On%20those%20platforms%20the%20literal%20string%20%60N%60%20is%20appended%20to%20the%20epoch%20seconds%2C%20so%20%60END_TIME%20-%20START_TIME%60%20produces%20garbage%20arithmetic%20and%20%60DURATION_MS%60%20will%20be%20either%20a%20hugely%20wrong%20number%20or%20a%20bash%20arithmetic%20error.%20Since%20the%20script%20uses%20%60%23!%2Fusr%2Fbin%2Fenv%20bash%60%20with%20no%20explicit%20platform%20guard%2C%20any%20developer%20running%20this%20on%20macOS%20will%20see%20broken%20duration%20values%20in%20every%20report.%0A%0A%23%23%23%20Issue%204%20of%204%0Ascripts%2Frun-golden-suite.sh%3A29-32%0A**Colon-delimited%20gate%20format%20breaks%20if%20any%20command%20contains%20a%20colon**%0A%0AGate%20entries%20are%20split%20on%20%60%3A%60%20via%20%60IFS%3D'%3A'%60%20%28line%2075%29%2C%20but%20the%20delimiter%20is%20also%20valid%20in%20shell%20commands%20%28e.g.%2C%20%60npx%20ts-node%3Aesm%60%2C%20URLs%29.%20If%20any%20future%20gate%20command%20contains%20a%20colon%2C%20%60read%20-r%20name%20cmd%20is_optional%60%20will%20silently%20misparse%20both%20%60cmd%60%20and%20the%20optional%20flag.%20Consider%20a%20different%20delimiter%20%28e.g.%2C%20%60%7C%60%29%20or%20a%20structured%20gate%20definition%20file.%0A%0A&pr=45&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aspecs%2Fbenchmarks%2Freports%2FBASELINE-GOLDEN.yaml%3A9%0A**Malformed%20YAML%20%E2%80%94%20two%20gate%20entries%20collapsed%20onto%20one%20line**%0A%0ALine%209%20reads%20%60status%3A%20pass%20%20%20-%20name%3A%20g04-selftest%60%2C%20merging%20the%20end%20of%20the%20%60compliance%60%20entry%20and%20the%20start%20of%20%60g04-selftest%60%20without%20a%20newline.%20Any%20YAML%20parser%20will%20treat%20%60-%20name%3A%20g04-selftest%60%20as%20part%20of%20the%20%60status%60%20scalar%20value%20rather%20than%20as%20a%20second%20list%20item%2C%20silently%20corrupting%20the%20gate%20result%20data.%20The%20script's%20%60printf%20'%25s%5Cn'%20%22%24%7BGATE_RESULTS%5B%40%5D%7D%22%60%20in%20the%20heredoc%20on%20line%20159%20of%20the%20runner%20should%20have%20emitted%20the%20correct%20newlines%20%E2%80%94%20this%20file%20appears%20to%20have%20been%20committed%20with%20a%20manual%20edit%20gone%20wrong.%20It%20needs%20to%20be%20regenerated%20or%20hand-corrected%20before%20downstream%20tooling%20%28e31s04%20size%20budget%20reader%2C%20CI%20consumers%29%20parses%20it.%0A%0A%23%23%23%20Issue%202%20of%204%0Ascripts%2Frun-golden-suite.sh%3A108%0A**Gate%20output%20is%20captured%20but%20silently%20discarded**%0A%0A%60GATE_OUTPUT%60%20is%20assigned%20on%20this%20line%20%28capturing%20both%20stdout%20and%20stderr%20via%20%602%3E%261%60%29%20but%20is%20never%20referenced%20again%20%E2%80%94%20not%20in%20the%20YAML%20report%2C%20not%20in%20the%20terminal%20summary%2C%20and%20not%20in%20any%20error%20branch.%20When%20a%20gate%20fails%2C%20the%20only%20clue%20in%20the%20report%20is%20the%20non-zero%20%60exit_code%60%3B%20the%20actual%20error%20message%20or%20stack%20trace%20is%20lost.%20For%20a%20diagnostic%20tool%20whose%20whole%20job%20is%20explaining%20gate%20failures%2C%20this%20makes%20the%20runner%20unusable%20for%20root-cause%20analysis%3A%20you'd%20have%20to%20re-run%20the%20failing%20gate%20manually%20to%20see%20what%20went%20wrong.%0A%0A%23%23%23%20Issue%203%20of%204%0Ascripts%2Frun-golden-suite.sh%3A107-110%0A**%60date%20%2B%25s%25N%60%20is%20a%20Linux-only%20GNU%20coreutils%20extension**%0A%0A%60%25N%60%20%28nanoseconds%29%20is%20not%20supported%20by%20%60date%60%20on%20macOS%20or%20BSD.%20On%20those%20platforms%20the%20literal%20string%20%60N%60%20is%20appended%20to%20the%20epoch%20seconds%2C%20so%20%60END_TIME%20-%20START_TIME%60%20produces%20garbage%20arithmetic%20and%20%60DURATION_MS%60%20will%20be%20either%20a%20hugely%20wrong%20number%20or%20a%20bash%20arithmetic%20error.%20Since%20the%20script%20uses%20%60%23!%2Fusr%2Fbin%2Fenv%20bash%60%20with%20no%20explicit%20platform%20guard%2C%20any%20developer%20running%20this%20on%20macOS%20will%20see%20broken%20duration%20values%20in%20every%20report.%0A%0A%23%23%23%20Issue%204%20of%204%0Ascripts%2Frun-golden-suite.sh%3A29-32%0A**Colon-delimited%20gate%20format%20breaks%20if%20any%20command%20contains%20a%20colon**%0A%0AGate%20entries%20are%20split%20on%20%60%3A%60%20via%20%60IFS%3D'%3A'%60%20%28line%2075%29%2C%20but%20the%20delimiter%20is%20also%20valid%20in%20shell%20commands%20%28e.g.%2C%20%60npx%20ts-node%3Aesm%60%2C%20URLs%29.%20If%20any%20future%20gate%20command%20contains%20a%20colon%2C%20%60read%20-r%20name%20cmd%20is_optional%60%20will%20silently%20misparse%20both%20%60cmd%60%20and%20the%20optional%20flag.%20Consider%20a%20different%20delimiter%20%28e.g.%2C%20%60%7C%60%29%20or%20a%20structured%20gate%20definition%20file.%0A%0A&repo=danielvm-git%2Fbigpowers&pr=45&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(e31): golden suite runner — determi..."](https://github.com/danielvm-git/bigpowers/commit/0a62d3564482d57fbb7fbf58dda694172a786903) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41559501)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->