### PR TITLE
feat(e31): size budget, pre-merge mandate, evolve-skill — complete e31

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,17 @@ Stack: Markdown / Bash (documentation-based; skills integrate with Claude Code, 
 | Typecheck | N/A (Markdown / Bash project) |
 | CI platform | GitHub Actions (`.github/workflows/publish.yml`, `sync-skills.yml`) |
 | Compliance | `npm run compliance` |
+| Golden Suite | `bash scripts/run-golden-suite.sh` |
+
+### Pre-Merge Checklist
+
+Before opening a PR or landing a branch, run:
+
+```bash
+npm run compliance && bash scripts/run-golden-suite.sh
+```
+
+If any gate fails, fix before merging. Run `--baseline` after any intentional increase in skill count or structure.
 
 ## Architecture
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -28,6 +28,17 @@ All changes to this repository MUST follow the [Conventional Commits 1.0.0](http
 - Never call GitHub REST API directly (curl, fetch, etc.)
 - Never create GitHub issues from automated workflows — produce local .md files in specs/ instead
 
+### Pre-Merge Golden Gate
+
+Before merging any branch, run the deterministic golden suite:
+
+```bash
+bash scripts/run-golden-suite.sh
+```
+
+This runs compliance → G-04 self-test. If any gate fails, the merge is blocked.
+Pin a fresh baseline with `--baseline` after major structure changes.
+
 ## Agent Workflow Mandates
 
 **AGENTS MUST NEVER BYPASS THE BIGPOWERS WORKFLOW.**

--- a/scripts/run-golden-suite.sh
+++ b/scripts/run-golden-suite.sh
@@ -15,12 +15,14 @@ REPORT_DIR="specs/benchmarks/reports"
 BASELINE_FILE="$REPORT_DIR/BASELINE-GOLDEN.yaml"
 DRY_RUN=false
 BASELINE_MODE=false
+CHECK_SIZE=false
 
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=true ;;
     --baseline) BASELINE_MODE=true ;;
-    *) echo "Unknown flag: $arg"; echo "Usage: run-golden-suite.sh [--dry-run] [--baseline]"; exit 2 ;;
+    --check-size) CHECK_SIZE=true ;;
+    *) echo "Unknown flag: $arg"; echo "Usage: run-golden-suite.sh [--dry-run] [--baseline] [--check-size]"; exit 2 ;;
   esac
 done
 
@@ -178,6 +180,62 @@ if $BASELINE_MODE; then
     echo "  $skill_name: $skill_bytes" >> "$REPORT_FILE"
   done
   echo "Baseline pinned: $REPORT_FILE"
+fi
+
+# ── Size budget check (e31s04) ───────────────────────────────────────
+
+if $CHECK_SIZE; then
+  WARN_THRESHOLD=20
+  FAIL_THRESHOLD=50
+
+  if [[ ! -f "$BASELINE_FILE" ]]; then
+    echo "No baseline found. Run --baseline first."
+    exit 1
+  fi
+
+  echo ""
+  echo "Size Budget Check (+${WARN_THRESHOLD}% warn, +${FAIL_THRESHOLD}% fail):"
+  SIZE_WARNINGS=0
+  SIZE_FAILURES=0
+  NEW_SKILLS=0
+
+  for skill_md in skills/*/SKILL.md; do
+    skill_name=$(basename "$(dirname "$skill_md")")
+    current_bytes=$(wc -c < "$skill_md" | tr -d ' ')
+
+    # Get baseline size (best-effort grep from YAML)
+    baseline_bytes=$(grep "^  $skill_name:" "$BASELINE_FILE" 2>/dev/null | awk '{print $2}')
+
+    if [[ -z "$baseline_bytes" ]]; then
+      echo "  ${YELLOW}NEW${NC}  $skill_name: ${current_bytes}b (not in baseline)"
+      (( NEW_SKILLS += 1 )) || true
+      continue
+    fi
+
+    if [[ "$baseline_bytes" -eq 0 ]]; then
+      baseline_bytes=1  # avoid division by zero
+    fi
+
+    pct=$(( (current_bytes - baseline_bytes) * 100 / baseline_bytes ))
+
+    if [[ "$pct" -ge "$FAIL_THRESHOLD" ]]; then
+      echo "  ${RED}FAIL${NC} $skill_name: ${current_bytes}b (+${pct}%)"
+      (( SIZE_FAILURES += 1 )) || true
+    elif [[ "$pct" -ge "$WARN_THRESHOLD" ]]; then
+      echo "  ${YELLOW}WARN${NC} $skill_name: ${current_bytes}b (+${pct}%)"
+      (( SIZE_WARNINGS += 1 )) || true
+    else
+      echo "  ${GREEN}OK${NC}   $skill_name: ${current_bytes}b"
+    fi
+  done
+
+  echo ""
+  echo "Size summary: $SIZE_WARNINGS warnings, $SIZE_FAILURES failures, $NEW_SKILLS new"
+
+  if [[ "$SIZE_FAILURES" -gt 0 ]]; then
+    exit 1
+  fi
+  exit 0
 fi
 
 if [[ "$OVERALL" == "fail" ]]; then

--- a/skills/evolve-skill/SKILL.md
+++ b/skills/evolve-skill/SKILL.md
@@ -10,19 +10,20 @@ model: opus
 
 ## Loop
 
-1. **Establish baseline** — Run `run-benchmark <skill> --baseline`. If no definition exists at `specs/benchmarks/<skill>.yaml`, create one following `specs/benchmarks/SCHEMA.md` first. Save report path in `state.yaml`. If `specs/benchmarks/reports/BASELINE-<skill>.yaml` already exists, skip this step.
+1. **Regression gate** — Run `bash scripts/run-golden-suite.sh` to catch mechanical regressions (compliance, sync pipeline, size budget) before spending time on benchmark evals. If golden suite fails, fix regressions first — they are pre-requisites for any capability improvement.
+2. **Establish baseline** — Run `run-benchmark <skill> --baseline`. If no definition exists at `specs/benchmarks/<skill>.yaml`, create one following `specs/benchmarks/SCHEMA.md` first. Save report path in `state.yaml`. If `specs/benchmarks/reports/BASELINE-<skill>.yaml` already exists, skip this step.
 
-2. **Identify gap** — Read the baseline report (`specs/benchmarks/reports/BASELINE-<skill>.yaml`). Find scenarios with `result: FAIL` or low `pass_at_k`. This is the measurable gap.
+3. **Identify gap** — Read the baseline report (`specs/benchmarks/reports/BASELINE-<skill>.yaml`). Find scenarios with `result: FAIL` or low `pass_at_k`. This is the measurable gap.
 
-3. **`plan-work`** — Write a minimal change proposal targeting the failing scenarios. Include verify commands.
+4. **`plan-work`** — Write a minimal change proposal targeting the failing scenarios. Include verify commands.
 
-4. **Edit** via `craft-skill` / direct SKILL.md edit; run `bash scripts/sync-skills.sh`.
+5. **Edit** via `craft-skill` / direct SKILL.md edit; run `bash scripts/sync-skills.sh`.
 
-5. **Re-run benchmark** — `run-benchmark <skill>`. Compare new `pass_at_k` against baseline.
+6. **Re-run benchmark** — `run-benchmark <skill>`. Compare new `pass_at_k` against baseline.
    - **IMPROVED or STABLE** → advance to step 6.
    - **REGRESSION** (`new pass_at_k < baseline`) → revert the change and loop back to step 3.
 
-6. **Record decision** — Write `specs/adr/NNNN-evolve-<skill>.md` with before/after `pass_at_k` scores. Update `session-state`.
+7. **Record decision** — Write `specs/adr/NNNN-evolve-<skill>.md` with before/after `pass_at_k` scores. Update `session-state`.
 
 ## Verify
 


### PR DESCRIPTION
## e31 complete — 7/7 stories, 11/11 BCP

### e31s04 — Size Budget
`--check-size` on golden suite: +20% warn, +50% fail. 0 warnings, 0 failures on current baseline.

### e31s05 — Baseline
Already shipped in e31s03 (`--baseline` flag).

### e31s06 — Pre-Merge Mandate
CLAUDE.md + CONVENTIONS.md now require `run-golden-suite.sh` before merge.

### e31s07 — Evolve-Skill Integration
evolve-skill step 1 now runs golden suite as regression gate before benchmarks.

### Summary
| Story | PR | BCP |
|-------|----|-----|
| e31s01 G-04 selftest | #43 | 2 |
| e31s02 Compliance CI | #44 | 2 |
| e31s03 Golden suite | #45 | 3 |
| e31s04 Size budget | this | 1 |
| e31s05 Baseline | in s03 | 1 |
| e31s06 Pre-merge | this | 1 |
| e31s07 Evolve-skill | this | 1 |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the e31 epic by adding a `--check-size` flag to the golden suite (warn at +20%, fail at +50% growth vs baseline), documenting a mandatory pre-merge golden suite run in both `CLAUDE.md` and `CONVENTIONS.md`, and inserting a regression gate as step 1 of the `evolve-skill` loop.

- **`scripts/run-golden-suite.sh`**: New `--check-size` mode compares each `SKILL.md` byte count against the pinned baseline; has a logic bug where `exit 0` inside the size-check block short-circuits the existing `OVERALL` gate failure check, potentially masking compliance or G-04 failures.
- **`skills/evolve-skill/SKILL.md`**: Steps renumbered 1–7 with a new regression-gate step prepended; the internal "advance to step 6" cross-reference inside the new step 6 was not updated to "step 7".
- **`CLAUDE.md` / `CONVENTIONS.md`**: Documentation-only additions mandating `npm run compliance && bash scripts/run-golden-suite.sh` before any PR or merge.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the exit 0 short-circuit in the size-check block; the stale step reference in evolve-skill is a low-risk doc nit.

The --check-size exit path unconditionally exits 0 when no size failures exist, meaning a broken golden suite goes undetected when that flag is used as the pre-merge gate — the very gate this PR mandates. The fix is a single-line removal. Everything else is documentation or a minor cross-reference fix.

scripts/run-golden-suite.sh — the --check-size exit flow needs the unconditional exit 0 removed so the OVERALL gate result is still respected.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/run-golden-suite.sh | Adds `--check-size` flag with warn/fail thresholds against the pinned baseline; has a logic bug where `exit 0` inside the size-check block bypasses the OVERALL gate failure check. |
| skills/evolve-skill/SKILL.md | Prepends a "Regression gate" step so evolve-skill runs the golden suite before benchmarks; internal step reference "advance to step 6" was not updated to "step 7" after renumbering. |
| CLAUDE.md | Adds Pre-Merge Checklist section documenting the mandatory golden suite run before opening a PR; documentation-only, no logic concerns. |
| CONVENTIONS.md | Adds Pre-Merge Golden Gate section requiring `bash scripts/run-golden-suite.sh` before any merge; documentation-only, no logic concerns. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[run-golden-suite.sh] --> B{--dry-run?}
    B -- yes --> C[Print plan & exit 0]
    B -- no --> D[Run GATES: compliance to g04-selftest]
    D --> E[Set OVERALL = pass/fail]
    E --> F[Write YAML report]
    F --> G{--baseline?}
    G -- yes --> H[Append skill_sizes to report]
    H --> I{--check-size?}
    G -- no --> I
    I -- yes --> J[Load BASELINE-GOLDEN.yaml]
    J --> K[Compare each SKILL.md byte count]
    K --> L{SIZE_FAILURES > 0?}
    L -- yes --> M[exit 1]
    L -- no --> N[exit 0 bypasses OVERALL check]
    I -- no --> O{OVERALL == fail?}
    O -- yes --> P[exit 1]
    O -- no --> Q[exit 0]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[run-golden-suite.sh] --> B{--dry-run?}
    B -- yes --> C[Print plan & exit 0]
    B -- no --> D[Run GATES: compliance to g04-selftest]
    D --> E[Set OVERALL = pass/fail]
    E --> F[Write YAML report]
    F --> G{--baseline?}
    G -- yes --> H[Append skill_sizes to report]
    H --> I{--check-size?}
    G -- no --> I
    I -- yes --> J[Load BASELINE-GOLDEN.yaml]
    J --> K[Compare each SKILL.md byte count]
    K --> L{SIZE_FAILURES > 0?}
    L -- yes --> M[exit 1]
    L -- no --> N[exit 0 bypasses OVERALL check]
    I -- no --> O{OVERALL == fail?}
    O -- yes --> P[exit 1]
    O -- no --> Q[exit 0]
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Frun-golden-suite.sh%3A235-239%0AWhen%20%60--check-size%60%20is%20passed%20and%20no%20size%20failures%20exist%2C%20%60exit%200%60%20short-circuits%20before%20the%20%60OVERALL%60%20check%20at%20lines%20241%E2%80%93243.%20If%20the%20compliance%20gate%20or%20G-04%20self-test%20already%20failed%20%28setting%20%60OVERALL%3Dfail%60%29%2C%20the%20script%20still%20exits%20with%20code%200%2C%20giving%20a%20false%20green.%20A%20pre-merge%20run%20with%20%60--check-size%60%20would%20then%20silently%20accept%20a%20broken%20golden%20suite.%0A%0A%60%60%60suggestion%0A%20%20if%20%5B%5B%20%22%24SIZE_FAILURES%22%20-gt%200%20%5D%5D%3B%20then%0A%20%20%20%20exit%201%0A%20%20fi%0Afi%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Askills%2Fevolve-skill%2FSKILL.md%3A22-24%0AAfter%20inserting%20the%20new%20%22Regression%20gate%22%20as%20step%201%2C%20all%20subsequent%20steps%20were%20renumbered%20but%20the%20internal%20cross-reference%20inside%20step%206%20still%20says%20%22advance%20to%20step%206%22%20%E2%80%94%20it%20should%20now%20point%20to%20step%207%20%28Record%20decision%29.%0A%0A%60%60%60suggestion%0A6.%20**Re-run%20benchmark**%20%E2%80%94%20%60run-benchmark%20%3Cskill%3E%60.%20Compare%20new%20%60pass_at_k%60%20against%20baseline.%0A%20%20%20-%20**IMPROVED%20or%20STABLE**%20%E2%86%92%20advance%20to%20step%207.%0A%20%20%20-%20**REGRESSION**%20%28%60new%20pass_at_k%20%3C%20baseline%60%29%20%E2%86%92%20revert%20the%20change%20and%20loop%20back%20to%20step%203.%0A%60%60%60%0A%0A&pr=46&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Frun-golden-suite.sh%3A235-239%0AWhen%20%60--check-size%60%20is%20passed%20and%20no%20size%20failures%20exist%2C%20%60exit%200%60%20short-circuits%20before%20the%20%60OVERALL%60%20check%20at%20lines%20241%E2%80%93243.%20If%20the%20compliance%20gate%20or%20G-04%20self-test%20already%20failed%20%28setting%20%60OVERALL%3Dfail%60%29%2C%20the%20script%20still%20exits%20with%20code%200%2C%20giving%20a%20false%20green.%20A%20pre-merge%20run%20with%20%60--check-size%60%20would%20then%20silently%20accept%20a%20broken%20golden%20suite.%0A%0A%60%60%60suggestion%0A%20%20if%20%5B%5B%20%22%24SIZE_FAILURES%22%20-gt%200%20%5D%5D%3B%20then%0A%20%20%20%20exit%201%0A%20%20fi%0Afi%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Askills%2Fevolve-skill%2FSKILL.md%3A22-24%0AAfter%20inserting%20the%20new%20%22Regression%20gate%22%20as%20step%201%2C%20all%20subsequent%20steps%20were%20renumbered%20but%20the%20internal%20cross-reference%20inside%20step%206%20still%20says%20%22advance%20to%20step%206%22%20%E2%80%94%20it%20should%20now%20point%20to%20step%207%20%28Record%20decision%29.%0A%0A%60%60%60suggestion%0A6.%20**Re-run%20benchmark**%20%E2%80%94%20%60run-benchmark%20%3Cskill%3E%60.%20Compare%20new%20%60pass_at_k%60%20against%20baseline.%0A%20%20%20-%20**IMPROVED%20or%20STABLE**%20%E2%86%92%20advance%20to%20step%207.%0A%20%20%20-%20**REGRESSION**%20%28%60new%20pass_at_k%20%3C%20baseline%60%29%20%E2%86%92%20revert%20the%20change%20and%20loop%20back%20to%20step%203.%0A%60%60%60%0A%0A&repo=danielvm-git%2Fbigpowers&pr=46&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(e31): size budget, pre-merge mandat..."](https://github.com/danielvm-git/bigpowers/commit/e0d6247753d45206efb91326b2e52f74abc6ba83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41559815)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->