### PR TITLE
fix(skills): remove tautological verify commands from 5 skills

### DIFF
--- a/.cursor/rules/gate-trace.mdc
+++ b/.cursor/rules/gate-trace.mdc
@@ -70,10 +70,6 @@ gate_trace:
 - scripts/check-blind-spots.sh (e38s04) — produces blind-spots.json.
 - specs/execution-status.yaml — output target for gate result.
 
-## Verify
-
-→ verify: `test -f skills/gate-trace/SKILL.md && grep -q 'PASS.*CONCERNS.*FAIL.*WAIVED' skills/gate-trace/SKILL.md && echo "OK: gate-trace skill created" || echo "FAIL"`
-
 ## Handoff
 
 Gate: READY → next: release-branch (final step before merge)

--- a/.cursor/rules/publish-package.mdc
+++ b/.cursor/rules/publish-package.mdc
@@ -71,8 +71,6 @@ See [REFERENCE.md](REFERENCE.md)
 
 ## Verify
 
-→ verify: `test -f skills/publish-package/SKILL.md && echo "OK: skill file exists" || echo "FAIL: no skill file"`
-→ verify: `grep -q "name: publish-package" skills/publish-package/SKILL.md && echo "OK: frontmatter" || echo "FAIL: frontmatter"`
 → verify: `grep -ci "npm\|crates.io\|pypi\|publish\|registry" skills/publish-package/SKILL.md | awk '{if($1>=4) print "OK: semantics"; else print "FAIL: missing"}'`
 → verify: `grep -q "publish-package" SKILL-INDEX.md && echo "OK: in SKILL-INDEX" || echo "FAIL: not indexed"`
 

--- a/.cursor/rules/run-benchmark.mdc
+++ b/.cursor/rules/run-benchmark.mdc
@@ -64,7 +64,3 @@ scenarios:
    - `IMPROVED: 0.67 → 0.83`
    - `REGRESSION: 0.83 → 0.67 — do NOT ship this change`
    - `STABLE: 0.83 = 0.83`
-
-## Verify
-
-→ verify: `test -f skills/run-benchmark/SKILL.md && grep -q 'pass_at_k\|pass.at.k' skills/run-benchmark/SKILL.md && echo OK || echo FAIL`

--- a/.cursor/rules/visual-dashboard.mdc
+++ b/.cursor/rules/visual-dashboard.mdc
@@ -48,5 +48,3 @@ Required YAML keys:
 ## Agent screens (optional)
 
 Push HTML to the dashboard session dir for rich diagrams. See `start-server.sh` for `CONTENT_DIR`.
-
-→ verify: `test -f skills/visual-dashboard/scripts/read-specs-status.cjs && test -f skills/visual-dashboard/scripts/cockpit.html`

--- a/.cursor/rules/wire-ci.mdc
+++ b/.cursor/rules/wire-ci.mdc
@@ -100,8 +100,6 @@ Add the following to the project's documentation or CLAUDE.md after setup:
 
 ## Verify
 
-→ verify: `test -f skills/wire-ci/SKILL.md && echo "OK: skill file exists" || echo "FAIL: no skill file"`
-→ verify: `grep -q "name: wire-ci" skills/wire-ci/SKILL.md && echo "OK: frontmatter" || echo "FAIL: frontmatter"`
 → verify: `grep -ci "template\|workflow\|validate\|dry.run" skills/wire-ci/SKILL.md | awk '{if($1>=3) print "OK: semantics"; else print "FAIL: missing"}'`
 → verify: `grep -q "wire-ci" SKILL-INDEX.md && echo "OK: in SKILL-INDEX" || echo "FAIL: not indexed"`
 

--- a/.gemini/extensions/bigpowers/commands/prompts/gate-trace.md
+++ b/.gemini/extensions/bigpowers/commands/prompts/gate-trace.md
@@ -65,10 +65,6 @@ gate_trace:
 - scripts/check-blind-spots.sh (e38s04) — produces blind-spots.json.
 - specs/execution-status.yaml — output target for gate result.
 
-## Verify
-
-→ verify: `test -f skills/gate-trace/SKILL.md && grep -q 'PASS.*CONCERNS.*FAIL.*WAIVED' skills/gate-trace/SKILL.md && echo "OK: gate-trace skill created" || echo "FAIL"`
-
 ## Handoff
 
 Gate: READY → next: release-branch (final step before merge)

--- a/.gemini/extensions/bigpowers/commands/prompts/publish-package.md
+++ b/.gemini/extensions/bigpowers/commands/prompts/publish-package.md
@@ -66,8 +66,6 @@ See [REFERENCE.md](REFERENCE.md)
 
 ## Verify
 
-→ verify: `test -f skills/publish-package/SKILL.md && echo "OK: skill file exists" || echo "FAIL: no skill file"`
-→ verify: `grep -q "name: publish-package" skills/publish-package/SKILL.md && echo "OK: frontmatter" || echo "FAIL: frontmatter"`
 → verify: `grep -ci "npm\|crates.io\|pypi\|publish\|registry" skills/publish-package/SKILL.md | awk '{if($1>=4) print "OK: semantics"; else print "FAIL: missing"}'`
 → verify: `grep -q "publish-package" SKILL-INDEX.md && echo "OK: in SKILL-INDEX" || echo "FAIL: not indexed"`
 

--- a/.gemini/extensions/bigpowers/commands/prompts/run-benchmark.md
+++ b/.gemini/extensions/bigpowers/commands/prompts/run-benchmark.md
@@ -59,7 +59,3 @@ scenarios:
    - `IMPROVED: 0.67 → 0.83`
    - `REGRESSION: 0.83 → 0.67 — do NOT ship this change`
    - `STABLE: 0.83 = 0.83`
-
-## Verify
-
-→ verify: `test -f skills/run-benchmark/SKILL.md && grep -q 'pass_at_k\|pass.at.k' skills/run-benchmark/SKILL.md && echo OK || echo FAIL`

--- a/.gemini/extensions/bigpowers/commands/prompts/visual-dashboard.md
+++ b/.gemini/extensions/bigpowers/commands/prompts/visual-dashboard.md
@@ -43,5 +43,3 @@ Required YAML keys:
 ## Agent screens (optional)
 
 Push HTML to the dashboard session dir for rich diagrams. See `start-server.sh` for `CONTENT_DIR`.
-
-→ verify: `test -f skills/visual-dashboard/scripts/read-specs-status.cjs && test -f skills/visual-dashboard/scripts/cockpit.html`

--- a/.gemini/extensions/bigpowers/commands/prompts/wire-ci.md
+++ b/.gemini/extensions/bigpowers/commands/prompts/wire-ci.md
@@ -95,8 +95,6 @@ Add the following to the project's documentation or CLAUDE.md after setup:
 
 ## Verify
 
-→ verify: `test -f skills/wire-ci/SKILL.md && echo "OK: skill file exists" || echo "FAIL: no skill file"`
-→ verify: `grep -q "name: wire-ci" skills/wire-ci/SKILL.md && echo "OK: frontmatter" || echo "FAIL: frontmatter"`
 → verify: `grep -ci "template\|workflow\|validate\|dry.run" skills/wire-ci/SKILL.md | awk '{if($1>=3) print "OK: semantics"; else print "FAIL: missing"}'`
 → verify: `grep -q "wire-ci" SKILL-INDEX.md && echo "OK: in SKILL-INDEX" || echo "FAIL: not indexed"`
 

--- a/.gemini/extensions/bigpowers/skills/gate-trace/SKILL.md
+++ b/.gemini/extensions/bigpowers/skills/gate-trace/SKILL.md
@@ -70,10 +70,6 @@ gate_trace:
 - scripts/check-blind-spots.sh (e38s04) — produces blind-spots.json.
 - specs/execution-status.yaml — output target for gate result.
 
-## Verify
-
-→ verify: `test -f skills/gate-trace/SKILL.md && grep -q 'PASS.*CONCERNS.*FAIL.*WAIVED' skills/gate-trace/SKILL.md && echo "OK: gate-trace skill created" || echo "FAIL"`
-
 ## Handoff
 
 Gate: READY → next: release-branch (final step before merge)

--- a/.gemini/extensions/bigpowers/skills/publish-package/SKILL.md
+++ b/.gemini/extensions/bigpowers/skills/publish-package/SKILL.md
@@ -71,8 +71,6 @@ See [REFERENCE.md](REFERENCE.md)
 
 ## Verify
 
-→ verify: `test -f skills/publish-package/SKILL.md && echo "OK: skill file exists" || echo "FAIL: no skill file"`
-→ verify: `grep -q "name: publish-package" skills/publish-package/SKILL.md && echo "OK: frontmatter" || echo "FAIL: frontmatter"`
 → verify: `grep -ci "npm\|crates.io\|pypi\|publish\|registry" skills/publish-package/SKILL.md | awk '{if($1>=4) print "OK: semantics"; else print "FAIL: missing"}'`
 → verify: `grep -q "publish-package" SKILL-INDEX.md && echo "OK: in SKILL-INDEX" || echo "FAIL: not indexed"`
 

--- a/.gemini/extensions/bigpowers/skills/run-benchmark/SKILL.md
+++ b/.gemini/extensions/bigpowers/skills/run-benchmark/SKILL.md
@@ -64,7 +64,3 @@ scenarios:
    - `IMPROVED: 0.67 → 0.83`
    - `REGRESSION: 0.83 → 0.67 — do NOT ship this change`
    - `STABLE: 0.83 = 0.83`
-
-## Verify
-
-→ verify: `test -f skills/run-benchmark/SKILL.md && grep -q 'pass_at_k\|pass.at.k' skills/run-benchmark/SKILL.md && echo OK || echo FAIL`

--- a/.gemini/extensions/bigpowers/skills/visual-dashboard/SKILL.md
+++ b/.gemini/extensions/bigpowers/skills/visual-dashboard/SKILL.md
@@ -48,5 +48,3 @@ Required YAML keys:
 ## Agent screens (optional)
 
 Push HTML to the dashboard session dir for rich diagrams. See `start-server.sh` for `CONTENT_DIR`.
-
-→ verify: `test -f skills/visual-dashboard/scripts/read-specs-status.cjs && test -f skills/visual-dashboard/scripts/cockpit.html`

--- a/.gemini/extensions/bigpowers/skills/wire-ci/SKILL.md
+++ b/.gemini/extensions/bigpowers/skills/wire-ci/SKILL.md
@@ -100,8 +100,6 @@ Add the following to the project's documentation or CLAUDE.md after setup:
 
 ## Verify
 
-→ verify: `test -f skills/wire-ci/SKILL.md && echo "OK: skill file exists" || echo "FAIL: no skill file"`
-→ verify: `grep -q "name: wire-ci" skills/wire-ci/SKILL.md && echo "OK: frontmatter" || echo "FAIL: frontmatter"`
 → verify: `grep -ci "template\|workflow\|validate\|dry.run" skills/wire-ci/SKILL.md | awk '{if($1>=3) print "OK: semantics"; else print "FAIL: missing"}'`
 → verify: `grep -q "wire-ci" SKILL-INDEX.md && echo "OK: in SKILL-INDEX" || echo "FAIL: not indexed"`
 

--- a/.pi/prompts/gate-trace.md
+++ b/.pi/prompts/gate-trace.md
@@ -69,10 +69,6 @@ gate_trace:
 - scripts/check-blind-spots.sh (e38s04) — produces blind-spots.json.
 - specs/execution-status.yaml — output target for gate result.
 
-## Verify
-
-→ verify: `test -f skills/gate-trace/SKILL.md && grep -q 'PASS.*CONCERNS.*FAIL.*WAIVED' skills/gate-trace/SKILL.md && echo "OK: gate-trace skill created" || echo "FAIL"`
-
 ## Handoff
 
 Gate: READY → next: release-branch (final step before merge)

--- a/.pi/prompts/publish-package.md
+++ b/.pi/prompts/publish-package.md
@@ -70,8 +70,6 @@ See [REFERENCE.md](REFERENCE.md)
 
 ## Verify
 
-→ verify: `test -f skills/publish-package/SKILL.md && echo "OK: skill file exists" || echo "FAIL: no skill file"`
-→ verify: `grep -q "name: publish-package" skills/publish-package/SKILL.md && echo "OK: frontmatter" || echo "FAIL: frontmatter"`
 → verify: `grep -ci "npm\|crates.io\|pypi\|publish\|registry" skills/publish-package/SKILL.md | awk '{if($1>=4) print "OK: semantics"; else print "FAIL: missing"}'`
 → verify: `grep -q "publish-package" SKILL-INDEX.md && echo "OK: in SKILL-INDEX" || echo "FAIL: not indexed"`
 

--- a/.pi/prompts/run-benchmark.md
+++ b/.pi/prompts/run-benchmark.md
@@ -63,7 +63,3 @@ scenarios:
    - `IMPROVED: 0.67 → 0.83`
    - `REGRESSION: 0.83 → 0.67 — do NOT ship this change`
    - `STABLE: 0.83 = 0.83`
-
-## Verify
-
-→ verify: `test -f skills/run-benchmark/SKILL.md && grep -q 'pass_at_k\|pass.at.k' skills/run-benchmark/SKILL.md && echo OK || echo FAIL`

--- a/.pi/prompts/visual-dashboard.md
+++ b/.pi/prompts/visual-dashboard.md
@@ -47,5 +47,3 @@ Required YAML keys:
 ## Agent screens (optional)
 
 Push HTML to the dashboard session dir for rich diagrams. See `start-server.sh` for `CONTENT_DIR`.
-
-→ verify: `test -f skills/visual-dashboard/scripts/read-specs-status.cjs && test -f skills/visual-dashboard/scripts/cockpit.html`

--- a/.pi/prompts/wire-ci.md
+++ b/.pi/prompts/wire-ci.md
@@ -99,8 +99,6 @@ Add the following to the project's documentation or CLAUDE.md after setup:
 
 ## Verify
 
-→ verify: `test -f skills/wire-ci/SKILL.md && echo "OK: skill file exists" || echo "FAIL: no skill file"`
-→ verify: `grep -q "name: wire-ci" skills/wire-ci/SKILL.md && echo "OK: frontmatter" || echo "FAIL: frontmatter"`
 → verify: `grep -ci "template\|workflow\|validate\|dry.run" skills/wire-ci/SKILL.md | awk '{if($1>=3) print "OK: semantics"; else print "FAIL: missing"}'`
 → verify: `grep -q "wire-ci" SKILL-INDEX.md && echo "OK: in SKILL-INDEX" || echo "FAIL: not indexed"`
 

--- a/.pi/skills/gate-trace/SKILL.md
+++ b/.pi/skills/gate-trace/SKILL.md
@@ -71,10 +71,6 @@ gate_trace:
 - scripts/check-blind-spots.sh (e38s04) — produces blind-spots.json.
 - specs/execution-status.yaml — output target for gate result.
 
-## Verify
-
-→ verify: `test -f skills/gate-trace/SKILL.md && grep -q 'PASS.*CONCERNS.*FAIL.*WAIVED' skills/gate-trace/SKILL.md && echo "OK: gate-trace skill created" || echo "FAIL"`
-
 ## Handoff
 
 Gate: READY → next: release-branch (final step before merge)

--- a/.pi/skills/publish-package/SKILL.md
+++ b/.pi/skills/publish-package/SKILL.md
@@ -72,8 +72,6 @@ See [REFERENCE.md](REFERENCE.md)
 
 ## Verify
 
-→ verify: `test -f skills/publish-package/SKILL.md && echo "OK: skill file exists" || echo "FAIL: no skill file"`
-→ verify: `grep -q "name: publish-package" skills/publish-package/SKILL.md && echo "OK: frontmatter" || echo "FAIL: frontmatter"`
 → verify: `grep -ci "npm\|crates.io\|pypi\|publish\|registry" skills/publish-package/SKILL.md | awk '{if($1>=4) print "OK: semantics"; else print "FAIL: missing"}'`
 → verify: `grep -q "publish-package" SKILL-INDEX.md && echo "OK: in SKILL-INDEX" || echo "FAIL: not indexed"`
 

--- a/.pi/skills/run-benchmark/SKILL.md
+++ b/.pi/skills/run-benchmark/SKILL.md
@@ -65,7 +65,3 @@ scenarios:
    - `IMPROVED: 0.67 → 0.83`
    - `REGRESSION: 0.83 → 0.67 — do NOT ship this change`
    - `STABLE: 0.83 = 0.83`
-
-## Verify
-
-→ verify: `test -f skills/run-benchmark/SKILL.md && grep -q 'pass_at_k\|pass.at.k' skills/run-benchmark/SKILL.md && echo OK || echo FAIL`

--- a/.pi/skills/visual-dashboard/SKILL.md
+++ b/.pi/skills/visual-dashboard/SKILL.md
@@ -49,5 +49,3 @@ Required YAML keys:
 ## Agent screens (optional)
 
 Push HTML to the dashboard session dir for rich diagrams. See `start-server.sh` for `CONTENT_DIR`.
-
-→ verify: `test -f skills/visual-dashboard/scripts/read-specs-status.cjs && test -f skills/visual-dashboard/scripts/cockpit.html`

--- a/.pi/skills/wire-ci/SKILL.md
+++ b/.pi/skills/wire-ci/SKILL.md
@@ -101,8 +101,6 @@ Add the following to the project's documentation or CLAUDE.md after setup:
 
 ## Verify
 
-→ verify: `test -f skills/wire-ci/SKILL.md && echo "OK: skill file exists" || echo "FAIL: no skill file"`
-→ verify: `grep -q "name: wire-ci" skills/wire-ci/SKILL.md && echo "OK: frontmatter" || echo "FAIL: frontmatter"`
 → verify: `grep -ci "template\|workflow\|validate\|dry.run" skills/wire-ci/SKILL.md | awk '{if($1>=3) print "OK: semantics"; else print "FAIL: missing"}'`
 → verify: `grep -q "wire-ci" SKILL-INDEX.md && echo "OK: in SKILL-INDEX" || echo "FAIL: not indexed"`
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -128,7 +128,7 @@
     },
     "gate-trace": {
       "description": "\"Deterministic traceability quality gate — reads coverage matrix + blind-spot data, applies decision rules with oracle confidence downgrade, emits PASS/CONCERNS/FAIL/WAIVED verdict. Use before release-branch to gate merges on traceability.\"# story: e38s06",
-      "sha256": "15ca25acd70b90dd",
+      "sha256": "636810f46c6d0b93",
       "path": "skills/gate-trace/SKILL.md"
     },
     "grill-me": {
@@ -208,7 +208,7 @@
     },
     "publish-package": {
       "description": "\"Package registry publishing for npm, crates.io, PyPI, and Homebrew. Verifies prerequisites, runs the publish command, confirms success, and surfaces actionable error hints on failure.\"",
-      "sha256": "80bafe8c1274b49a",
+      "sha256": "3c1b82a417a7f170",
       "path": "skills/publish-package/SKILL.md"
     },
     "quick-fix": {
@@ -243,7 +243,7 @@
     },
     "run-benchmark": {
       "description": "Run skill quality benchmarks from specs/benchmarks/ definitions and write pass@k reports. Use before and after evolve-skill to prove quality changes are improvements, not regressions.",
-      "sha256": "9a3b988a2694d07e",
+      "sha256": "27fbc4e5346ecf21",
       "path": "skills/run-benchmark/SKILL.md"
     },
     "run-evals": {
@@ -348,12 +348,12 @@
     },
     "visual-dashboard": {
       "description": "Start a browser-based dashboard that visualizes architecture, implementation plans, and project status. Persists artifacts in .bigpowers/dashboard/. Reads specs/state.yaml, release-plan.yaml, epics, and planning-status via HTTP API or opencode panel.",
-      "sha256": "a1ca3502a91b9d2d",
+      "sha256": "8d0f5a9dffc9700a",
       "path": "skills/visual-dashboard/SKILL.md"
     },
     "wire-ci": {
       "description": "\"CI pipeline setup with pre-built templates and local validation. Generates GitHub Actions workflows, validates YAML syntax and permissions, supports dry-run via act/gh. The CI equivalent of wire-observability.\"",
-      "sha256": "1296ac1181853f95",
+      "sha256": "732ab59251710ea1",
       "path": "skills/wire-ci/SKILL.md"
     },
     "wire-observability": {

--- a/skills/gate-trace/SKILL.md
+++ b/skills/gate-trace/SKILL.md
@@ -72,10 +72,6 @@ gate_trace:
 - scripts/check-blind-spots.sh (e38s04) — produces blind-spots.json.
 - specs/execution-status.yaml — output target for gate result.
 
-## Verify
-
-→ verify: `test -f skills/gate-trace/SKILL.md && grep -q 'PASS.*CONCERNS.*FAIL.*WAIVED' skills/gate-trace/SKILL.md && echo "OK: gate-trace skill created" || echo "FAIL"`
-
 ## Handoff
 
 Gate: READY → next: release-branch (final step before merge)

--- a/skills/publish-package/SKILL.md
+++ b/skills/publish-package/SKILL.md
@@ -72,7 +72,5 @@ See [REFERENCE.md](REFERENCE.md)
 
 ## Verify
 
-→ verify: `test -f skills/publish-package/SKILL.md && echo "OK: skill file exists" || echo "FAIL: no skill file"`
-→ verify: `grep -q "name: publish-package" skills/publish-package/SKILL.md && echo "OK: frontmatter" || echo "FAIL: frontmatter"`
 → verify: `grep -ci "npm\|crates.io\|pypi\|publish\|registry" skills/publish-package/SKILL.md | awk '{if($1>=4) print "OK: semantics"; else print "FAIL: missing"}'`
 → verify: `grep -q "publish-package" SKILL-INDEX.md && echo "OK: in SKILL-INDEX" || echo "FAIL: not indexed"`

--- a/skills/run-benchmark/SKILL.md
+++ b/skills/run-benchmark/SKILL.md
@@ -66,6 +66,4 @@ scenarios:
    - `REGRESSION: 0.83 → 0.67 — do NOT ship this change`
    - `STABLE: 0.83 = 0.83`
 
-## Verify
 
-→ verify: `test -f skills/run-benchmark/SKILL.md && grep -q 'pass_at_k\|pass.at.k' skills/run-benchmark/SKILL.md && echo OK || echo FAIL`

--- a/skills/visual-dashboard/SKILL.md
+++ b/skills/visual-dashboard/SKILL.md
@@ -49,5 +49,3 @@ Required YAML keys:
 ## Agent screens (optional)
 
 Push HTML to the dashboard session dir for rich diagrams. See `start-server.sh` for `CONTENT_DIR`.
-
-→ verify: `test -f skills/visual-dashboard/scripts/read-specs-status.cjs && test -f skills/visual-dashboard/scripts/cockpit.html`

--- a/skills/wire-ci/SKILL.md
+++ b/skills/wire-ci/SKILL.md
@@ -101,7 +101,5 @@ Add the following to the project's documentation or CLAUDE.md after setup:
 
 ## Verify
 
-→ verify: `test -f skills/wire-ci/SKILL.md && echo "OK: skill file exists" || echo "FAIL: no skill file"`
-→ verify: `grep -q "name: wire-ci" skills/wire-ci/SKILL.md && echo "OK: frontmatter" || echo "FAIL: frontmatter"`
 → verify: `grep -ci "template\|workflow\|validate\|dry.run" skills/wire-ci/SKILL.md | awk '{if($1>=3) print "OK: semantics"; else print "FAIL: missing"}'`
 → verify: `grep -q "wire-ci" SKILL-INDEX.md && echo "OK: in SKILL-INDEX" || echo "FAIL: not indexed"`

--- a/specs/benchmarks/reports/BASELINE-GOLDEN.yaml
+++ b/specs/benchmarks/reports/BASELINE-GOLDEN.yaml
@@ -1,95 +1,120 @@
-timestamp: "2026-07-03T03:57:19Z"
-git_commit: "34d0ce89c4a26915786bd9b45379e7f2c289cc06"
+timestamp: "2026-07-04T11:51:20Z"
+git_commit: "1a7e6dbe83b3f418b5ee8ee1e8621cc8cb05acc3"
 suite: "golden-deterministic"
 mode: "baseline"
 gates:
-- name: compliance
-  exit_code: 0
-  duration_seconds: 16.74
-  status: pass
-- name: g04-selftest
-  exit_code: 1
-  duration_seconds: .03
-  status: fail
+  - name: compliance
+    exit_code: 0
+    duration_seconds: 7.16
+    status: pass
+  - name: g04-selftest
+    exit_code: 0
+    duration_seconds: .03
+    status: pass
+  - name: g07-negative-path
+    exit_code: 0
+    duration_seconds: .08
+    status: pass
+  - name: g08-anti-vacuity
+    exit_code: 0
+    duration_seconds: .22
+    status: pass
+  - name: g09-yaml-roundtrip
+    exit_code: 0
+    duration_seconds: .42
+    status: pass
+  - name: g10-trace-anti-vacuity
+    exit_code: 0
+    duration_seconds: .23
+    status: pass
+  - name: g11-gitignore-venv
+    exit_code: 1
+    duration_seconds: .05
+    status: fail
+  - name: specs-parse
+    exit_code: 0
+    duration_seconds: 1.63
+    status: pass
 summary:
-  total: 2
-  passed: 1
+  total: 8
+  passed: 7
   failed: 1
   skipped: 0
-  pass_rate: .50
+  pass_rate: .87
   overall: "fail"
 
 # Skill byte counts (baseline for e31s04 size budget)
 skill_sizes:
-  align-grid: 12066
-  assess-impact: 3090
-  audit-code: 5894
-  audit-plan: 3580
-  build-epic: 5171
-  change-request: 2574
-  commit-message: 3512
-  compose-workflow: 2130
-  craft-skill: 2755
-  deepen-architecture: 6069
-  define-language: 3965
-  define-success: 2748
-  delegate-task: 3244
-  deploy: 4090
-  design-interface: 3650
-  develop-tdd: 4543
-  diagnose-root: 1257
-  dispatch-agents: 3192
-  edit-document: 1214
-  elaborate-spec: 3994
-  enforce-first: 3425
-  evolve-skill: 1729
-  execute-plan: 2204
-  extract-design: 4084
-  fix-bug: 2283
-  grill-me: 1960
-  grill-with-docs: 1425
-  guard-git: 2828
-  hook-commits: 2478
-  inspect-quality: 4466
-  investigate-bug: 4974
-  kickoff-branch: 4500
-  map-codebase: 3415
-  migrate-spec: 5435
-  model-domain: 4746
-  orchestrate-project: 3678
-  organize-workspace: 3911
-  plan-refactor: 3034
-  plan-release: 5856
-  plan-work: 4044
-  publish-package: 2857
-  quick-fix: 4370
-  release-branch: 5055
-  request-review: 3533
-  research-first: 2391
-  reset-baseline: 780
-  respond-review: 2151
-  run-benchmark: 2607
-  run-evals: 1259
-  run-planning: 4661
-  scope-work: 3874
-  search-skills: 3288
-  security-review: 2979
-  seed-conventions: 3915
-  session-state: 5975
-  setup-environment: 1106
-  simulate-agents: 1243
-  slice-tasks: 4312
-  smoke-test: 2151
-  spike-prototype: 3305
-  stocktake-skills: 2349
-  survey-context: 5467
-  terse-mode: 2132
-  trace-requirement: 2477
-  using-bigpowers: 4732
-  validate-contracts: 3483
-  validate-fix: 3769
-  verify-work: 6044
-  visual-dashboard: 2042
-  wire-ci: 5066
-  wire-observability: 3231
-  write-document: 5119
+  align-grid: 12083
+  assess-impact: 3107
+  audit-code: 5911
+  audit-plan: 3597
+  build-epic: 5678
+  change-request: 2591
+  commit-message: 3529
+  compose-workflow: 2147
+  craft-skill: 2772
+  deepen-architecture: 6086
+  define-language: 3982
+  define-success: 2765
+  delegate-task: 3261
+  deploy: 4107
+  design-interface: 3667
+  develop-tdd: 4560
+  diagnose-root: 1274
+  dispatch-agents: 3209
+  edit-document: 1231
+  elaborate-spec: 4011
+  enforce-first: 3442
+  evolve-skill: 2031
+  execute-plan: 2221
+  extract-design: 4101
+  fix-bug: 2300
+  gate-trace: 3095
+  grill-me: 1977
+  grill-with-docs: 1442
+  guard-git: 2845
+  hook-commits: 2495
+  inspect-quality: 4483
+  investigate-bug: 4991
+  kickoff-branch: 4517
+  map-codebase: 3432
+  migrate-spec: 5452
+  model-domain: 4763
+  orchestrate-project: 3695
+  organize-workspace: 3928
+  plan-refactor: 3051
+  plan-release: 5872
+  plan-work: 4061
+  publish-package: 2626
+  quick-fix: 4387
+  release-branch: 5072
+  request-review: 3550
+  research-first: 2408
+  reset-baseline: 797
+  respond-review: 2168
+  run-benchmark: 2474
+  run-evals: 1276
+  run-planning: 4678
+  scope-work: 3891
+  search-skills: 3305
+  security-review: 2996
+  seed-conventions: 3932
+  session-state: 6489
+  setup-environment: 1123
+  simulate-agents: 1260
+  slice-tasks: 4329
+  smoke-test: 2168
+  spike-prototype: 3322
+  stocktake-skills: 2366
+  survey-context: 5694
+  terse-mode: 2149
+  trace-requirement: 2494
+  using-bigpowers: 4793
+  validate-contracts: 3500
+  validate-fix: 3786
+  verify-work: 6428
+  visual-dashboard: 1926
+  wire-ci: 4859
+  wire-observability: 3248
+  write-document: 5136

--- a/specs/benchmarks/reports/GOLDEN-2026-07-04.yaml
+++ b/specs/benchmarks/reports/GOLDEN-2026-07-04.yaml
@@ -1,0 +1,44 @@
+timestamp: "2026-07-04T11:51:06Z"
+git_commit: "1a7e6dbe83b3f418b5ee8ee1e8621cc8cb05acc3"
+suite: "golden-deterministic"
+mode: "daily"
+gates:
+  - name: compliance
+    exit_code: 0
+    duration_seconds: 7.20
+    status: pass
+  - name: g04-selftest
+    exit_code: 0
+    duration_seconds: .03
+    status: pass
+  - name: g07-negative-path
+    exit_code: 0
+    duration_seconds: .05
+    status: pass
+  - name: g08-anti-vacuity
+    exit_code: 0
+    duration_seconds: .21
+    status: pass
+  - name: g09-yaml-roundtrip
+    exit_code: 0
+    duration_seconds: .40
+    status: pass
+  - name: g10-trace-anti-vacuity
+    exit_code: 0
+    duration_seconds: .26
+    status: pass
+  - name: g11-gitignore-venv
+    exit_code: 1
+    duration_seconds: .06
+    status: fail
+  - name: specs-parse
+    exit_code: 0
+    duration_seconds: 1.68
+    status: pass
+summary:
+  total: 8
+  passed: 7
+  failed: 1
+  skipped: 0
+  pass_rate: .87
+  overall: "fail"

--- a/specs/bugs/BUG-2026-07-04-tautological-verify.md
+++ b/specs/bugs/BUG-2026-07-04-tautological-verify.md
@@ -1,0 +1,71 @@
+---
+bug_id: BUG-2026-07-04-tautological-verify
+status: open
+severity: medium
+scope: skills
+title: "Tautological verify commands in 5 non-critical skills — file-existence checks pass vacuously"
+---
+
+## Problem
+
+5 skills have verify commands that only test file existence rather than behavior:
+
+| Skill | Verify command | Why tautological |
+|-------|----------------|-----------------|
+| `publish-package` | `test -f skills/publish-package/SKILL.md` | sync-skills.sh already validates SKILL.md exists |
+| `publish-package` | `grep -q "name: publish-package" skills/publish-package/SKILL.md` | sync-skills.sh already validates frontmatter |
+| `wire-ci` | `test -f skills/wire-ci/SKILL.md` | sync-skills.sh already validates SKILL.md exists |
+| `wire-ci` | `grep -q "name: wire-ci" skills/wire-ci/SKILL.md` | sync-skills.sh already validates frontmatter |
+| `run-benchmark` | `test -f skills/run-benchmark/SKILL.md && grep -q 'pass_at_k\|pass.at.k'` | Own-file content check, not behavioral |
+| `gate-trace` | `test -f skills/gate-trace/SKILL.md && grep -q 'PASS.*CONCERNS.*FAIL.*WAIVED'` | Own-file content check, not behavioral |
+| `visual-dashboard` | `test -f skills/visual-dashboard/scripts/...` | Own-script file existence, not behavioral |
+
+### Expected behavior
+
+- Critical-path skills (build-epic, verify-work, audit-code, release-branch) have behavioral verify commands — they already do.
+- Other skills: tautological checks are removed entirely. sync-skills.sh already validates SKILL.md existence and frontmatter globally.
+
+### How to reproduce
+
+```bash
+grep -c 'test -f.*SKILL.md.*grep.*name:' skills/*/SKILL.md | grep -v ':0$' | wc -l
+```
+
+## Root Cause Analysis
+
+The verify sections in SKILL.md files were written early in the bigpowers project lifecycle, before `sync-skills.sh` existed as a global validation layer. The intent was to prove the skill was "configured correctly" but the checks only validate what `sync-skills.sh` already validates — and do so per-skill, adding noise without signal.
+
+**Code path**: Each of the 5 affected skills has a `## Verify` section (or inline verify command) containing one or more file-existence checks.
+
+**Why current code fails**: A verify command like `test -f skills/publish-package/SKILL.md` passes even if the skill's instructions produce garbage output. It tests that a file tree exists, not that the skill works.
+
+**Contributing factors**: No standard was documented for what makes a good verify command. The "test -f" pattern was cargo-culted.
+
+**Risk level**: Low (quality signal, not functional)
+
+## TDD Fix Plan
+
+This is a data-cleanup fix with no logic change. No RED-GREEN cycles needed.
+
+1. **GREEN**: Remove tautological verify commands from `publish-package`, `wire-ci`, `run-benchmark`, `gate-trace`, and `visual-dashboard` SKILL.md files.
+   **verify**: `grep -c 'test -f.*SKILL.md.*grep.*name:' skills/*/SKILL.md | grep -v ':0$' | wc -l | awk '{if($1==0) print "OK"; else print "REMAINING: "$1}'`
+
+## Acceptance Criteria
+
+- [ ] 7 tautological verify commands removed from 5 SKILL.md files
+- [ ] Critical-path skill verify commands unchanged
+- [x] Compliance still passes (88/88, 100%)
+- [x] Golden suite still passes (7/8, G-11 pre-existing)
+
+## Resolution
+
+**Fixed**: Removed 7 tautological verify commands from 5 SKILL.md files:
+- `publish-package`: removed 2 (file existence + frontmatter), kept semantic + index checks
+- `wire-ci`: removed 2 (file existence + frontmatter), kept semantic + index checks
+- `run-benchmark`: removed whole verify section (self-referential)
+- `gate-trace`: removed whole verify section (self-referential)
+- `visual-dashboard`: removed inline verify (own-script file existence)
+
+Critical-path skills (build-epic, verify-work, audit-code, release-branch) verified unchanged.
+
+**verify**: `bash scripts/run-golden-suite.sh && grep -c 'test -f.*SKILL.md.*grep.*name:' skills/*/SKILL.md | grep -v ':0$' | wc -l | awk '{if($1==0) print "OK"; else print "REMAINING: "$1}'` → OK

--- a/specs/bugs/registry.yaml
+++ b/specs/bugs/registry.yaml
@@ -1,183 +1,211 @@
 # AUTO-GENERATED — sync-bugs-registry.sh
 bugs:
-  - id: BUG-2026-06-02T164500
-    status: fixed
-    severity: high
-    scope: ci
-    title: "GitHub Actions Sync Skills and Release failed after YAML follow-up"
-    file: bugs/BUG-2026-06-02T164500.md
-    files_changed: "scripts/sync-skills.sh, package-lock.json, .github/workflows/publish.yml, .cursor/rules/trace-requirement.mdc, .gemini/extensions/bigpowers/gemini-extension.json"
-    approach: "sed -E whitespace collapse, jq version/description, lockfile refresh, Node 22 in publish workflow"
-    risk_level: "high"
-    commit_message: "fix(ci): repair sync-skills sed and refresh package-lock; fix(ci): use Node 22 for semantic-release workflow"
-  - id: BUG-2026-06-11T120000
-    status: fixed
-    severity: medium
-    scope: dashboard/tui
-    title: "TUI markup tags render as literal text; layout diverges from prototype"
-    file: bugs/BUG-2026-06-11T120000.md
-  - id: BUG-2026-06-11T160000
-    status: fixed
-    severity: medium
-    scope: dashboard/tui
-    title: "{dim} and {|} render as literal text after TUI prototype adaptation"
-    file: bugs/BUG-2026-06-11T160000.md
-  - id: BUG-2026-06-11T183000
-    status: fixed
-    severity: medium
-    scope: dashboard/cli
-    title: "dashboard CLI not exposed as bin entry — only works inside bigpowers repo"
-    file: bugs/BUG-2026-06-11T183000.md
-    files_changed: "package.json"
-    approach: "Add bigpowers-dashboard to bin field in package.json pointing to dashboard/bin/dashboard.js"
-    risk_level: "low"
-    commit_message: "fix(dashboard): expose bigpowers-dashboard as global CLI bin entry"
-  - id: BUG-2026-06-13T090000
-    status: fixed
-    severity: medium
-    scope: docs
-    title: "Doctrine drift — docs teach stale artifact names, dead skill references, and an undefined quality gate"
-    file: bugs/BUG-2026-06-13T090000.md
-    files_changed: "docs/references/gates.md, docs/PRINCIPLES.md, docs/references/model-profiles.md, scripts/check-skill-size.sh, scripts/audit-compliance.sh"
-    approach: "Update gates.md + PRINCIPLES.md to YAML artifact names; fix dead skill names in model-profiles.md; single-source skill count; add SKILL.md size lint; define or soften 94% threshold"
-    risk_level: "medium"
-    commit_message: "fix(docs): update doctrine to match YAML artifact layout, fix skill names, add size lint, instrument 94% gate"
-  - id: BUG-2026-06-18T100000
-    status: fixed
-    severity: high
-    scope: skills
-    title: "YAML frontmatter quoting breaks skill loading"
-    file: bugs/BUG-2026-06-18T100000.md
-  - id: BUG-2026-06-24T045323
-    status: fixed
-    severity: high
-    scope: ci
-    title: "npm install fails during postinstall — docs/ excluded from tarball"
-    file: bugs/BUG-2026-06-24T045323.md
-  - id: BUG-2026-06-27T000000
-    status: fixed
-    severity: high
-    scope: ci
-    title: "8 SKILL.md files exceed line cap — CI blocked on check-skill-size.sh"
-    file: bugs/BUG-2026-06-27T000000.md
-    files_changed: "deploy/SKILL.md, deploy/REFERENCE.md, develop-tdd/SKILL.md, migrate-spec/SKILL.md, migrate-spec/REFERENCE.md, publish-package/SKILL.md, publish-package/REFERENCE.md, release-branch/SKILL.md, release-branch/REFERENCE.md, smoke-test/SKILL.md, smoke-test/REFERENCE.md, validate-contracts/SKILL.md, validate-contracts/REFERENCE.md, wire-ci/SKILL.md, wire-ci/REFERENCE.md"
-    approach: "Trim each over-length SKILL.md by moving procedural detail into REFERENCE.md"
-    risk_level: "low"
-    commit_message: "fix(ci): trim 8 over-length SKILL.md files to pass check-skill-size lint"
-  - id: BUG-2026-07-02-skill-verify-false-fails
-    status: fixed
-    severity: medium
-    scope: ci
-    title: "skill-verify script reports false FAILs"
-    file: bugs/BUG-2026-07-02-skill-verify-false-fails.md
-  - id: BUG-2026-07-02T103911
-    status: fixed
-    severity: high
-    scope: ci
-    title: "npm install fails on macOS — bash 3.2 lacks declare -A"
-    file: bugs/BUG-2026-07-02T103911.md
-  - id: BUG-2026-07-03-capsule-release-labels
-    status: fixed
-    severity: medium
-    scope: specs
-    title: "Backlog capsule release labels drifted from their release trains"
-    file: bugs/BUG-2026-07-03-capsule-release-labels.md
-  - id: BUG-2026-07-03-codebase-wiki-venv-pollution
-    status: fixed
-    severity: medium
-    scope: specs
-    title: "OKF codebase-wiki concepts polluted with .venv/site-packages false-positive links from buggy trace run"
-    file: bugs/BUG-2026-07-03-codebase-wiki-venv-pollution.md
-    risk_level: "medium"
-    commit_message: "fix(trace): exclude .venv, site-packages, __pycache__ from trace-stories walker"
-  - id: BUG-2026-07-03-glossary-sparse
-    status: fixed
-    severity: medium
-    scope: specs
-    title: "GLOSSARY_LATEST.yaml remains sparse — key domain terms missing"
-    file: bugs/BUG-2026-07-03-glossary-sparse.md
-  - id: BUG-2026-07-03-golden-lock-stale-e37-ids
-    status: fixed
-    severity: low
-    scope: ci
-    title: "e42 golden workflow renamed from e37 but lock file internals still carry 19 e37 identifiers"
-    file: bugs/BUG-2026-07-03-golden-lock-stale-e37-ids.md
-    risk_level: "low"
-  - id: BUG-2026-07-03-install-docs-stale
-    status: fixed
-    severity: medium
-    scope: docs
-    title: "README and docs reference removed npm lifecycle scripts (postinstall, npx)"
-    file: bugs/BUG-2026-07-03-install-docs-stale.md
-    commit_message: "docs: update all install instructions for postinstall-free flow"
-  - id: BUG-2026-07-03-negative-path-self-test
-    status: fixed
-    severity: medium
-    scope: ci
-    title: "Negative-path self-test — compliance step scripts have no proof they can fail"
-    file: bugs/BUG-2026-07-03-negative-path-self-test.md
-  - id: BUG-2026-07-03-trace-engine-vacuous-gate
-    status: fixed
-    severity: high
-    scope: scripts
-    title: "trace-stories.py uses lossy hand-rolled YAML parser — collects 1 of ~240 stories, --strict gate passes vacuously"
-    file: bugs/BUG-2026-07-03-trace-engine-vacuous-gate.md
-    risk_level: "high"
-  - id: BUG-2026-07-03-trace-stories-613-line
-    status: fixed
-    severity: low
-    scope: refactor
-    title: "trace-stories.sh 613-line waiver contradicts CONVENTIONS context-window justification"
-    file: bugs/BUG-2026-07-03-trace-stories-613-line.md
-  - id: BUG-2026-07-03-validate-specs-no-real-parser
-    status: fixed
-    severity: high
-    scope: scripts
-    title: "validate-specs-yaml.sh does no real YAML parsing — grep-only checks let 40 corrupt files pass every gate"
-    file: bugs/BUG-2026-07-03-validate-specs-no-real-parser.md
-    risk_level: "high"
-    commit_message: "fix(release-pipeline): stop YAML round-trip corruption, recover specs"
-  - id: BUG-2026-07-03-venv-not-gitignored
-    status: fixed
-    severity: low
-    scope: repo
-    title: ".venv/ exists at repo root and is not gitignored — one 'git add .' from committing the virtualenv"
-    file: bugs/BUG-2026-07-03-venv-not-gitignored.md
-    risk_level: "low"
-    commit_message: "fix(repo): gitignore Python virtualenvs and bytecode"
-  - id: BUG-2026-07-03-version-mirror-drift
-    status: fixed
-    severity: medium
-    scope: release-pipeline
-    title: "Version mirrors in state.yaml and release-plan.yaml drift after every semantic-release"
-    file: bugs/BUG-2026-07-03-version-mirror-drift.md
-  - id: BUG-2026-07-03-waiver-scoring
-    status: fixed
-    severity: medium
-    scope: ci
-    title: "Waiver-list scoring hides regressions inside intentional FAIL denominator"
-    file: bugs/BUG-2026-07-03-waiver-scoring.md
-  - id: BUG-2026-07-03-yaml-roundtrip-corruption
-    status: fixed
-    severity: critical
-    scope: release-pipeline
-    title: "Release prepare-hook corrupts YAML cockpit via lossy round-trip — 40 spec files flattened and committed"
-    file: bugs/BUG-2026-07-03-yaml-roundtrip-corruption.md
-    risk_level: "critical"
-    commit_message: "fix(release-pipeline): stop YAML round-trip corruption, recover specs"
-  - id: BUG-2026-07-04-stale-bak-features
-    status: fixed
-    severity: low
-    scope: specs
-    title: "Stale .bak file in features directory — karpathy.feature.bak"
-    file: bugs/BUG-2026-07-04-stale-bak-features.md
-    files_changed: "specs/verifications/features/karpathy.feature.bak"
-    approach: "Delete stale backup file; fixed on main in commit 21e85ec"
-    risk_level: "low"
-    commit_message: "fix(specs): delete stale karpathy.feature.bak from features directory"
-  - id: BUG-2026-07-03T020000
-    status: fixed
-    severity: high
-    scope: ci
-    title: "release-branch does not verify CI completion before declaring success"
-    file: bugs/BUG-2026-07-03T020000.md
+- approach: sed -E whitespace collapse, jq version/description, lockfile refresh,
+    Node 22 in publish workflow
+  commit_message: 'fix(ci): repair sync-skills sed and refresh package-lock; fix(ci):
+    use Node 22 for semantic-release workflow'
+  file: bugs/BUG-2026-06-02T164500.md
+  files_changed: scripts/sync-skills.sh, package-lock.json, .github/workflows/publish.yml,
+    .cursor/rules/trace-requirement.mdc, .gemini/extensions/bigpowers/gemini-extension.json
+  id: BUG-2026-06-02T164500
+  risk_level: high
+  scope: ci
+  severity: high
+  status: fixed
+  title: GitHub Actions Sync Skills and Release failed after YAML follow-up
+- file: bugs/BUG-2026-06-11T120000.md
+  id: BUG-2026-06-11T120000
+  scope: dashboard/tui
+  severity: medium
+  status: fixed
+  title: TUI markup tags render as literal text; layout diverges from prototype
+- file: bugs/BUG-2026-06-11T160000.md
+  id: BUG-2026-06-11T160000
+  scope: dashboard/tui
+  severity: medium
+  status: fixed
+  title: '{dim} and {|} render as literal text after TUI prototype adaptation'
+- approach: Add bigpowers-dashboard to bin field in package.json pointing to dashboard/bin/dashboard.js
+  commit_message: 'fix(dashboard): expose bigpowers-dashboard as global CLI bin entry'
+  file: bugs/BUG-2026-06-11T183000.md
+  files_changed: package.json
+  id: BUG-2026-06-11T183000
+  risk_level: low
+  scope: dashboard/cli
+  severity: medium
+  status: fixed
+  title: dashboard CLI not exposed as bin entry — only works inside bigpowers repo
+- approach: Update gates.md + PRINCIPLES.md to YAML artifact names; fix dead skill
+    names in model-profiles.md; single-source skill count; add SKILL.md size lint;
+    define or soften 94% threshold
+  commit_message: 'fix(docs): update doctrine to match YAML artifact layout, fix skill
+    names, add size lint, instrument 94% gate'
+  file: bugs/BUG-2026-06-13T090000.md
+  files_changed: docs/references/gates.md, docs/PRINCIPLES.md, docs/references/model-profiles.md,
+    scripts/check-skill-size.sh, scripts/audit-compliance.sh
+  id: BUG-2026-06-13T090000
+  risk_level: medium
+  scope: docs
+  severity: medium
+  status: fixed
+  title: Doctrine drift — docs teach stale artifact names, dead skill references,
+    and an undefined quality gate
+- file: bugs/BUG-2026-06-18T100000.md
+  id: BUG-2026-06-18T100000
+  scope: skills
+  severity: high
+  status: fixed
+  title: YAML frontmatter quoting breaks skill loading
+- file: bugs/BUG-2026-06-24T045323.md
+  id: BUG-2026-06-24T045323
+  scope: ci
+  severity: high
+  status: fixed
+  title: npm install fails during postinstall — docs/ excluded from tarball
+- approach: Trim each over-length SKILL.md by moving procedural detail into REFERENCE.md
+  commit_message: 'fix(ci): trim 8 over-length SKILL.md files to pass check-skill-size
+    lint'
+  file: bugs/BUG-2026-06-27T000000.md
+  files_changed: deploy/SKILL.md, deploy/REFERENCE.md, develop-tdd/SKILL.md, migrate-spec/SKILL.md,
+    migrate-spec/REFERENCE.md, publish-package/SKILL.md, publish-package/REFERENCE.md,
+    release-branch/SKILL.md, release-branch/REFERENCE.md, smoke-test/SKILL.md, smoke-test/REFERENCE.md,
+    validate-contracts/SKILL.md, validate-contracts/REFERENCE.md, wire-ci/SKILL.md,
+    wire-ci/REFERENCE.md
+  id: BUG-2026-06-27T000000
+  risk_level: low
+  scope: ci
+  severity: high
+  status: fixed
+  title: 8 SKILL.md files exceed line cap — CI blocked on check-skill-size.sh
+- file: bugs/BUG-2026-07-02-skill-verify-false-fails.md
+  id: BUG-2026-07-02-skill-verify-false-fails
+  scope: ci
+  severity: medium
+  status: fixed
+  title: skill-verify script reports false FAILs
+- file: bugs/BUG-2026-07-02T103911.md
+  id: BUG-2026-07-02T103911
+  scope: ci
+  severity: high
+  status: fixed
+  title: npm install fails on macOS — bash 3.2 lacks declare -A
+- file: bugs/BUG-2026-07-03-capsule-release-labels.md
+  id: BUG-2026-07-03-capsule-release-labels
+  scope: specs
+  severity: medium
+  status: fixed
+  title: Backlog capsule release labels drifted from their release trains
+- commit_message: 'fix(trace): exclude .venv, site-packages, __pycache__ from trace-stories
+    walker'
+  file: bugs/BUG-2026-07-03-codebase-wiki-venv-pollution.md
+  id: BUG-2026-07-03-codebase-wiki-venv-pollution
+  risk_level: medium
+  scope: specs
+  severity: medium
+  status: fixed
+  title: OKF codebase-wiki concepts polluted with .venv/site-packages false-positive
+    links from buggy trace run
+- file: bugs/BUG-2026-07-03-glossary-sparse.md
+  id: BUG-2026-07-03-glossary-sparse
+  scope: specs
+  severity: medium
+  status: fixed
+  title: GLOSSARY_LATEST.yaml remains sparse — key domain terms missing
+- file: bugs/BUG-2026-07-03-golden-lock-stale-e37-ids.md
+  id: BUG-2026-07-03-golden-lock-stale-e37-ids
+  risk_level: low
+  scope: ci
+  severity: low
+  status: fixed
+  title: e42 golden workflow renamed from e37 but lock file internals still carry
+    19 e37 identifiers
+- commit_message: 'docs: update all install instructions for postinstall-free flow'
+  file: bugs/BUG-2026-07-03-install-docs-stale.md
+  id: BUG-2026-07-03-install-docs-stale
+  scope: docs
+  severity: medium
+  status: fixed
+  title: README and docs reference removed npm lifecycle scripts (postinstall, npx)
+- file: bugs/BUG-2026-07-03-negative-path-self-test.md
+  id: BUG-2026-07-03-negative-path-self-test
+  scope: ci
+  severity: medium
+  status: fixed
+  title: Negative-path self-test — compliance step scripts have no proof they can
+    fail
+- file: bugs/BUG-2026-07-03-trace-engine-vacuous-gate.md
+  id: BUG-2026-07-03-trace-engine-vacuous-gate
+  risk_level: high
+  scope: scripts
+  severity: high
+  status: fixed
+  title: trace-stories.py uses lossy hand-rolled YAML parser — collects 1 of ~240
+    stories, --strict gate passes vacuously
+- file: bugs/BUG-2026-07-03-trace-stories-613-line.md
+  id: BUG-2026-07-03-trace-stories-613-line
+  scope: refactor
+  severity: low
+  status: fixed
+  title: trace-stories.sh 613-line waiver contradicts CONVENTIONS context-window justification
+- commit_message: 'fix(release-pipeline): stop YAML round-trip corruption, recover
+    specs'
+  file: bugs/BUG-2026-07-03-validate-specs-no-real-parser.md
+  id: BUG-2026-07-03-validate-specs-no-real-parser
+  risk_level: high
+  scope: scripts
+  severity: high
+  status: fixed
+  title: validate-specs-yaml.sh does no real YAML parsing — grep-only checks let 40
+    corrupt files pass every gate
+- commit_message: 'fix(repo): gitignore Python virtualenvs and bytecode'
+  file: bugs/BUG-2026-07-03-venv-not-gitignored.md
+  id: BUG-2026-07-03-venv-not-gitignored
+  risk_level: low
+  scope: repo
+  severity: low
+  status: fixed
+  title: .venv/ exists at repo root and is not gitignored — one 'git add .' from committing
+    the virtualenv
+- file: bugs/BUG-2026-07-03-version-mirror-drift.md
+  id: BUG-2026-07-03-version-mirror-drift
+  scope: release-pipeline
+  severity: medium
+  status: fixed
+  title: Version mirrors in state.yaml and release-plan.yaml drift after every semantic-release
+- file: bugs/BUG-2026-07-03-waiver-scoring.md
+  id: BUG-2026-07-03-waiver-scoring
+  scope: ci
+  severity: medium
+  status: fixed
+  title: Waiver-list scoring hides regressions inside intentional FAIL denominator
+- commit_message: 'fix(release-pipeline): stop YAML round-trip corruption, recover
+    specs'
+  file: bugs/BUG-2026-07-03-yaml-roundtrip-corruption.md
+  id: BUG-2026-07-03-yaml-roundtrip-corruption
+  risk_level: critical
+  scope: release-pipeline
+  severity: critical
+  status: fixed
+  title: Release prepare-hook corrupts YAML cockpit via lossy round-trip — 40 spec
+    files flattened and committed
+- approach: Delete stale backup file; fixed on main in commit 21e85ec
+  commit_message: 'fix(specs): delete stale karpathy.feature.bak from features directory'
+  file: bugs/BUG-2026-07-04-stale-bak-features.md
+  files_changed: specs/verifications/features/karpathy.feature.bak
+  id: BUG-2026-07-04-stale-bak-features
+  risk_level: low
+  scope: specs
+  severity: low
+  status: fixed
+  title: Stale .bak file in features directory — karpathy.feature.bak
+- file: bugs/BUG-2026-07-03T020000.md
+  id: BUG-2026-07-03T020000
+  scope: ci
+  severity: high
+  status: fixed
+  title: release-branch does not verify CI completion before declaring success
+- id: BUG-2026-07-04-tautological-verify
+  scope: skills
+  severity: medium
+  status: open
+  title: Tautological verify commands in 5 non-critical skills

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -1,48 +1,51 @@
-active_flow: null
+active_flow: fix_bug
+bigpowers_version: 2.59.7
+bug_cycle:
+  completed_steps:
+  - 1
+  - 2
+  - 3
+  - 4
+  current_step: 5
 bug_id: null
 handoff:
-  next_skill: survey-context
-  context: 'Issue #38 complete. release-branch gates: compliance 88/88,
-    commits conventional, security review clean (specs-only, no code),
-    traceability WAIVED (no gate-trace script), CI 2/2 passed at 6c83112,
-    cycle time recorded. Landed on main.'
-bug_cycle:
-  current_step: null
-  completed_steps: []
-previous_handoff:
-  next_skill: survey-context
-  context: 'BUG-2026-07-03-trace-engine-vacuous-gate fixed and landed. This was the third and final fail-open
-    bug in the bug class cluster: - BUG-2026-07-03-validate-specs-no-real-parser → fixed (real YAML parser)
-    - BUG-2026-07-03-yaml-roundtrip-corruption → fixed (PyYAML round-trip) - BUG-2026-07-03-trace-engine-vacuous-gate
-    → fixed (PyYAML + floor assertion + G-10)'
-release:
-  ci_verified: true
-  released_at: '2026-07-04T08:35:00Z'
-  commit: 6c83112
-bigpowers_version: 2.59.7
-node20_migration:
-  completed: true
-  commit: 5b6f1dd
-  changes: actions/checkout v4→v6, concurrency, timeout-minutes
+  context: 'Issue #39 fixed: removed 7 tautological verify commands from 5 non-critical
+    skills. Compliance 88/88. Golden suite 7/8 (G-11 pre-existing). Ready for release-branch.'
+  next_skill: release-branch
 metrics:
+  epic_e31:
+    completed_at: '2026-07-03T04:10:07Z'
+    prs: []
+    stories: 7
+    total_bcps: 11
   skill_timings:
-    survey-context:
-      calls: 0
-      total_seconds: 0
-      avg_seconds: 0
-      _start: '2026-06-28T23:57:13Z'
-    release-branch:
-      calls: 2
-      total_seconds: 472.0
-      avg_seconds: 236.0
     plan-work:
+      avg_seconds: 101.0
       calls: 1
       total_seconds: 101.0
-      avg_seconds: 101.0
-  story_start: '2026-07-02T23:00:00Z'
+    release-branch:
+      avg_seconds: 236.0
+      calls: 2
+      total_seconds: 472.0
+    survey-context:
+      _start: '2026-06-28T23:57:13Z'
+      avg_seconds: 0
+      calls: 0
+      total_seconds: 0
   story_end: '2026-07-03T12:30:00Z'
-  epic_e31:
-    total_bcps: 11
-    stories: 7
-    prs: []
-    completed_at: '2026-07-03T04:10:07Z'
+  story_start: '2026-07-02T23:00:00Z'
+node20_migration:
+  changes: actions/checkout v4→v6, concurrency, timeout-minutes
+  commit: 5b6f1dd
+  completed: true
+previous_handoff:
+  context: 'BUG-2026-07-03-trace-engine-vacuous-gate fixed and landed. This was the
+    third and final fail-open bug in the bug class cluster: - BUG-2026-07-03-validate-specs-no-real-parser
+    → fixed (real YAML parser) - BUG-2026-07-03-yaml-roundtrip-corruption → fixed
+    (PyYAML round-trip) - BUG-2026-07-03-trace-engine-vacuous-gate → fixed (PyYAML
+    + floor assertion + G-10)'
+  next_skill: survey-context
+release:
+  ci_verified: true
+  commit: 6c83112
+  released_at: '2026-07-04T08:35:00Z'


### PR DESCRIPTION
## Summary
- Removes 7 tautological verify commands from 5 non-critical skill SKILL.md files
- Keeps semantic content checks (publish-package, wire-ci) and SKILL-INDEX checks
- Critical-path skills (build-epic, verify-work, audit-code, release-branch) unchanged
- sync-skills.sh already validates SKILL.md existence/frontmatter globally

## Verify
- [x] Compliance 88/88 (100%)
- [x] Golden suite 7/8 (G-11 pre-existing)
- [x] All artifacts synced
- [x] No tautological 'test -f' verify commands remain

## Closes
Closes #39