### PR TITLE
docs(bugs): mark GitHub Pages deploy flaky bug fixed

### DIFF
--- a/specs/bugs/BUG-2026-07-06T134600-github-pages-deploy-flaky.md
+++ b/specs/bugs/BUG-2026-07-06T134600-github-pages-deploy-flaky.md
@@ -69,4 +69,9 @@ Verified via `gh run view` and deployment API:
 
 ## Resolution
 
-<!-- filled in by validate-fix -->
+**Fixed** in PR #56 — merged to `main` as `f124ff0`.
+
+- Root cause: transient GitHub Pages API rejection after successful build (run 28795963238); not a site build defect.
+- Fix: 3-attempt deploy with 45s backoff; `cancel-in-progress: true` on pages concurrency group.
+- Verify: post-merge run [28796637544](https://github.com/danielvm-git/bigpowers/actions/runs/28796637544) — build + deploy green on attempt 1.
+- Site: https://danielvm-git.github.io/bigpowers/ returns 200.

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -1,16 +1,7 @@
-active_flow: fix_bug
-bug_id: BUG-2026-07-06T134600
+active_flow: null
+bug_id: null
 bigpowers_version: 2.68.6
-bug_cycle:
-  current_step: 4
-  completed_steps:
-  - 1 (investigate-bug)
-  - 2 (diagnose-root)
-  - 3 (develop-tdd)
-active_decisions:
-  fix_approach: Deploy job retries actions/deploy-pages up to 3 times with 45s backoff; pages concurrency
-    cancel-in-progress true
+bug_cycle: {}
 handoff:
-  context: GitHub Pages push deploy failed transiently (run 28795963238). workflow_dispatch succeeded.
-    Retry wiring added to docs-site.yml.
-  next_skill: validate-fix
+  context: "BUG-2026-07-06T134600 fixed — GitHub Pages deploy retry merged (PR #56). Run 28796637544 green."
+  next_skill: null


### PR DESCRIPTION
## Summary

- Fills resolution section in BUG-2026-07-06T134600-github-pages-deploy-flaky.md
- Clears bug_cycle in specs/state.yaml (fix landed in PR #56)


Made with [Cursor](https://cursor.com)