### PR TITLE
fix(plan-release): encapsulate G28 boolean logic in check-spec-version-gap

### DIFF
--- a/scripts/check-spec-version-gap.sh
+++ b/scripts/check-spec-version-gap.sh
@@ -62,6 +62,35 @@ version_lt() {
   return 1
 }
 
+is_protected_branch() {
+  [[ "$1" == "main" || "$1" == "master" ]]
+}
+
+on_feature_branch() {
+  local branch="$1"
+  [[ -n "$branch" ]] || return 1
+  is_protected_branch "$branch" && return 1
+  return 0
+}
+
+yaml_value_set() {
+  local value="$1"
+  [[ -n "$value" ]] || return 1
+  [[ "$value" == "null" || "$value" == "None" ]] && return 1
+  return 0
+}
+
+has_dirty_specs() {
+  [[ -d "$SPECS" ]] && git -C "$PROJECT_DIR" status --porcelain -- specs/ 2>/dev/null | grep -q .
+}
+
+is_blocking_active_flow() {
+  local flow="$1"
+  yaml_value_set "$flow" || return 1
+  case "$flow" in build_epic|develop_tdd|fix_bug) return 0 ;; esac
+  return 1
+}
+
 find_migrations() {
   local ver="$1" reg="$BP_ROOT/specs/migrations/registry.okf.md"
   [[ ! -f "$reg" ]] && { echo "[]"; return; }
@@ -83,13 +112,12 @@ print(json.dumps(out))
 }
 
 check_active_work() {
-  local branch; branch=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo "")
-  if [[ -n "$branch" && "$branch" != "main" && "$branch" != "master" ]]; then echo "true"; return; fi
-  if [[ -d "$SPECS" ]] && git -C "$PROJECT_DIR" status --porcelain -- specs/ 2>/dev/null | grep -q .; then echo "true"; return; fi
-  local af; af=$(yaml_get "$SPECS/state.yaml" "active_flow")
-  if [[ -n "$af" && "$af" != "null" && "$af" != "None" ]]; then
-    case "$af" in build_epic|develop_tdd|fix_bug) echo "true"; return ;; esac
-  fi
+  local branch af
+  branch=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo "")
+  if on_feature_branch "$branch"; then echo "true"; return; fi
+  if has_dirty_specs; then echo "true"; return; fi
+  af=$(yaml_get "$SPECS/state.yaml" "active_flow")
+  if is_blocking_active_flow "$af"; then echo "true"; return; fi
   echo "false"
 }
 
@@ -103,7 +131,7 @@ fi
 
 SV=$(yaml_get "$SPECS/state.yaml" "bigpowers_version")
 
-if [[ -n "$SV" && "$SV" != "null" && "$SV" != "None" ]]; then
+if yaml_value_set "$SV"; then
   if [[ "$SV" == "$IV" ]]; then
     emit_json '{"gap":false,"stamp":true,"detected_version":"'"$SV"'","installed_version":"'"$IV"'","detection_method":"stamp","confidence":"high"}'
     exit 0
@@ -123,7 +151,7 @@ for f in release-plan.yaml execution-status.yaml product/SCOPE_LATEST.yaml metri
 done
 if [[ -f "$SPECS/state.yaml" ]]; then
   ec=$(yaml_get "$SPECS/state.yaml" "epic_cycle.current_step")
-  if [[ -n "$ec" && "$ec" != "null" && "$ec" != "None" ]]; then
+  if yaml_value_set "$ec"; then
     MARKERS+=("epic_cycle"); [[ "$DV" == "2.0.0" ]] && DV="2.20.0"
   fi
 fi

--- a/specs/benchmarks/reports/GOLDEN-2026-07-06.yaml
+++ b/specs/benchmarks/reports/GOLDEN-2026-07-06.yaml
@@ -1,5 +1,5 @@
-timestamp: "2026-07-06T23:22:25Z"
-git_commit: "edfdb791ee749e7ba26bb0563a77dc821c319533"
+timestamp: "2026-07-06T23:42:59Z"
+git_commit: "606c31d9463fe398d9405d9f273f1f7fb53c60ff"
 suite: "golden-combined"
 mode: "daily"
 deterministic:
@@ -11,7 +11,7 @@ deterministic:
 gates:
   - name: compliance
     exit_code: 0
-    duration_seconds: 40.80
+    duration_seconds: 37.78
     status: pass
   - name: g04-selftest
     exit_code: 0
@@ -19,7 +19,7 @@ gates:
     status: pass
   - name: g06-migrate-version
     exit_code: 0
-    duration_seconds: 6.64
+    duration_seconds: 6.09
     status: pass
   - name: g07-negative-path
     exit_code: 0
@@ -27,23 +27,23 @@ gates:
     status: pass
   - name: g08-anti-vacuity
     exit_code: 0
-    duration_seconds: .08
+    duration_seconds: .07
     status: pass
   - name: g09-yaml-roundtrip
     exit_code: 0
-    duration_seconds: .18
+    duration_seconds: .10
     status: pass
   - name: g10-trace-anti-vacuity
     exit_code: 0
-    duration_seconds: .11
+    duration_seconds: .09
     status: pass
   - name: g11-gitignore-venv
     exit_code: 0
-    duration_seconds: .07
+    duration_seconds: .08
     status: pass
   - name: specs-parse
     exit_code: 0
-    duration_seconds: .58
+    duration_seconds: .54
     status: pass
 agent_stories:
   total: 0

--- a/specs/bugs/BUG-2026-07-06-migrate-spec-migration-logic-violations.md
+++ b/specs/bugs/BUG-2026-07-06-migrate-spec-migration-logic-violations.md
@@ -3,27 +3,17 @@ bug_id: BUG-2026-07-06-migrate-spec-migration-logic-violations
 status: open
 severity: medium
 scope: skills/migrate-spec
-title: "migrate-spec: migrate-version.sh and check-spec-version-gap.sh exceed line limits and violate boolean encapsulation (G28)"
+title: "migrate-spec: migrate-version.sh exceeds line limits (G28 in check-spec-version-gap fixed separately)"
 ---
 
 # BUG-2026-07-06-migrate-spec-migration-logic-violations
 
 ## Problem
 
-**Actual behavior:** The version migration engine and version gap check scripts fail multiple compliance gates:
-1. `scripts/migrate-version.sh` — 727 lines (exceeds 300 and 500 lines limits, uses complex booleans at line 103, and has duplicate symbols).
-2. `scripts/check-spec-version-gap.sh` — uses complex unencapsulated boolean logic chains (G28) at lines 87, 90, 106, 126.
+**Remaining:** `scripts/migrate-version.sh` — 727 lines (exceeds 300/500 limits).
 
-**Expected behavior:** Version migration and gap check scripts should remain under 300 lines with encapsulated boolean expressions.
-
-**How to reproduce:**
-1. Run `bash scripts/run-verification-gates.sh` with waivers disabled.
-2. Observe the failures under `akita.feature` (file size > 300) and `cleancode.feature` (file size > 500, complex boolean G28).
-
-## Root Cause Analysis
-- `migrate-version.sh` grew excessively as version-specific migration rules were sequentially appended to it.
-- Conditional checks for branch names and version flags inside both scripts did not encapsulate complex multi-clause boolean checks into named functions.
+**Fixed elsewhere:** G28 in `check-spec-version-gap.sh` — see `BUG-2026-07-06-plan-release-gap-logic-boolean`.
 
 ## Proposed Resolution
-1. Partition `migrate-version.sh` migration steps into separate, dynamic rule scripts.
-2. Extract multi-clause conditionals in both scripts into helper functions.
+
+Partition `migrate-version.sh` migration steps into lib modules under 300 lines.

--- a/specs/bugs/BUG-2026-07-06-migrate-spec-migration-logic-violations.okf.md
+++ b/specs/bugs/BUG-2026-07-06-migrate-spec-migration-logic-violations.okf.md
@@ -2,7 +2,7 @@
 okf_kind: concept
 okf_version: "0.1"
 id: "BUG-2026-07-06-migrate-spec-migration-logic-violations"
-title: "migrate-spec: migrate-version.sh and check-spec-version-gap.sh exceed line limits and violate boolean encapsulation (G28)"
+title: "migrate-spec: migrate-version.sh exceeds line limits (G28 in check-spec-version-gap fixed separately)"
 category: bug
 tier: extended
 severity: medium
@@ -12,7 +12,7 @@ references:
     - specs/bugs/BUG-2026-07-06-migrate-spec-migration-logic-violations.md
 ---
 
-# migrate-spec: migrate-version.sh and check-spec-version-gap.sh exceed line limits and violate boolean encapsulation (G28)
+# migrate-spec: migrate-version.sh exceeds line limits (G28 in check-spec-version-gap fixed separately)
 
 **Bug:** BUG-2026-07-06-migrate-spec-migration-logic-violations | **Severity:** medium | **Status:** open | **Scope:** skills/migrate-spec
 **Tier:** extended

--- a/specs/bugs/BUG-2026-07-06-plan-release-gap-logic-boolean.md
+++ b/specs/bugs/BUG-2026-07-06-plan-release-gap-logic-boolean.md
@@ -1,6 +1,6 @@
 ---
 bug_id: BUG-2026-07-06-plan-release-gap-logic-boolean
-status: open
+status: fixed
 severity: medium
 scope: skills/plan-release
 title: "plan-release: check-spec-version-gap.sh contains complex unencapsulated boolean logic (G28)"
@@ -10,16 +10,8 @@ title: "plan-release: check-spec-version-gap.sh contains complex unencapsulated 
 
 ## Problem
 
-**Actual behavior:** The version check logic in `scripts/check-spec-version-gap.sh` violates the G28 boolean encapsulation gate by writing multiple three-clause conditionals on a single line (Lines 87, 90, 106, 126).
+`scripts/check-spec-version-gap.sh` violated G28 by using multi-clause `&&` conditionals inline at lines 87, 90, 106, and 126.
 
-**Expected behavior:** Complex conditionals should be encapsulated in named, intention-revealing functions.
+## Resolution
 
-**How to reproduce:**
-1. Run `bash scripts/run-verification-gates.sh` with waivers disabled.
-2. Note the failure in `cleancode.feature` (complex boolean logic G28).
-
-## Root Cause Analysis
-Shell conditionals checking arrays and environment flags did not structure the boolean checks into clean function definitions, resulting in long conditional clauses.
-
-## Proposed Resolution
-Extract the complex conditionals into named shell functions with intention-revealing names.
+**Fixed:** Extracted `yaml_value_set`, `on_feature_branch`, `is_protected_branch`, `has_dirty_specs`, and `is_blocking_active_flow` helpers. Call sites now use single intention-revealing predicates. Golden suite 9/9 PASS.

--- a/specs/bugs/BUG-2026-07-06-plan-release-gap-logic-boolean.okf.md
+++ b/specs/bugs/BUG-2026-07-06-plan-release-gap-logic-boolean.okf.md
@@ -6,7 +6,7 @@ title: "plan-release: check-spec-version-gap.sh contains complex unencapsulated 
 category: bug
 tier: extended
 severity: medium
-status: open
+status: fixed
 generator: scripts/sync-bugs-registry.sh
 references:
     - specs/bugs/BUG-2026-07-06-plan-release-gap-logic-boolean.md
@@ -14,7 +14,7 @@ references:
 
 # plan-release: check-spec-version-gap.sh contains complex unencapsulated boolean logic (G28)
 
-**Bug:** BUG-2026-07-06-plan-release-gap-logic-boolean | **Severity:** medium | **Status:** open | **Scope:** skills/plan-release
+**Bug:** BUG-2026-07-06-plan-release-gap-logic-boolean | **Severity:** medium | **Status:** fixed | **Scope:** skills/plan-release
 **Tier:** extended
 
 See `specs/bugs/BUG-2026-07-06-plan-release-gap-logic-boolean.md` for full investigation and fix details.

--- a/specs/bugs/BUG-2026-07-06-run-evals-golden-suite-oversized.okf.md
+++ b/specs/bugs/BUG-2026-07-06-run-evals-golden-suite-oversized.okf.md
@@ -6,7 +6,7 @@ title: "run-evals: Underlying test suite runner run-golden-suite.sh exceeds 300-
 category: bug
 tier: extended
 severity: medium
-status: open
+status: fixed
 generator: scripts/sync-bugs-registry.sh
 references:
     - specs/bugs/BUG-2026-07-06-run-evals-golden-suite-oversized.md
@@ -14,7 +14,7 @@ references:
 
 # run-evals: Underlying test suite runner run-golden-suite.sh exceeds 300-line context window limit
 
-**Bug:** BUG-2026-07-06-run-evals-golden-suite-oversized | **Severity:** medium | **Status:** open | **Scope:** skills/run-evals
+**Bug:** BUG-2026-07-06-run-evals-golden-suite-oversized | **Severity:** medium | **Status:** fixed | **Scope:** skills/run-evals
 **Tier:** extended
 
 See `specs/bugs/BUG-2026-07-06-run-evals-golden-suite-oversized.md` for full investigation and fix details.

--- a/specs/bugs/registry.yaml
+++ b/specs/bugs/registry.yaml
@@ -229,16 +229,16 @@ bugs:
     status: open
     severity: medium
     scope: skills/migrate-spec
-    title: "migrate-spec: migrate-version.sh and check-spec-version-gap.sh exceed line limits and violate boolean encapsulation (G28)"
+    title: "migrate-spec: migrate-version.sh exceeds line limits (G28 in check-spec-version-gap fixed separately)"
     file: bugs/BUG-2026-07-06-migrate-spec-migration-logic-violations.md
   - id: BUG-2026-07-06-plan-release-gap-logic-boolean
-    status: open
+    status: fixed
     severity: medium
     scope: skills/plan-release
     title: "plan-release: check-spec-version-gap.sh contains complex unencapsulated boolean logic (G28)"
     file: bugs/BUG-2026-07-06-plan-release-gap-logic-boolean.md
   - id: BUG-2026-07-06-run-evals-golden-suite-oversized
-    status: open
+    status: fixed
     severity: medium
     scope: skills/run-evals
     title: "run-evals: Underlying test suite runner run-golden-suite.sh exceeds 300-line context window limit"


### PR DESCRIPTION
## Summary

- Extracts multi-clause conditionals in `check-spec-version-gap.sh` into named helpers: `yaml_value_set`, `on_feature_branch`, `has_dirty_specs`, `is_blocking_active_flow`
- Closes `BUG-2026-07-06-plan-release-gap-logic-boolean`
- Updates `migrate-spec` bug to note G28 portion resolved; `migrate-version.sh` size remains open

## Test plan

- [x] `bash scripts/check-spec-version-gap.sh --json`
- [x] `bash scripts/run-verification-gates.sh` — 9/9 PASS
- [x] `npm run compliance` — PASS
- [ ] GitHub Actions CI green on merge


Made with [Cursor](https://cursor.com)