### PR TITLE
fix(audit-code): split audit-compliance.sh into lib modules

### DIFF
--- a/scripts/audit-compliance.sh
+++ b/scripts/audit-compliance.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # audit-compliance.sh — Agentic Gherkin Compliance Harness (LLM-Judge Upgrade)
-show_help() {
+
+_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_LIB/audit-compliance-runner.sh"
+source "$_LIB/audit-compliance-report.sh"
+
+audit_show_help() {
   cat <<EOF
 Usage: bash scripts/audit-compliance.sh [feature-file|directory] [options]
 
@@ -15,320 +20,45 @@ If a directory is provided, all .feature files in that directory will be process
 EOF
 }
 
-# --- Arguments Parsing ---
 DRY_RUN=false
 SCENARIO_FILTER=""
 JUDGE="binary"
 MODEL=""
 INPUTS=()
+TOTAL_GLOBAL_PASS=0
+TOTAL_GLOBAL_FAIL=0
+TOTAL_GLOBAL_WAIVED=0
+TOTAL_GLOBAL_EXPIRED=0
+SCORE=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --help)
-      show_help
-      exit 0
-      ;;
-    --dry-run)
-      DRY_RUN=true
-      shift
-      ;;
-    --scenario)
-      SCENARIO_FILTER="$2"
-      shift 2
-      ;;
-    --judge)
-      JUDGE="$2"
-      shift 2
-      ;;
-    --model)
-      MODEL="$2"
-      shift 2
-      ;;
-    -*)
-      echo "Unknown option: $1"
-      show_help
-      exit 1
-      ;;
-    *)
-      INPUTS+=("$1")
-      shift
-      ;;
+    --help) audit_show_help; exit 0 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    --scenario) SCENARIO_FILTER="$2"; shift 2 ;;
+    --judge) JUDGE="$2"; shift 2 ;;
+    --model) MODEL="$2"; shift 2 ;;
+    -*) echo "Unknown option: $1"; audit_show_help; exit 1 ;;
+    *) INPUTS+=("$1"); shift ;;
   esac
 done
 
 if [[ ${#INPUTS[@]} -eq 0 ]]; then
   echo "Error: No feature file or directory specified."
-  show_help
+  audit_show_help
   exit 1
 fi
 
-# --- Global Stats ---
-TOTAL_GLOBAL_PASS=0
-TOTAL_GLOBAL_FAIL=0
-TOTAL_GLOBAL_WAIVED=0
-TOTAL_GLOBAL_EXPIRED=0
-
-# --- Waiver Subsystem ---
-# Sourced from scripts/lib/waiver-utils.sh — provides has_waiver().
-WAIVER_FILE="specs/verifications/waivers.yaml"
-true && source "$(dirname "${BASH_SOURCE[0]}")/lib/waiver-utils.sh"
-
-# --- Judging Logic ---
-
-judge_with_gemini() {
-  local step="$1"
-  local feature_name="$2"
-  local scenario_name="$3"
-  local evidence="$4"
-  local report_file="$5"
-
-  echo "    [JUDGE] Sending evidence to Gemini CLI..."
-  
-  local prompt="You are the Master Test Architect judging a compliance audit.
-Benchmark Feature: $feature_name
-Scenario: $scenario_name
-Compliance Step: $step
-
-Evidence gathered from the codebase:
----
-$evidence
----
-
-Based on the benchmark principles, does this evidence demonstrate compliance?
-Respond strictly in the following format:
-VERDICT: [PASS/FAIL]
-RATIONALE: [One sentence explanation]"
-
-  local model_output
-  local gemini_cmd="gemini --approval-mode plan"
-  if [[ -n "$MODEL" ]]; then
-    gemini_cmd="$gemini_cmd -m $MODEL"
-  fi
-  
-  model_output=$($gemini_cmd -p "$prompt" 2>&1)
-  local exit_code=$?
-
-  if [[ $exit_code -eq 0 ]]; then
-    local verdict
-    verdict=$(echo "$model_output" | grep "VERDICT:" | cut -d' ' -f2)
-    local rationale
-    rationale=$(echo "$model_output" | grep "RATIONALE:" | cut -d' ' -f2-)
-
-    if [[ "$verdict" == "PASS" ]]; then
-      echo "      Result: PASS"
-      echo "- [x] $step (PASS) - $rationale" >> "$report_file"
-      return 0
-    else
-      echo "      Result: FAIL"
-      echo "- [ ] $step (FAIL) - $rationale" >> "$report_file"
-      return 1
-    fi
-  else
-    echo "      Result: ERROR (Gemini CLI failed)"
-    echo "- [ ] $step (ERROR) - Gemini CLI exit code $exit_code. Output: $model_output" >> "$report_file"
-    return 1
-  fi
-}
-
-
-
-# --- Core Execution ---
-
-process_step() {
-  local step="$1"
-  local feature_name="$2"
-  local scenario_name="$3"
-  local report_file="$4"
-  echo "    [STEP] $step"
-
-  if [[ "$DRY_RUN" == "true" ]]; then
-    return 0
-  fi
-
-  local sanitized_step
-  sanitized_step=$(echo "$step" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
-  local step_script="specs/verifications/steps/${sanitized_step}.sh"
-
-  if [[ -f "$step_script" ]]; then
-    echo "    [EXEC] Gathering evidence: $step_script"
-    local evidence
-    evidence=$(bash "$step_script" 2>&1)
-    local exit_code=$?
-
-    if [[ "$JUDGE" == "gemini" ]]; then
-      judge_with_gemini "$step" "$feature_name" "$scenario_name" "$evidence" "$report_file"
-      # Gemini path: rely on judge return code (no waiver check for LLM path)
-    else
-      # Binary path: check waivers before counting as FAIL
-      if [[ $exit_code -eq 0 ]]; then
-        echo "      Result: PASS"
-        echo "- [x] $step (PASS)" >> "$report_file"
-        return 0
-      fi
-
-      # Step failed — check if it has a valid waiver
-      has_waiver "$sanitized_step"
-      local waiver_code=$?
-
-      if [[ $waiver_code -eq 0 ]]; then
-        # Valid waiver — exclude from denominator
-        echo "      Result: WAIVED (documented exception)"
-        echo "- [~] $step (WAIVED)" >> "$report_file"
-        ((TOTAL_GLOBAL_WAIVED++))
-        return 3  # Special code: waived (not PASS, not FAIL)
-      elif [[ $waiver_code -eq 2 ]]; then
-        # Expired waiver — re-enter denominator as FAIL
-        echo "      Result: FAIL (EXPIRED WAIVER)"
-        echo "- [ ] $step (FAIL) - EXPIRED WAIVER: review_date has passed" >> "$report_file"
-        ((TOTAL_GLOBAL_EXPIRED++))
-        ((TOTAL_GLOBAL_FAIL++))
-        return 1
-      else
-        # No waiver — genuine FAIL
-        echo "      Result: FAIL"
-        echo "- [ ] $step (FAIL) - $evidence" >> "$report_file"
-        ((TOTAL_GLOBAL_FAIL++))
-        return 1
-      fi
-    fi
-  else
-    echo "      Result: FAIL (Missing evidence: $step_script)"
-    echo "- [ ] $step (FAIL) - No verification script found at $step_script" >> "$report_file"
-    ((TOTAL_GLOBAL_FAIL++))
-    return 1
-  fi
-}
-
-run_audit_file() {
-  local FEATURE_FILE="$1"
-  echo "------------------------------------------------------------"
-  echo "FEATURE: $FEATURE_FILE"
-  
-  local REPORT_FILE="specs/verifications/reports/audit-$(basename "$FEATURE_FILE" .feature)-$(date +%Y%m%d-%H%M%S).md"
-  mkdir -p specs/verifications/reports
-
-  echo "# Audit Report: $FEATURE_FILE" > "$REPORT_FILE"
-  echo "Date: $(date)" >> "$REPORT_FILE"
-  echo "Mode: Autonomous Verification (Judge: $JUDGE)" >> "$REPORT_FILE"
-  echo "" >> "$REPORT_FILE"
-
-  local TOTAL_PASS=0
-  local TOTAL_FAIL=0
-  local CURRENT_FEATURE=""
-  local CURRENT_SCENARIO=""
-  local IN_SCENARIO=false
-
-  while IFS= read -r line; do
-    line=$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-    
-    if [[ "$line" =~ ^Feature: ]]; then
-      CURRENT_FEATURE="${line#Feature: }"
-      echo "FEATURE: $CURRENT_FEATURE"
-      echo "## Feature: $CURRENT_FEATURE" >> "$REPORT_FILE"
-    elif [[ "$line" =~ ^Scenario: ]]; then
-      CURRENT_SCENARIO="${line#Scenario: }"
-      if [[ -n "$SCENARIO_FILTER" && "$CURRENT_SCENARIO" != "$SCENARIO_FILTER" ]]; then
-        IN_SCENARIO=false
-        continue
-      fi
-      IN_SCENARIO=true
-      echo "  SCENARIO: $CURRENT_SCENARIO"
-      echo "### Scenario: $CURRENT_SCENARIO" >> "$REPORT_FILE"
-    elif [[ "$line" =~ ^(Given|When|Then|And|But)\  ]]; then
-      if [[ "$IN_SCENARIO" == "true" ]]; then
-        local step_result
-        process_step "$line" "$CURRENT_FEATURE" "$CURRENT_SCENARIO" "$REPORT_FILE"
-        step_result=$?
-        if [[ $step_result -eq 3 ]]; then
-          # Waived — excluded from both pass and fail counts
-          :
-        elif [[ $step_result -eq 0 ]]; then
-          ((TOTAL_PASS++))
-          ((TOTAL_GLOBAL_PASS++))
-        else
-          ((TOTAL_FAIL++))
-        fi
-      fi
-    fi
-  done < "$FEATURE_FILE"
-
-  echo ""
-  echo "File Summary: PASS: $TOTAL_PASS, FAIL: $TOTAL_FAIL"
-  echo "Report saved to: $REPORT_FILE"
-}
-
-# --- Main Execution ---
 for input in "${INPUTS[@]}"; do
   if [[ -d "$input" ]]; then
     for f in "$input"/*.feature; do
-      if [[ -f "$f" ]]; then
-        run_audit_file "$f"
-      fi
+      [[ -f "$f" ]] && audit_run_file "$f"
     done
   elif [[ -f "$input" ]]; then
-    run_audit_file "$input"
+    audit_run_file "$input"
   else
     echo "Warning: Input not found: $input"
   fi
 done
 
-echo "============================================================"
-echo "Global Audit Summary:"
-TOTAL_GLOBAL_ALL=$((TOTAL_GLOBAL_PASS + TOTAL_GLOBAL_FAIL))
-echo "  TOTAL PASS:   $TOTAL_GLOBAL_PASS"
-echo "  TOTAL FAIL:   $TOTAL_GLOBAL_FAIL"
-echo "  TOTAL WAIVED: $TOTAL_GLOBAL_WAIVED  (excluded from denominator)"
-if [[ $TOTAL_GLOBAL_EXPIRED -gt 0 ]]; then
-  echo "  EXPIRED WAIVERS: $TOTAL_GLOBAL_EXPIRED (counted as FAIL)"
-fi
-if [[ $TOTAL_GLOBAL_ALL -gt 0 ]]; then
-  SCORE=$(awk "BEGIN { printf \"%d\", $TOTAL_GLOBAL_PASS * 100 / $TOTAL_GLOBAL_ALL }")
-else
-  SCORE=0
-fi
-
-# ── OKF verification-report (e45s02) ────────────────────────────────────
-OKF_DIR="specs/verifications/reports"
-mkdir -p "$OKF_DIR"
-OKF_FILE="$OKF_DIR/audit-$(date +%Y-%m-%d).okf.md"
-TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-GIT_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
-GATE=$(if [[ $SCORE -ge 94 ]]; then echo "pass"; else echo "fail"; fi)
-
-cat > "$OKF_FILE" << OKF_EOF
----
-okf_kind: verification-report
-okf_version: "0.1"
-score: ${SCORE}
-gate_status: "${GATE}"
-threshold: 94
-total_pass: ${TOTAL_GLOBAL_PASS}
-total_fail: ${TOTAL_GLOBAL_FAIL}
-total_waived: ${TOTAL_GLOBAL_WAIVED}
-generated_by: scripts/audit-compliance.sh
-generated_at: "${TIMESTAMP}"
-git_commit: "${GIT_COMMIT}"
----
-
-# Compliance Audit — $(date +%Y-%m-%d)
-
-**Score:** ${SCORE}% (${TOTAL_GLOBAL_PASS}/${TOTAL_GLOBAL_ALL} passed, ${TOTAL_GLOBAL_WAIVED} waived)
-**Gate:** ${GATE} | **Threshold:** 94%
-
-See \`specs/verifications/reports/audit-*.md\` for detailed step-by-step reports.
-OKF_EOF
-
-echo "OKF report: $OKF_FILE"
-
-if [[ $TOTAL_GLOBAL_WAIVED -gt 0 ]]; then
-  echo "  SCORE: ${SCORE}% (of ${TOTAL_GLOBAL_ALL} unwaived checks, threshold 94%)"
-else
-  echo "  SCORE: ${SCORE}% (threshold 94%)"
-fi
-if [[ $SCORE -ge 94 ]]; then
-  echo "  GATE: PASS"
-  exit 0
-else
-  echo "  GATE: FAIL (below 94%)"
-  exit 1
-fi
+audit_print_summary_and_exit

--- a/scripts/lib/audit-compliance-judge.sh
+++ b/scripts/lib/audit-compliance-judge.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# story: e45s02
+# Gemini LLM judge for audit-compliance.sh
+
+if [ -n "${AUDIT_COMPLIANCE_JUDGE_LOADED:-}" ]; then return 0; fi
+AUDIT_COMPLIANCE_JUDGE_LOADED=1
+
+audit_judge_with_gemini() {
+  local step="$1" feature_name="$2" scenario_name="$3" evidence="$4" report_file="$5"
+  local prompt model_output gemini_cmd exit_code verdict rationale
+
+  echo "    [JUDGE] Sending evidence to Gemini CLI..."
+
+  prompt="You are the Master Test Architect judging a compliance audit.
+Benchmark Feature: $feature_name
+Scenario: $scenario_name
+Compliance Step: $step
+
+Evidence gathered from the codebase:
+---
+$evidence
+---
+
+Based on the benchmark principles, does this evidence demonstrate compliance?
+Respond strictly in the following format:
+VERDICT: [PASS/FAIL]
+RATIONALE: [One sentence explanation]"
+
+  gemini_cmd="gemini --approval-mode plan"
+  [[ -n "$MODEL" ]] && gemini_cmd="$gemini_cmd -m $MODEL"
+
+  model_output=$($gemini_cmd -p "$prompt" 2>&1)
+  exit_code=$?
+
+  if [[ $exit_code -eq 0 ]]; then
+    verdict=$(echo "$model_output" | grep "VERDICT:" | cut -d' ' -f2)
+    rationale=$(echo "$model_output" | grep "RATIONALE:" | cut -d' ' -f2-)
+    if [[ "$verdict" == "PASS" ]]; then
+      echo "      Result: PASS"
+      echo "- [x] $step (PASS) - $rationale" >> "$report_file"
+      return 0
+    fi
+    echo "      Result: FAIL"
+    echo "- [ ] $step (FAIL) - $rationale" >> "$report_file"
+    return 1
+  fi
+
+  echo "      Result: ERROR (Gemini CLI failed)"
+  echo "- [ ] $step (ERROR) - Gemini CLI exit code $exit_code. Output: $model_output" >> "$report_file"
+  return 1
+}

--- a/scripts/lib/audit-compliance-report.sh
+++ b/scripts/lib/audit-compliance-report.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# story: e45s02
+# OKF report and gate verdict for audit-compliance.sh
+
+if [ -n "${AUDIT_COMPLIANCE_REPORT_LOADED:-}" ]; then return 0; fi
+AUDIT_COMPLIANCE_REPORT_LOADED=1
+
+audit_write_okf_report() {
+  local OKF_DIR OKF_FILE TIMESTAMP GIT_COMMIT GATE TOTAL_GLOBAL_ALL
+
+  TOTAL_GLOBAL_ALL=$((TOTAL_GLOBAL_PASS + TOTAL_GLOBAL_FAIL))
+  if [[ $TOTAL_GLOBAL_ALL -gt 0 ]]; then
+    SCORE=$(awk "BEGIN { printf \"%d\", $TOTAL_GLOBAL_PASS * 100 / $TOTAL_GLOBAL_ALL }")
+  else
+    SCORE=0
+  fi
+
+  OKF_DIR="specs/verifications/reports"
+  mkdir -p "$OKF_DIR"
+  OKF_FILE="$OKF_DIR/audit-$(date +%Y-%m-%d).okf.md"
+  TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  GIT_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+  GATE=$(if [[ $SCORE -ge 94 ]]; then echo "pass"; else echo "fail"; fi)
+
+  cat > "$OKF_FILE" << OKF_EOF
+---
+okf_kind: verification-report
+okf_version: "0.1"
+score: ${SCORE}
+gate_status: "${GATE}"
+threshold: 94
+total_pass: ${TOTAL_GLOBAL_PASS}
+total_fail: ${TOTAL_GLOBAL_FAIL}
+total_waived: ${TOTAL_GLOBAL_WAIVED}
+generated_by: scripts/audit-compliance.sh
+generated_at: "${TIMESTAMP}"
+git_commit: "${GIT_COMMIT}"
+---
+
+# Compliance Audit — $(date +%Y-%m-%d)
+
+**Score:** ${SCORE}% (${TOTAL_GLOBAL_PASS}/${TOTAL_GLOBAL_ALL} passed, ${TOTAL_GLOBAL_WAIVED} waived)
+**Gate:** ${GATE} | **Threshold:** 94%
+
+See \`specs/verifications/reports/audit-*.md\` for detailed step-by-step reports.
+OKF_EOF
+
+  echo "OKF report: $OKF_FILE"
+}
+
+audit_print_summary_and_exit() {
+  local TOTAL_GLOBAL_ALL=$((TOTAL_GLOBAL_PASS + TOTAL_GLOBAL_FAIL))
+
+  echo "============================================================"
+  echo "Global Audit Summary:"
+  echo "  TOTAL PASS:   $TOTAL_GLOBAL_PASS"
+  echo "  TOTAL FAIL:   $TOTAL_GLOBAL_FAIL"
+  echo "  TOTAL WAIVED: $TOTAL_GLOBAL_WAIVED  (excluded from denominator)"
+  [[ $TOTAL_GLOBAL_EXPIRED -gt 0 ]] && echo "  EXPIRED WAIVERS: $TOTAL_GLOBAL_EXPIRED (counted as FAIL)"
+
+  audit_write_okf_report
+
+  if [[ $TOTAL_GLOBAL_WAIVED -gt 0 ]]; then
+    echo "  SCORE: ${SCORE}% (of ${TOTAL_GLOBAL_ALL} unwaived checks, threshold 94%)"
+  else
+    echo "  SCORE: ${SCORE}% (threshold 94%)"
+  fi
+
+  if [[ $SCORE -ge 94 ]]; then
+    echo "  GATE: PASS"
+    exit 0
+  fi
+  echo "  GATE: FAIL (below 94%)"
+  exit 1
+}

--- a/scripts/lib/audit-compliance-runner.sh
+++ b/scripts/lib/audit-compliance-runner.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# story: e45s02
+# Feature-file runner for audit-compliance.sh
+
+if [ -n "${AUDIT_COMPLIANCE_RUNNER_LOADED:-}" ]; then return 0; fi
+AUDIT_COMPLIANCE_RUNNER_LOADED=1
+
+source "$(dirname "${BASH_SOURCE[0]}")/audit-compliance-judge.sh"
+WAIVER_FILE="specs/verifications/waivers.yaml"
+true && source "$(dirname "${BASH_SOURCE[0]}")/waiver-utils.sh"
+
+audit_process_step() {
+  local step="$1" feature_name="$2" scenario_name="$3" report_file="$4"
+  local sanitized_step step_script evidence exit_code waiver_code
+
+  echo "    [STEP] $step"
+  [[ "$DRY_RUN" == "true" ]] && return 0
+
+  sanitized_step=$(echo "$step" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+  step_script="specs/verifications/steps/${sanitized_step}.sh"
+
+  if [[ ! -f "$step_script" ]]; then
+    echo "      Result: FAIL (Missing evidence: $step_script)"
+    echo "- [ ] $step (FAIL) - No verification script found at $step_script" >> "$report_file"
+    ((TOTAL_GLOBAL_FAIL++))
+    return 1
+  fi
+
+  echo "    [EXEC] Gathering evidence: $step_script"
+  evidence=$(bash "$step_script" 2>&1)
+  exit_code=$?
+
+  if [[ "$JUDGE" == "gemini" ]]; then
+    audit_judge_with_gemini "$step" "$feature_name" "$scenario_name" "$evidence" "$report_file"
+    return $?
+  fi
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "      Result: PASS"
+    echo "- [x] $step (PASS)" >> "$report_file"
+    return 0
+  fi
+
+  has_waiver "$sanitized_step"
+  waiver_code=$?
+
+  if [[ $waiver_code -eq 0 ]]; then
+    echo "      Result: WAIVED (documented exception)"
+    echo "- [~] $step (WAIVED)" >> "$report_file"
+    ((TOTAL_GLOBAL_WAIVED++))
+    return 3
+  fi
+  if [[ $waiver_code -eq 2 ]]; then
+    echo "      Result: FAIL (EXPIRED WAIVER)"
+    echo "- [ ] $step (FAIL) - EXPIRED WAIVER: review_date has passed" >> "$report_file"
+    ((TOTAL_GLOBAL_EXPIRED++))
+    ((TOTAL_GLOBAL_FAIL++))
+    return 1
+  fi
+
+  echo "      Result: FAIL"
+  echo "- [ ] $step (FAIL) - $evidence" >> "$report_file"
+  ((TOTAL_GLOBAL_FAIL++))
+  return 1
+}
+
+audit_run_file() {
+  local FEATURE_FILE="$1" REPORT_FILE line TOTAL_PASS TOTAL_FAIL step_result
+  local CURRENT_FEATURE="" CURRENT_SCENARIO="" IN_SCENARIO=false
+
+  echo "------------------------------------------------------------"
+  echo "FEATURE: $FEATURE_FILE"
+
+  REPORT_FILE="specs/verifications/reports/audit-$(basename "$FEATURE_FILE" .feature)-$(date +%Y%m%d-%H%M%S).md"
+  mkdir -p specs/verifications/reports
+
+  {
+    echo "# Audit Report: $FEATURE_FILE"
+    echo "Date: $(date)"
+    echo "Mode: Autonomous Verification (Judge: $JUDGE)"
+    echo ""
+  } > "$REPORT_FILE"
+
+  TOTAL_PASS=0
+  TOTAL_FAIL=0
+
+  while IFS= read -r line; do
+    line=$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+    if [[ "$line" =~ ^Feature: ]]; then
+      CURRENT_FEATURE="${line#Feature: }"
+      echo "FEATURE: $CURRENT_FEATURE"
+      echo "## Feature: $CURRENT_FEATURE" >> "$REPORT_FILE"
+    elif [[ "$line" =~ ^Scenario: ]]; then
+      CURRENT_SCENARIO="${line#Scenario: }"
+      if [[ -n "$SCENARIO_FILTER" && "$CURRENT_SCENARIO" != "$SCENARIO_FILTER" ]]; then
+        IN_SCENARIO=false
+        continue
+      fi
+      IN_SCENARIO=true
+      echo "  SCENARIO: $CURRENT_SCENARIO"
+      echo "### Scenario: $CURRENT_SCENARIO" >> "$REPORT_FILE"
+    elif [[ "$line" =~ ^(Given|When|Then|And|But)\  ]]; then
+      [[ "$IN_SCENARIO" != "true" ]] && continue
+      audit_process_step "$line" "$CURRENT_FEATURE" "$CURRENT_SCENARIO" "$REPORT_FILE"
+      step_result=$?
+      if [[ $step_result -eq 3 ]]; then
+        :
+      elif [[ $step_result -eq 0 ]]; then
+        ((TOTAL_PASS++))
+        ((TOTAL_GLOBAL_PASS++))
+      else
+        ((TOTAL_FAIL++))
+      fi
+    fi
+  done < "$FEATURE_FILE"
+
+  echo ""
+  echo "File Summary: PASS: $TOTAL_PASS, FAIL: $TOTAL_FAIL"
+  echo "Report saved to: $REPORT_FILE"
+}

--- a/specs/benchmarks/reports/GOLDEN-2026-07-06.yaml
+++ b/specs/benchmarks/reports/GOLDEN-2026-07-06.yaml
@@ -1,5 +1,5 @@
-timestamp: "2026-07-06T23:57:10Z"
-git_commit: "8e7365f4144833a9852c1c71ceac127697a7613b"
+timestamp: "2026-07-07T00:29:27Z"
+git_commit: "08bc945872f8a06efecff20315c3422b55e90995"
 suite: "golden-combined"
 mode: "daily"
 deterministic:
@@ -11,15 +11,15 @@ deterministic:
 gates:
   - name: compliance
     exit_code: 0
-    duration_seconds: 36.71
+    duration_seconds: 61.05
     status: pass
   - name: g04-selftest
     exit_code: 0
-    duration_seconds: .03
+    duration_seconds: .05
     status: pass
   - name: g06-migrate-version
     exit_code: 0
-    duration_seconds: 5.73
+    duration_seconds: 6.44
     status: pass
   - name: g07-negative-path
     exit_code: 0
@@ -27,23 +27,23 @@ gates:
     status: pass
   - name: g08-anti-vacuity
     exit_code: 0
-    duration_seconds: .07
+    duration_seconds: .08
     status: pass
   - name: g09-yaml-roundtrip
     exit_code: 0
-    duration_seconds: .09
+    duration_seconds: .12
     status: pass
   - name: g10-trace-anti-vacuity
     exit_code: 0
-    duration_seconds: .09
+    duration_seconds: .10
     status: pass
   - name: g11-gitignore-venv
     exit_code: 0
-    duration_seconds: .05
+    duration_seconds: .07
     status: pass
   - name: specs-parse
     exit_code: 0
-    duration_seconds: .48
+    duration_seconds: .77
     status: pass
 agent_stories:
   total: 0

--- a/specs/bugs/BUG-2026-07-04-tautological-verify.md
+++ b/specs/bugs/BUG-2026-07-04-tautological-verify.md
@@ -1,6 +1,6 @@
 ---
 bug_id: BUG-2026-07-04-tautological-verify
-status: open
+status: fixed
 severity: medium
 scope: skills
 title: "Tautological verify commands in 5 non-critical skills — file-existence checks pass vacuously"

--- a/specs/bugs/BUG-2026-07-04-tautological-verify.okf.md
+++ b/specs/bugs/BUG-2026-07-04-tautological-verify.okf.md
@@ -6,7 +6,7 @@ title: "Tautological verify commands in 5 non-critical skills — file-existence
 category: bug
 tier: extended
 severity: medium
-status: open
+status: fixed
 generator: scripts/sync-bugs-registry.sh
 references:
     - specs/bugs/BUG-2026-07-04-tautological-verify.md
@@ -14,7 +14,7 @@ references:
 
 # Tautological verify commands in 5 non-critical skills — file-existence checks pass vacuously
 
-**Bug:** BUG-2026-07-04-tautological-verify | **Severity:** medium | **Status:** open | **Scope:** skills
+**Bug:** BUG-2026-07-04-tautological-verify | **Severity:** medium | **Status:** fixed | **Scope:** skills
 **Tier:** extended
 
 See `specs/bugs/BUG-2026-07-04-tautological-verify.md` for full investigation and fix details.

--- a/specs/bugs/BUG-2026-07-06-audit-code-auditor-oversized.md
+++ b/specs/bugs/BUG-2026-07-06-audit-code-auditor-oversized.md
@@ -1,6 +1,6 @@
 ---
 bug_id: BUG-2026-07-06-audit-code-auditor-oversized
-status: open
+status: fixed
 severity: medium
 scope: skills/audit-code
 title: "audit-code: Underlying auditor scripts exceed 300-line context window limit"
@@ -10,16 +10,15 @@ title: "audit-code: Underlying auditor scripts exceed 300-line context window li
 
 ## Problem
 
-**Actual behavior:** The compliance audit engine script `scripts/audit-compliance.sh` has grown to 334 lines, violating the 300-line limit.
+`scripts/audit-compliance.sh` — 334 lines (exceeded 300-line cap).
 
-**Expected behavior:** Auditor scripts should remain under 300 lines of code.
+## Resolution
 
-**How to reproduce:**
-1. Run `bash scripts/run-verification-gates.sh` with waivers disabled.
-2. Note the failure in `akita.feature` (file size > 300).
+**Fixed:** Split into `audit-compliance-{judge,runner,report}.sh` libs. Entry script 334 → 64 lines. Compliance + golden suite 9/9 PASS.
 
-## Root Cause Analysis
-The script manages feature parsing, environment checks, and reporting logic in a single file, resulting in expansion over time.
-
-## Proposed Resolution
-Extract feature file parsing or report generation logic into helper modules.
+| File | Lines |
+|------|-------|
+| audit-compliance.sh | 64 |
+| audit-compliance-runner.sh | 121 |
+| audit-compliance-report.sh | 75 |
+| audit-compliance-judge.sh | 51 |

--- a/specs/bugs/BUG-2026-07-06-audit-code-auditor-oversized.okf.md
+++ b/specs/bugs/BUG-2026-07-06-audit-code-auditor-oversized.okf.md
@@ -6,7 +6,7 @@ title: "audit-code: Underlying auditor scripts exceed 300-line context window li
 category: bug
 tier: extended
 severity: medium
-status: open
+status: fixed
 generator: scripts/sync-bugs-registry.sh
 references:
     - specs/bugs/BUG-2026-07-06-audit-code-auditor-oversized.md
@@ -14,7 +14,7 @@ references:
 
 # audit-code: Underlying auditor scripts exceed 300-line context window limit
 
-**Bug:** BUG-2026-07-06-audit-code-auditor-oversized | **Severity:** medium | **Status:** open | **Scope:** skills/audit-code
+**Bug:** BUG-2026-07-06-audit-code-auditor-oversized | **Severity:** medium | **Status:** fixed | **Scope:** skills/audit-code
 **Tier:** extended
 
 See `specs/bugs/BUG-2026-07-06-audit-code-auditor-oversized.md` for full investigation and fix details.

--- a/specs/bugs/registry.yaml
+++ b/specs/bugs/registry.yaml
@@ -190,13 +190,13 @@ bugs:
     title: "Stale .bak file in features directory — karpathy.feature.bak"
     file: bugs/BUG-2026-07-04-stale-bak-features.md
   - id: BUG-2026-07-04-tautological-verify
-    status: open
+    status: fixed
     severity: medium
     scope: skills
     title: "Tautological verify commands in 5 non-critical skills — file-existence checks pass vacuously"
     file: bugs/BUG-2026-07-04-tautological-verify.md
   - id: BUG-2026-07-06-audit-code-auditor-oversized
-    status: open
+    status: fixed
     severity: medium
     scope: skills/audit-code
     title: "audit-code: Underlying auditor scripts exceed 300-line context window limit"

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -1,23 +1,15 @@
 active_flow: fix_bug
 active_epic: e45
 active_story: null
-bug_id: BUG-2026-07-06-craft-skill-sync-oversized
+bug_id: BUG-2026-07-06-gate-trace-matrix-oversized
 bigpowers_version: 2.73.7
 bug_cycle:
-  current_step: 5
-  completed_steps:
-  - 1
-  - 2
-  - 3
-  - 4
-  bug_id: BUG-2026-07-06-craft-skill-sync-oversized
-epic_cycle:
-  current_step: 0
-  story: null
-  story_bcps: null
+  current_step: 1
+  completed_steps: []
+  bug_id: BUG-2026-07-06-gate-trace-matrix-oversized
 handoff:
-  context: fix-bug step 5 — release-branch in progress for craft-skill-sync-oversized
-  next_skill: release-branch
+  context: "fix-bug step 1 — investigate-bug for gate-trace-matrix-oversized"
+  next_skill: investigate-bug
   epic: e45
 metrics:
   story_start: null


### PR DESCRIPTION
## Summary

- Refactors `audit-compliance.sh` from 334 → 64 lines across 3 lib modules
- Closes `BUG-2026-07-06-audit-code-auditor-oversized`

## Test plan

- [x] `npm run compliance` — PASS
- [x] `bash scripts/run-verification-gates.sh` — 9/9 PASS
- [ ] GitHub Actions CI green on merge


Made with [Cursor](https://cursor.com)