### PR TITLE
fix(ci): add orphan gitlink guard to prevent checkout failures

### DIFF
--- a/scripts/lib/check-orphan-gitlinks.sh
+++ b/scripts/lib/check-orphan-gitlinks.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# check-orphan-gitlinks.sh — fail if git index has gitlinks without .gitmodules URLs
+# story: BUG-2026-07-09T033939-golden-g01-submodule-checkout
+set -euo pipefail
+
+check_orphan_gitlinks() {
+  local repo_root="${1:-.}"
+  local gitlinks orphans=0
+
+  cd "$repo_root"
+
+  while IFS= read -r path; do
+    [[ -z "$path" ]] && continue
+    if [[ ! -f .gitmodules ]] || ! git config -f .gitmodules --get "submodule.${path}.url" >/dev/null 2>&1; then
+      gitlinks+=("$path")
+      orphans=$((orphans + 1))
+    fi
+  done < <(git ls-files -s | awk '$1 == "160000" { $1=$2=$3=""; sub(/^ /, ""); print }')
+
+  if [[ "$orphans" -eq 0 ]]; then
+    echo "no orphan gitlinks"
+    return 0
+  fi
+
+  echo "orphan gitlink(s) without .gitmodules URL:" >&2
+  printf '  %s\n' "${gitlinks[@]}" >&2
+  return 1
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  check_orphan_gitlinks "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi

--- a/scripts/validate-doctrine.sh
+++ b/scripts/validate-doctrine.sh
@@ -137,6 +137,17 @@ else
   done
 fi
 
+# ── CI: orphan gitlinks break actions/checkout submodule cleanup ───────────────
+echo "--- [CI] orphan gitlinks ---"
+# shellcheck source=lib/check-orphan-gitlinks.sh
+source "$REPO_ROOT/scripts/lib/check-orphan-gitlinks.sh"
+if check_orphan_gitlinks "$REPO_ROOT" >/dev/null; then
+  doctrine_pass "no orphan gitlinks"
+else
+  doctrine_fail "git index contains gitlink(s) without .gitmodules URL — breaks actions/checkout"
+  check_orphan_gitlinks "$REPO_ROOT" >&2 || true
+fi
+
 # ── CI: trace-stories wrapper smoke (REPO_ROOT must be set under set -u) ───────
 echo "--- [CI] trace-stories wrapper smoke ---"
 if bash "$REPO_ROOT/scripts/trace-stories.sh" --help >/dev/null 2>&1; then

--- a/specs/bugs/BUG-2026-07-09T033939-golden-g01-submodule-checkout.md
+++ b/specs/bugs/BUG-2026-07-09T033939-golden-g01-submodule-checkout.md
@@ -1,0 +1,111 @@
+---
+bug_id: BUG-2026-07-09T033939-golden-g01-submodule-checkout
+status: fixed
+severity: high
+scope: ci
+title: "Golden Story G-01 fails at checkout — orphan gitlink tests/fixtures/.tmp-v1.x"
+security_impact: NONE
+risk_level: low
+commit_message: "fix(ci): remove embedded git repo tests/fixtures/.tmp-v1.x causing submodule checkout failures"
+---
+
+# BUG-2026-07-09T033939: Golden Story G-01 checkout fails on orphan gitlink
+
+## Problem
+
+**Actual:** Run [28782189517](https://github.com/danielvm-git/bigpowers/actions/runs/28782189517) — **Golden Story G-01: CI Gate Regression Test** failed in the `activation` job at step **Checkout .github and .agents folders**. All downstream jobs (`agent`, `detection`, `safe_outputs`, `conclusion`) were skipped.
+
+Error from `actions/checkout` post-checkout cleanup:
+
+```
+fatal: No url found for submodule path 'tests/fixtures/.tmp-v1.x' in .gitmodules
+The process '/usr/bin/git' failed with exit code 128
+```
+
+**Expected:** Sparse checkout of agent config folders completes; the golden workflow proceeds to run compliance gates.
+
+**Reproduce:**
+
+```bash
+gh run view 28782189517 --log-failed
+git ls-tree 77bfededdf4322d2ce480835d8043d56190c182e tests/fixtures/.tmp-v1.x
+# → 160000 commit … (gitlink/submodule mode)
+git submodule status   # fails with same error on affected SHAs
+```
+
+**Prior history:** Related to golden workflow scope (`BUG-2026-07-03-golden-lock-stale-e37-ids` — stale e37 IDs in lock file; different failure mode). **Novel** symptom: orphan gitlink without `.gitmodules` entry.
+
+**Security impact:** NONE — no exploit path identified. Checkout failure prevents workflow execution; no credential or data exposure.
+
+## Root Cause Analysis
+
+### Phase 1 — Reproduce
+
+- Confirmed failing step: `Checkout .github and .agents folders` in run 28782189517 at SHA `77bfeded` (release 2.68.0).
+- At that SHA, `tests/fixtures/.tmp-v1.x` was indexed as mode `160000` (gitlink/submodule) pointing to commit `6ab8c849`.
+- Repository has **no** `.gitmodules` file — git cannot resolve the submodule URL.
+- `actions/checkout` v7 runs `git submodule foreach` during credential cleanup; git exits 128 when any gitlink lacks a `.gitmodules` URL.
+
+### Phase 2 — Isolate
+
+- Failure is **not** in gh-aw activation logic, secret validation, or sparse-checkout path list — checkout fetch and sparse-checkout succeed; failure occurs in post-checkout submodule cleanup.
+- Only one orphan gitlink existed: `tests/fixtures/.tmp-v1.x`.
+- The directory was a migrate-spec test fixture that had been accidentally committed as an embedded git repository (nested `.git`) rather than normal tree content.
+- Same failure mode would affect any workflow using `actions/checkout` on affected SHAs (including `sync-skills.yml` per fix commit message).
+
+### Phase 3 — Hypothesize
+
+| # | Hypothesis | Falsification |
+|---|------------|---------------|
+| 1 | Orphan gitlink without `.gitmodules` breaks checkout submodule cleanup | **Confirmed** — `git ls-tree` shows 160000; no `.gitmodules`; error names exact path |
+| 2 | Sparse-checkout cone mode omits fixture path but submodule index still triggers foreach | **Rejected** — error occurs after successful checkout of sparse paths; index still lists gitlink |
+| 3 | gh-aw checkout step misconfigured | **Rejected** — standard `actions/checkout@v7`; failure is git index state, not workflow YAML |
+| 4 | Missing `DEEPSEEK_API_KEY` caused early exit | **Rejected** — secret validation step succeeded; failure is two steps later at checkout |
+
+### Phase 4 — Verify
+
+- **Root cause confirmed:** embedded git repo at `tests/fixtures/.tmp-v1.x` committed as gitlink (160000) without `.gitmodules` entry.
+- **Fix landed:** commit `288e20e` (2026-07-06) removed the gitlink and re-added fixture files as normal tree objects (`040000 tree`).
+- **Timing:** scheduled run at 09:37 UTC predates fix push (~11:41 UTC local / after 08:41 -0300); run hit `main` at unfixed SHA `77bfeded`.
+- **Current main verified:** `git ls-tree HEAD tests/fixtures/.tmp-v1.x` → `040000 tree`; `git submodule status` exits 0; no `.gitmodules`.
+
+**Risk level:** Low — data/index defect, not runtime logic. Recurrence risk remains without a compliance gate detecting new orphan gitlinks.
+
+## TDD Fix Plan
+
+> **Note:** Data fix (cycles 1–2) already shipped in `288e20e`. Cycles 3–4 add regression prevention still outstanding.
+
+1. **RED:** Index contains a gitlink (`160000`) at `tests/fixtures/.tmp-v1.x` with no `.gitmodules` URL — `git submodule status` exits 128.
+   **GREEN:** Remove gitlink; commit fixture files as normal tree content (already done in `288e20e`).
+   **verify:** `git ls-tree HEAD tests/fixtures/.tmp-v1.x | grep -q '^040000'`
+
+2. **RED:** Golden G-01 activation job fails at checkout on affected SHA (observed run 28782189517).
+   **GREEN:** Merge fix to `main`; re-run or wait for next scheduled G-01 — checkout step passes.
+   **verify:** `gh run list --workflow e42-golden-deepseek.lock.yml --limit 3`
+
+3. **RED:** No automated guard prevents re-introducing orphan gitlinks in tracked paths.
+   **GREEN:** Add doctrine or compliance assertion: fail if any indexed path has mode `160000` while `.gitmodules` is absent or lacks matching URL.
+   **verify:** `bash scripts/validate-doctrine.sh 2>&1 | grep -q 'no orphan gitlinks'`
+
+4. **RED:** Regression test does not assert the guard rejects a synthetic gitlink scenario.
+   **GREEN:** Add `tests/test-no-orphan-gitlinks.sh` that validates the check passes on clean tree and documents expected failure mode.
+   **verify:** `bash tests/test-no-orphan-gitlinks.sh`
+
+**REFACTOR:** None.
+
+## Acceptance Criteria
+
+- [x] `tests/fixtures/.tmp-v1.x` is tree content, not gitlink (288e20e)
+- [x] `git submodule status` succeeds on current `main`
+- [x] Doctrine/compliance gate detects orphan gitlinks
+- [x] Regression test for gitlink guard passes
+- [x] Existing tests still pass
+- [ ] Golden G-01 workflow dispatch green post-merge
+
+## Resolution
+
+**Fixed** — data fix in `288e20e`; regression gate added in fix branch.
+
+- Root cause: orphan gitlink at `tests/fixtures/.tmp-v1.x` without `.gitmodules` URL broke `actions/checkout` submodule cleanup.
+- Prevention: `scripts/lib/check-orphan-gitlinks.sh` wired into `validate-doctrine.sh`; `tests/test-no-orphan-gitlinks.sh` covers clean tree + synthetic orphan.
+- Verify: `bash tests/test-no-orphan-gitlinks.sh && bash scripts/validate-doctrine.sh`

--- a/specs/bugs/BUG-2026-07-09T033939-golden-g01-submodule-checkout.okf.md
+++ b/specs/bugs/BUG-2026-07-09T033939-golden-g01-submodule-checkout.okf.md
@@ -1,0 +1,21 @@
+---
+okf_kind: concept
+okf_version: "0.1"
+type: Bug
+id: "BUG-2026-07-09T033939-golden-g01-submodule-checkout"
+title: "Golden Story G-01 fails at checkout — orphan gitlink tests/fixtures/.tmp-v1.x"
+category: bug
+tier: extended
+severity: high
+status: fixed
+generator: scripts/sync-bugs-registry.sh
+references:
+    - specs/bugs/BUG-2026-07-09T033939-golden-g01-submodule-checkout.md
+---
+
+# Golden Story G-01 fails at checkout — orphan gitlink tests/fixtures/.tmp-v1.x
+
+**Bug:** BUG-2026-07-09T033939-golden-g01-submodule-checkout | **Severity:** high | **Status:** fixed | **Scope:** ci
+**Tier:** extended
+
+See `specs/bugs/BUG-2026-07-09T033939-golden-g01-submodule-checkout.md` for full investigation and fix details.

--- a/specs/bugs/registry.yaml
+++ b/specs/bugs/registry.yaml
@@ -336,3 +336,17 @@ bugs:
     scope: install
     title: "install.sh uses legacy .gemini/extensions/ directory instead of config/plugins/"
     file: bugs/BUG-2026-07-07-install-gemini-plugins.md
+  - id: BUG-2026-07-09-dead-function-build-skill-graph
+    status: open
+    severity: low
+    scope: scripts
+    title: "Dead function `skill_graph_show_help` in build-skill-graph.sh"
+    file: bugs/BUG-2026-07-09-dead-function-build-skill-graph.md
+  - id: BUG-2026-07-09T033939-golden-g01-submodule-checkout
+    status: fixed
+    severity: high
+    scope: ci
+    title: "Golden Story G-01 fails at checkout — orphan gitlink tests/fixtures/.tmp-v1.x"
+    file: bugs/BUG-2026-07-09T033939-golden-g01-submodule-checkout.md
+    risk_level: "low"
+    commit_message: "fix(ci): remove embedded git repo tests/fixtures/.tmp-v1.x causing submodule checkout failures"

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -1,12 +1,14 @@
-active_flow: null
+active_flow: fix_bug
 active_epic: e37
 active_story: null
-bug_id: null
+bug_id: BUG-2026-07-09T033939-golden-g01-submodule-checkout
 bigpowers_version: 2.76.1
-bug_cycle: null
+bug_cycle:
+  current_step: 4
+  completed_steps: [1, 2, 3]
 handoff:
-  context: fix-bug complete — removed dead function skill_graph_show_help from build-skill-graph.sh; landed via fix/dead-function-build-skill-graph (b927dca2); compliance 95/95, gates 11/11.
-  next_skill: survey-context
+  context: fix-bug yolo — orphan gitlink regression gate added; preflight green; pushing for CI verify
+  next_skill: validate-fix
   epic: e37
 epic_cycle:
   step: 8

--- a/tests/test-no-orphan-gitlinks.sh
+++ b/tests/test-no-orphan-gitlinks.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# story: BUG-2026-07-09T033939-golden-g01-submodule-checkout
+# Regression: orphan gitlinks (160000) without .gitmodules URLs break actions/checkout.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../scripts/lib/check-orphan-gitlinks.sh
+source "$REPO_ROOT/scripts/lib/check-orphan-gitlinks.sh"
+
+# Clean tree must pass.
+if ! output="$(check_orphan_gitlinks "$REPO_ROOT")"; then
+  echo "FAIL: check_orphan_gitlinks failed on clean tree"
+  exit 1
+fi
+if [[ "$output" != "no orphan gitlinks" ]]; then
+  echo "FAIL: unexpected output: $output"
+  exit 1
+fi
+
+# Synthetic orphan: gitlink path with no .gitmodules entry must fail.
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+git -C "$tmpdir" init -q
+git -C "$tmpdir" config user.email "test@example.com"
+git -C "$tmpdir" config user.name "test"
+mkdir -p "$tmpdir/sub"
+echo "nested" >"$tmpdir/sub/file.txt"
+git -C "$tmpdir/sub" init -q
+git -C "$tmpdir/sub" add file.txt
+git -C "$tmpdir/sub" commit -qm "nested"
+git -C "$tmpdir" add sub
+if ! check_orphan_gitlinks "$tmpdir" >/dev/null 2>&1; then
+  echo "PASS: synthetic orphan gitlink correctly rejected"
+  exit 0
+fi
+
+echo "FAIL: check_orphan_gitlinks should reject orphan gitlink in synthetic repo"
+exit 1


### PR DESCRIPTION
## Summary
- Adds `scripts/lib/check-orphan-gitlinks.sh` and wires it into `validate-doctrine.sh`
- Adds `tests/test-no-orphan-gitlinks.sh` regression test
- Documents BUG-2026-07-09T033939 (Golden Story G-01 checkout failure)

## Test plan
- [x] `bash tests/test-no-orphan-gitlinks.sh`
- [x] `npm run compliance`
- [x] `bash scripts/run-verification-gates.sh` (11/11)
- [ ] Golden Story G-01 workflow dispatch green on main