### PR TITLE
fix(scripts): fall back to simple_yaml when PyYAML is absent during setup

### DIFF
--- a/scripts/lib/simple_yaml.py
+++ b/scripts/lib/simple_yaml.py
@@ -7,20 +7,30 @@ def parse_simple_yaml(text: str) -> dict:
     root: dict = {}
     # Each stack entry: (indent, container, parent_dict, key_in_parent)
     stack: list = [(0, root, None, None)]
-    skip_until_indent = None  # skip block scalar continuation lines (| and >)
+    skip_until_indent = None  # indent of an active block scalar's key line
+    block: dict = {}  # active block scalar: {'lines': [...], 'style': str, 'assign': fn}
+
+    def flush_block():
+        if block:
+            block['assign'](_fold_block(block['lines'], block['style']))
+            block.clear()
+
     for i, raw in enumerate(text.splitlines()):
         stripped = raw.strip()
-        if not stripped or stripped.startswith("#"):
-            # Reset block-scalar skip on blank lines
-            continue
         indent = len(raw) - len(raw.lstrip())
-        
-        # Skip block scalar continuation (| and > in YAML)
+
+        # Inside a block scalar: capture continuation lines verbatim. Blank and
+        # '#'-prefixed lines are literal content here, not comments.
         if skip_until_indent is not None:
-            if indent > skip_until_indent:
+            if not stripped or indent > skip_until_indent:
+                if block:
+                    block['lines'].append(raw)
                 continue
-            else:
-                skip_until_indent = None
+            flush_block()
+            skip_until_indent = None
+
+        if not stripped or stripped.startswith("#"):
+            continue
         
         # Pop stack until we're at the right nesting level
         # Don't pop list containers at same indent — sibling items stay in same list
@@ -68,8 +78,11 @@ def parse_simple_yaml(text: str) -> dict:
                 v = v.strip()
                 # Detect block scalars in list items too
                 if v in ("|", ">", "|-", ">-", "|+", ">+"):
-                    item = {k: v}
+                    item = {k: None}
                     container.append(item)
+                    block.clear()
+                    block.update(lines=[], style=v,
+                                 assign=lambda s, _i=item, _k=k: _i.__setitem__(_k, s))
                     skip_until_indent = indent
                     continue
                 item = {k: _yaml_scalar(v) if v else None}
@@ -87,12 +100,18 @@ def parse_simple_yaml(text: str) -> dict:
         key = key.strip()
         val = val.strip()
         
-        # Detect block scalars (|, >, |- etc.)
+        # Detect block scalars (|, >, |- etc.) and capture their folded content.
         if val in ("|", ">", "|-", ">-", "|+", ">+"):
+            tgt = None
             if isinstance(container, list) and container:
-                container[-1][key] = val  # store the marker
+                tgt = container[-1]
             elif isinstance(container, dict):
-                container[key] = val
+                tgt = container
+            if tgt is not None:
+                tgt[key] = None
+                block.clear()
+                block.update(lines=[], style=val,
+                             assign=lambda s, _t=tgt, _k=key: _t.__setitem__(_k, s))
             skip_until_indent = indent
             continue
         
@@ -111,11 +130,43 @@ def parse_simple_yaml(text: str) -> dict:
                 stack.append((indent, nxt, container, key))
             else:
                 container[key] = _yaml_scalar(val)
+    flush_block()
     return root
+
+
+def _fold_block(raw_lines, style):
+    """Fold a YAML block scalar (| literal / > folded) to match PyYAML."""
+    # Strip the common leading indentation of the block's content lines.
+    indents = [len(l) - len(l.lstrip()) for l in raw_lines if l.strip()]
+    ci = min(indents) if indents else 0
+    lines = [l[ci:] if len(l) >= ci else l.strip() for l in raw_lines]
+    if style[0] == "|":  # literal: keep line breaks
+        text = "\n".join(lines)
+    else:  # folded: single break -> space, blank line -> newline
+        parts, prev_blank = [], True
+        for l in lines:
+            if l == "":
+                parts.append("\n")
+                prev_blank = True
+            else:
+                if parts and not prev_blank:
+                    parts.append(" ")
+                parts.append(l)
+                prev_blank = False
+        text = "".join(parts)
+    text = text.rstrip("\n")
+    # Chomping indicator: '-' strip, default clip (single trailing newline).
+    return text if style.endswith("-") else text + "\n"
 
 
 def _yaml_scalar(val: str):
     """Convert a YAML scalar string to Python type."""
+    stripped = val.strip()
+    # Double-quoted scalar: unescape YAML escapes (\" and \\) like PyYAML, and
+    # keep it a string (no bool/int coercion). Keeps the PyYAML-free fallback
+    # byte-identical to PyYAML for quoted descriptions.
+    if len(stripped) >= 2 and stripped[0] == '"' and stripped[-1] == '"':
+        return stripped[1:-1].replace('\\"', '"').replace("\\\\", "\\")
     val = val.strip('"').strip("'")
     if val in ("true", "false"):
         return val == "true"

--- a/scripts/lib/srp-engine.py
+++ b/scripts/lib/srp-engine.py
@@ -1,18 +1,29 @@
 #!/usr/bin/env python3
 # story: e48s15
+# story: BUG-2026-07-18-setup-pyyaml-missing
 import os
 import sys
 import json
 import glob
 import subprocess
-import yaml
 
-# Ensure scripts/lib is on the path so link_utils resolves regardless of cwd.
+# Ensure scripts/lib is on the path so sibling modules (link_utils, and the
+# simple_yaml fallback below) resolve regardless of cwd.
 _LIB_DIR = os.path.dirname(os.path.abspath(__file__))
 if _LIB_DIR not in sys.path:
     sys.path.insert(0, _LIB_DIR)
 
 from link_utils import LINK_RE, EXTERNAL_RE, strip_code_spans  # noqa: E402
+
+# End-user setup (bigpowers setup) may run on a python3 without PyYAML.
+# Prefer PyYAML for exact parsing; fall back to the dependency-free
+# simple_yaml.py (story e38s01) so setup never hard-crashes.
+try:
+    import yaml
+    _load_yaml = yaml.safe_load
+except ModuleNotFoundError:
+    from simple_yaml import parse_simple_yaml
+    _load_yaml = parse_simple_yaml
 
 def rewrite_links_for_pi(body, name):
     """Repoint relative links so they resolve from .pi/skills/<name>/.
@@ -114,7 +125,7 @@ def parse_skill(skill_md_path):
     skill_body = '---'.join(parts[2:])
 
     try:
-        frontmatter = yaml.safe_load(frontmatter_raw)
+        frontmatter = _load_yaml(frontmatter_raw)
     except Exception as e:
         print(f"Error parsing YAML frontmatter in {skill_md_path}: {e}", file=sys.stderr)
         sys.exit(1)
@@ -160,7 +171,7 @@ def get_active_adapters(repo_root):
         return ["cursor", "gemini", "pi"]
     try:
         with open(targets_file, 'r', encoding='utf-8') as f:
-            data = yaml.safe_load(f)
+            data = _load_yaml(f.read())
         adapters = []
         for target in data.get('targets', []):
             if target.get('skill') is not None:

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -74,7 +74,7 @@ if [[ -f "$TARGETS_FILE" ]] && command -v yq >/dev/null 2>&1; then
     [[ -n "$adapter" && "$adapter" != "null" ]] && SKILL_ADAPTERS+=("$adapter")
   done < <(yq -r '.targets[] | select(.skill != null) | .skill.adapter' "$TARGETS_FILE" | sort -u)
 else
-  echo "sync-skills: WARN — targets.yaml missing; using legacy render list" >&2
+  echo "sync-skills: WARN — yq unavailable or targets.yaml missing; using legacy render list (cursor gemini pi)" >&2
   SKILL_ADAPTERS=(cursor gemini pi)
 fi
 

--- a/scripts/test-setup-no-pyyaml.sh
+++ b/scripts/test-setup-no-pyyaml.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# test-setup-no-pyyaml.sh — recurrence guard for BUG-2026-07-18-setup-pyyaml-missing
+#
+# `bigpowers setup` must not crash when the resolved python3 lacks PyYAML.
+# Two setup-path scripts hard-depended on PyYAML: srp-engine.py (import yaml)
+# and validate-skill-yaml.py (sys.exit(2) on ImportError). Both now fall back
+# to scripts/lib/simple_yaml.py. This guard asserts:
+#   1. srp-engine.py parses a skill under a PyYAML-free interpreter.
+#   2. validate-skill-yaml.py runs (does not exit 2) under the same.
+#   3. simple_yaml's output equals PyYAML's for every skill's frontmatter
+#      (covers escaped quotes and folded/literal block scalars).
+#
+# Usage: bash scripts/test-setup-no-pyyaml.sh
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib/skill-common.sh"
+resolve_repo_root
+cd "$REPO_ROOT"
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; NC='\033[0m'
+FAILURES=0
+pass() { echo -e "${GREEN}PASS${NC} $1"; }
+fail() { echo -e "${RED}FAIL${NC} $1"; FAILURES=$((FAILURES + 1)); }
+
+# Build a throwaway PyYAML-free interpreter — a fresh venv has no PyYAML,
+# reproducing a stock macOS python3 without touching the caller's environment.
+NOYAML_DIR="$(mktemp -d)"
+trap 'rm -rf "$NOYAML_DIR"' EXIT
+if ! python3 -m venv "$NOYAML_DIR/venv" >/dev/null 2>&1; then
+  echo "test-setup-no-pyyaml: SKIP — cannot create venv"; exit 0
+fi
+NOPY="$NOYAML_DIR/venv/bin/python"
+if "$NOPY" -c "import yaml" >/dev/null 2>&1; then
+  echo "test-setup-no-pyyaml: SKIP — fresh venv unexpectedly has PyYAML"; exit 0
+fi
+
+# 1. srp-engine.py must parse a skill's frontmatter without crashing.
+if "$NOPY" scripts/lib/srp-engine.py skills/fix-bug/SKILL.md >/dev/null 2>&1; then
+  pass "srp-engine.py parses frontmatter without PyYAML"
+else
+  fail "srp-engine.py crashed without PyYAML"
+fi
+
+# 2. validate-skill-yaml.py must not bail with exit 2 (the old PyYAML-required path).
+rc=0
+"$NOPY" scripts/validate-skill-yaml.py >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 2 ]]; then
+  pass "validate-skill-yaml.py runs without PyYAML (exit $rc)"
+else
+  fail "validate-skill-yaml.py bailed with exit 2 (PyYAML required)"
+fi
+
+# 3. Fallback fidelity: simple_yaml must equal PyYAML for every skill's
+#    frontmatter. Runs under python3 (CI has PyYAML); skips if PyYAML absent.
+if python3 - <<'PY'; then
+import glob, sys
+sys.path.insert(0, "scripts/lib")
+from simple_yaml import parse_simple_yaml
+try:
+    import yaml
+except ImportError:
+    print("skip: PyYAML not available for comparison"); sys.exit(0)
+bad = []
+for p in sorted(glob.glob("skills/*/SKILL.md")):
+    fm = open(p, encoding="utf-8").read().split("---")[1]
+    a = parse_simple_yaml(fm)
+    b = yaml.safe_load(fm)
+    for k in ("name", "description", "effort", "model"):
+        if a.get(k) != b.get(k):
+            bad.append(f"{p}:{k}")
+if bad:
+    print("mismatch: " + ", ".join(bad)); sys.exit(1)
+sys.exit(0)
+PY
+  pass "simple_yaml matches PyYAML for all skill frontmatter"
+else
+  fail "simple_yaml diverged from PyYAML for some skill frontmatter"
+fi
+
+if [[ "$FAILURES" -gt 0 ]]; then
+  echo "test-setup-no-pyyaml: $FAILURES failure(s)" >&2
+  exit 1
+fi
+echo "test-setup-no-pyyaml: PASS"

--- a/scripts/validate-skill-yaml.py
+++ b/scripts/validate-skill-yaml.py
@@ -4,11 +4,18 @@ import glob
 import sys
 import os
 
+# Prefer PyYAML; fall back to the dependency-free scripts/lib/simple_yaml.py
+# (story e38s01) so `bigpowers setup` works on a python3 without PyYAML.
+# story: BUG-2026-07-18-setup-pyyaml-missing
+_LIB = os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib")
 try:
     import yaml
-except ImportError:
-    print("ERROR: PyYAML required — pip install pyyaml")
-    sys.exit(2)
+    _load_yaml = yaml.safe_load
+except ModuleNotFoundError:
+    if _LIB not in sys.path:
+        sys.path.insert(0, _LIB)
+    from simple_yaml import parse_simple_yaml
+    _load_yaml = parse_simple_yaml
 
 SKILLS_DIR = ".pi/skills"
 files = sorted(glob.glob(f"{SKILLS_DIR}/*/SKILL.md"))
@@ -30,8 +37,8 @@ for path in files:
     frontmatter = parts[1]
 
     try:
-        data = yaml.safe_load(frontmatter)
-    except yaml.YAMLError as e:
+        data = _load_yaml(frontmatter)
+    except Exception as e:
         parse_failures.append((skill_name, str(e).split("\n")[0]))
         continue
 

--- a/specs/bugs/BUG-2026-07-18-setup-pyyaml-missing.md
+++ b/specs/bugs/BUG-2026-07-18-setup-pyyaml-missing.md
@@ -1,0 +1,109 @@
+---
+bug_id: BUG-2026-07-18-setup-pyyaml-missing
+status: fixed
+severity: high
+scope: scripts (setup path)
+title: "bigpowers setup crashes when python3 lacks PyYAML (Issue #77)"
+---
+
+# BUG-2026-07-18-setup-pyyaml-missing
+
+/ GitHub: https://github.com/danielvm-git/bigpowers/issues/77
+
+## Problem
+
+**Actual behavior:** On a fresh macOS (reported: 15.7.2) with no `.venv` and a
+system `python3` that lacks PyYAML, `pnpx bigpowers setup` aborts:
+
+```
+python-env: WARN — python3 lacks PyYAML
+sync-skills: WARN — targets.yaml missing; using legacy render list
+Traceback (most recent call last):
+  File ".../scripts/lib/srp-engine.py", line 8, in <module>
+    import yaml
+ModuleNotFoundError: No module named 'yaml'
+❌ Failed: bash scripts/sync-skills.sh
+```
+
+**Expected behavior:** `bigpowers setup` completes without PyYAML installed. The
+repo already ships a dependency-free parser (`scripts/lib/simple_yaml.py`,
+e38s01); the setup path must use it as a fallback rather than hard-crash.
+
+**How to reproduce:**
+1. `python3 -m venv /tmp/noyaml` (a fresh venv has no PyYAML).
+2. `/tmp/noyaml/bin/python scripts/lib/srp-engine.py --all` → `ModuleNotFoundError`, exit 1.
+3. `/tmp/noyaml/bin/python scripts/validate-skill-yaml.py` → "ERROR: PyYAML required", exit 2.
+
+**Security impact:** NONE — install-time crash only; no exploit path.
+
+## Root Cause Analysis
+
+### Reproduce
+
+Under a PyYAML-free interpreter, `srp-engine.py` exits 1 (traceback) and
+`validate-skill-yaml.py` exits 2 (`ImportError` → `sys.exit(2)`). Confirmed with
+a throwaway venv.
+
+### Isolate
+
+`bin/bigpowers.js:36` runs `bash scripts/sync-skills.sh`, which sources
+`scripts/lib/python-env.sh`. `python-env.sh` deliberately **warns and continues**
+when the resolved interpreter lacks PyYAML (this is by design, per
+BUG-2026-07-04-python-interpreter-fragility — it only pins *which* python3 runs).
+Two setup-path scripts then hard-depend on PyYAML:
+
+1. **`scripts/lib/srp-engine.py`** — top-level `import yaml`; invoked at
+   `sync-skills.sh:85`. Crashes first (the reported traceback).
+2. **`scripts/validate-skill-yaml.py`** — `except ImportError: sys.exit(2)`;
+   invoked via `sync-skills.sh:99` → `sync_post_run` → `sync_post_regression_guards`
+   (`scripts/lib/sync-post.sh:98,132`), whose `if ! $PYTHON "$validate_script"`
+   turns exit-2 into `sync-skills: FAIL … exit 1`. A second landmine, reached only
+   once #1 is fixed — so both must be fixed for setup to complete.
+
+`scripts/install.sh` (the second setup step) has no Python/YAML dependency.
+
+Two fallback fidelity gaps surfaced once `simple_yaml` was wired in: it did not
+un-escape YAML double-quoted escapes (`\"`) and dropped folded/literal block
+scalars (`>` / `|`) entirely — producing over-escaped or empty descriptions for
+`align-grid` and `security-review`.
+
+### Hypothesize
+
+Give the two consumers the `simple_yaml` fallback the rest of the repo already
+uses (`trace-matrix.py`, `generate-allure-report.sh`), and close the two parser
+gaps so the PyYAML-free path is byte-identical to PyYAML. `pip install` was
+rejected: PEP 668 externally-managed-environment errors are the exact fragility
+this codebase moved away from.
+
+### Verify
+
+Under a PyYAML-free venv: both scripts exit 0, and a full `sync-skills.sh` run
+completes with only the (expected, deliberate) PyYAML WARN — no traceback, no
+FAIL. Regenerated `.cursor/.gemini/.pi` artifacts are **byte-identical** to the
+committed PyYAML-generated ones, proving the fallback is faithful.
+
+## Fix
+
+- `scripts/lib/srp-engine.py` — `import yaml` → try/except shim binding
+  `_load_yaml` to `yaml.safe_load` or `simple_yaml.parse_simple_yaml`; both call
+  sites use `_load_yaml`.
+- `scripts/validate-skill-yaml.py` — same shim (adds `scripts/lib` to
+  `sys.path`); `except yaml.YAMLError` → `except Exception`.
+- `scripts/lib/simple_yaml.py` — `_yaml_scalar` un-escapes double-quoted scalars;
+  new `_fold_block` folds `>`/`|` block scalars to match PyYAML; the parse loop
+  captures block-scalar content instead of skipping it.
+- `scripts/sync-skills.sh` — corrected the misleading `targets.yaml missing`
+  warning (it also fires when `yq` is absent, which is the common case).
+
+**Hardening added:** `scripts/test-setup-no-pyyaml.sh` — recurrence guard.
+Asserts srp-engine.py and validate-skill-yaml.py run under a PyYAML-free venv and
+that `simple_yaml` output equals PyYAML for every skill's frontmatter.
+
+## Verify steps
+
+→ verify: `bash scripts/test-setup-no-pyyaml.sh`
+
+**Evidence:**
+- `bash scripts/test-setup-no-pyyaml.sh` → 3/3 PASS.
+- `PATH=/tmp/noyaml/bin:$PATH bash scripts/sync-skills.sh` → exit 0, no traceback;
+  `git status` on `.cursor/.gemini/.pi` → clean (fallback ≡ PyYAML).


### PR DESCRIPTION
## Summary
<!-- bigpowers-provenance: agent-generated -->

`bigpowers setup` crashed on a stock macOS `python3` without PyYAML (Issue #77). `python-env.sh` deliberately warns-and-continues without PyYAML, but two setup-path scripts hard-depended on it:

- `scripts/lib/srp-engine.py` — `import yaml` at module load → `ModuleNotFoundError` (the reported traceback).
- `scripts/validate-skill-yaml.py` — `except ImportError: sys.exit(2)`, which `sync-post.sh` turns into `sync-skills: FAIL`. A second landmine reached only once the first is fixed.

### Fix
- Both scripts now fall back to the repo's dependency-free `scripts/lib/simple_yaml.py` (story e38s01) via a `_load_yaml` shim — chosen over `pip install` (PEP 668 externally-managed-environment fragility).
- `simple_yaml.py` gains double-quoted-escape unescaping and folded/literal block-scalar (`>` / `|`) support, so the PyYAML-free path is **byte-identical** to PyYAML across all skill frontmatter.
- `scripts/sync-skills.sh` — corrected the misleading `targets.yaml missing` warning (it also fires when `yq` is absent).
- New `scripts/test-setup-no-pyyaml.sh` recurrence guard; bug SoT in `specs/bugs/`.

## Test plan
- [x] Reproduced the crash under a fresh no-PyYAML venv (`srp-engine` exit 1, `validate` exit 2); both now exit 0.
- [x] Full `sync-skills.sh` under a no-PyYAML interpreter → exit 0, **zero drift** in generated `.cursor/.gemini/.pi` artifacts.
- [x] `scripts/test-setup-no-pyyaml.sh` → 3/3 PASS (crash-free + fallback ≡ PyYAML for all skills).
- [x] Preflight: `npm run compliance` PASS · verification gates 11/11 · `trace-stories --strict` exit 0.
- [x] Verified zero blast radius on `trace-matrix` output (base vs modified `simple_yaml` identical).

Closes #77