### PR TITLE
feat(e61): Hermes Agent integration — adapter + install hub

### DIFF
--- a/bin/setup.js
+++ b/bin/setup.js
@@ -55,7 +55,7 @@ const TOOLS = [
   { id: 'windsurf', name: 'Windsurf', globalPath: '~/.codeium/windsurf', localPath: '.codeium/windsurf' },
 ];
 const ALL_ID = '__all__';
-const SUPPORTED_IDS = new Set(['claude', 'gemini', 'pi', 'cursor', 'codex']);
+const SUPPORTED_IDS = new Set(['claude', 'gemini', 'pi', 'hermes', 'cursor', 'codex']);
 const UNSUPPORTED_HINT = '(TODO)';
 
 // ── clack helpers (lazy ESM import from CJS) ─────────────────────────────────

--- a/scripts/adapters/hermes.sh
+++ b/scripts/adapters/hermes.sh
@@ -1,10 +1,57 @@
 #!/usr/bin/env bash
 # story: e37s10
-render_skill() {
-  local out="${HERMES_SKILLS:-.hermes/skills}"
-  mkdir -p "$out/${IR_NAME:-_stub}" 2>/dev/null || true
+# story: e61s01
+# Hermes Agent skill adapter — renders .hermes/skills/<name>/SKILL.md from SkillIR.
+
+hermes_sanitize_name() {
+  local name="$1"
+  if [[ -z "$name" || "$name" == "null" || "$name" == *"/"* || "$name" == *".."* ]]; then
+    echo "hermes: invalid skill name: ${name:-<empty>}" >&2
+    return 1
+  fi
+  printf '%s' "$name"
 }
+
+render_skill() {
+  if declare -f render_hermes_skill >/dev/null 2>&1; then
+    render_hermes_skill
+    return
+  fi
+
+  local safe_name
+  safe_name=$(hermes_sanitize_name "${IR_NAME:-}") || return 1
+  local out="${HERMES_SKILLS:-.hermes/skills}"
+  mkdir -p "$out/$safe_name"
+
+  if [[ -n "${SKILL_MD_PATH:-}" && -f "$SKILL_MD_PATH" ]]; then
+    cp "$SKILL_MD_PATH" "$out/$safe_name/SKILL.md"
+    return 0
+  fi
+
+  {
+    echo "---"
+    echo "name: $safe_name"
+    [[ -n "${IR_MODEL:-}" && "$IR_MODEL" != "null" ]] && echo "model: $IR_MODEL"
+    echo "description: \"${IR_DESC_ESCAPED:-}\""
+    echo "---"
+    echo ""
+    echo "${IR_BODY:-}"
+  } > "$out/$safe_name/SKILL.md"
+}
+
 wire_context() {
   source "$(dirname "${BASH_SOURCE[0]}")/../lib/context-wire.sh"
   wire_context_mode config-bridge ".hermes/config.yaml" "instructions" "AGENTS.md"
 }
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]] && [[ ! -t 0 ]]; then
+  JSON_INPUT=$(cat)
+  if [[ -n "$JSON_INPUT" ]]; then
+    IR_NAME=$(echo "$JSON_INPUT" | jq -r '.name')
+    IR_MODEL=$(echo "$JSON_INPUT" | jq -r '.model')
+    IR_DESCRIPTION=$(echo "$JSON_INPUT" | jq -r '.description')
+    IR_BODY=$(echo "$JSON_INPUT" | jq -r '.body')
+    IR_DESC_ESCAPED=$(echo "$IR_DESCRIPTION" | sed 's/\\/\\\\/g; s/\"/\\"/g')
+    render_skill
+  fi
+fi

--- a/scripts/hooks/hermes/gateway/session-log/HOOK.yaml
+++ b/scripts/hooks/hermes/gateway/session-log/HOOK.yaml
@@ -1,0 +1,5 @@
+name: session-log
+description: Observe agent lifecycle events (bigpowers template — copy to ~/.hermes/hooks/)
+events:
+  - agent:start
+  - agent:end

--- a/scripts/hooks/hermes/gateway/session-log/handler.py
+++ b/scripts/hooks/hermes/gateway/session-log/handler.py
@@ -1,0 +1,7 @@
+# story: e61s01
+# Gateway hook template — copy directory to ~/.hermes/hooks/session-log/
+# Docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/hooks
+
+async def handle(event_type: str, context: dict) -> None:
+    """Observer-only; errors are caught by Hermes and never crash the agent."""
+    _ = event_type, context

--- a/scripts/hooks/hermes/plugin/guard-git-plugin.py
+++ b/scripts/hooks/hermes/plugin/guard-git-plugin.py
@@ -1,0 +1,14 @@
+# story: e61s01
+# Plugin hook template — install as a Hermes plugin (CLI + gateway).
+# Docs: https://hermes-agent.nousresearch.com/docs/developer-guide/plugins
+
+DANGEROUS = {"terminal", "write_file", "patch"}
+
+
+def warn_dangerous(tool_name, **kwargs):
+    if tool_name in DANGEROUS:
+        print(f"⚠ Executing potentially sensitive tool: {tool_name}")
+
+
+def register(ctx):
+    ctx.register_hook("pre_tool_call", warn_dangerous)

--- a/scripts/hooks/hermes/shell/block-dangerous-terminal.sh
+++ b/scripts/hooks/hermes/shell/block-dangerous-terminal.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# story: e61s01
+# Hermes shell hook template — blocks dangerous terminal commands on pre_tool_call.
+# Reads JSON event on stdin; emits {"decision":"block","reason":"..."} to block.
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // .tool_input.cmd // empty')
+
+if [[ "$TOOL" != "terminal" || -z "$CMD" ]]; then
+  exit 0
+fi
+
+case "$CMD" in
+  *'git push --force'*|*'git push -f '*|*'reset --hard'*|*'git clean -f'*|*'rm -rf /'*)
+    jq -nc --arg reason "BLOCKED: dangerous command pattern in terminal tool" \
+      '{decision: "block", reason: $reason}'
+    exit 0
+    ;;
+esac
+
+exit 0

--- a/scripts/hooks/hermes/shell/hooks-config.example.yaml
+++ b/scripts/hooks/hermes/shell/hooks-config.example.yaml
@@ -1,0 +1,7 @@
+# story: e61s01
+# Example hooks: block for ~/.hermes/config.yaml — copy paths to your install location.
+hooks:
+  pre_tool_call:
+    - matcher: "terminal"
+      command: "scripts/hooks/hermes/shell/block-dangerous-terminal.sh"
+      timeout: 5

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,6 +6,7 @@
 #   Claude Code  → ~/.claude/skills/<name>/ (one symlink per skill)
 #   Gemini CLI   → ~/.gemini/config/plugins/bigpowers/ (one dir symlink)
 #   pi           → ~/.pi/agent/skills/<name>/ (one symlink per skill)
+#   Hermes Agent → ~/.hermes/skills/<name>/ (symlink rendered .hermes/skills/)
 #   Cursor       → ~/.cursor/rules/ (one dir symlink; per-project note printed)
 #
 # Usage:
@@ -231,6 +232,52 @@ uninstall_pi() {
   fi
 }
 
+# ── Hermes Agent (e61s02) ─────────────────────────────────────────────────────
+
+HERMES_CONFIG_DIR="$HOME/.hermes"
+HERMES_SKILLS_DIR="$HERMES_CONFIG_DIR/skills"
+HERMES_RENDERED="$REPO_ROOT/.hermes/skills"
+HERMES_CONFIG="$HERMES_CONFIG_DIR/config.yaml"
+HERMES_HOOKS_DIR="$HERMES_CONFIG_DIR/hooks"
+
+install_hermes() {
+  echo ""
+  echo "Hermes Agent → $HERMES_SKILLS_DIR/"
+  if [[ ! -d "$HERMES_RENDERED" ]]; then
+    echo "  WARNING: $HERMES_RENDERED not found — run sync-skills.sh first"
+    return
+  fi
+  local count=0
+  for skill_dir in "$HERMES_RENDERED"/*/; do
+    [[ -f "${skill_dir}SKILL.md" ]] || continue
+    local name; name="$(basename "$skill_dir")"
+    link "$skill_dir" "$HERMES_SKILLS_DIR/$name"
+    count=$((count + 1))
+  done
+  echo "  $count skills installed"
+
+  echo "Hermes Agent → context bridge $HERMES_CONFIG"
+  source "$REPO_ROOT/scripts/lib/context-wire.sh"
+  wire_context_mode config-bridge "$HERMES_CONFIG" "instructions" "AGENTS.md"
+
+  if [[ -d "$REPO_ROOT/scripts/hooks/hermes/gateway/session-log" ]]; then
+    echo "Hermes Agent hook templates → $HERMES_HOOKS_DIR/ (copy paths into config to enable)"
+    link "$REPO_ROOT/scripts/hooks/hermes/gateway/session-log" "$HERMES_HOOKS_DIR/session-log"
+  fi
+}
+
+uninstall_hermes() {
+  echo ""
+  echo "Hermes Agent → removing management from $HERMES_CONFIG_DIR/"
+  if [[ -d "$HERMES_SKILLS_DIR" ]]; then
+    for dst in "$HERMES_SKILLS_DIR"/*/; do
+      [[ -L "${dst%/}" ]] || continue
+      unlink_if_managed "${dst%/}" "$REPO_ROOT/"
+    done
+  fi
+  unlink_if_managed "$HERMES_HOOKS_DIR/session-log" "$REPO_ROOT/"
+}
+
 # ── Codex CLI (e37s15) ───────────────────────────────────────────────────────
 
 CODEX_DIR="$HOME/.codex"
@@ -260,6 +307,7 @@ if $UNINSTALL; then
   uninstall_claude
   uninstall_gemini
   uninstall_pi
+  uninstall_hermes
   uninstall_cursor
   uninstall_codex
   echo ""
@@ -268,6 +316,7 @@ else
   install_claude
   install_gemini
   install_pi
+  install_hermes
   install_cursor
   install_codex
   echo ""

--- a/scripts/lib/install-helpers.js
+++ b/scripts/lib/install-helpers.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 // story: e60s01
+// story: e61s02
 // install-helpers.js — symlink helpers for bigpowers setup
 
 const fs = require('fs');
@@ -36,6 +37,25 @@ function linkFile(src, dst) {
     if (stat.isSymbolicLink()) fs.unlinkSync(dst);
   } catch {}
   fs.symlinkSync(src, dst);
+}
+
+function linkRenderedSkills(renderedDir, targetDir) {
+  if (!fs.existsSync(renderedDir)) return;
+  fs.mkdirSync(targetDir, { recursive: true });
+  for (const entry of fs.readdirSync(renderedDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (!fs.existsSync(path.join(renderedDir, entry.name, 'SKILL.md'))) continue;
+    linkDir(path.join(renderedDir, entry.name), path.join(targetDir, entry.name));
+  }
+}
+
+function bridgeHermesConfig(configPath) {
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  if (fs.existsSync(configPath)) {
+    const existing = fs.readFileSync(configPath, 'utf8');
+    if (/^instructions:/m.test(existing)) return;
+  }
+  fs.writeFileSync(configPath, 'instructions: AGENTS.md\n');
 }
 
 function linkHook(src, dst) {
@@ -85,6 +105,19 @@ function installGlobal(tool, repoRoot) {
       linkSkills(skillsDir, targetDir);
       break;
     }
+    case 'hermes': {
+      const renderedDir = path.join(repoRoot, '.hermes', 'skills');
+      const targetDir = path.join(homeDir, '.hermes', 'skills');
+      linkRenderedSkills(renderedDir, targetDir);
+      bridgeHermesConfig(path.join(homeDir, '.hermes', 'config.yaml'));
+      const hookSrc = path.join(repoRoot, 'scripts', 'hooks', 'hermes', 'gateway', 'session-log');
+      const hookDst = path.join(homeDir, '.hermes', 'hooks', 'session-log');
+      if (fs.existsSync(hookSrc)) {
+        fs.mkdirSync(path.dirname(hookDst), { recursive: true });
+        linkDir(hookSrc, hookDst);
+      }
+      break;
+    }
     case 'cursor': {
       const rulesSrc = path.join(repoRoot, '.cursor', 'rules');
       const rulesDst = path.join(homeDir, '.cursor', 'rules');
@@ -124,6 +157,13 @@ function installLocal(tool, repoRoot) {
       const targetDir = path.join(cwd, '.pi', 'agent', 'skills');
       fs.mkdirSync(targetDir, { recursive: true });
       linkSkills(skillsDir, targetDir);
+      break;
+    }
+    case 'hermes': {
+      const renderedDir = path.join(repoRoot, '.hermes', 'skills');
+      const targetDir = path.join(cwd, '.hermes', 'skills');
+      linkRenderedSkills(renderedDir, targetDir);
+      bridgeHermesConfig(path.join(cwd, '.hermes', 'config.yaml'));
       break;
     }
     case 'cursor': {
@@ -179,6 +219,20 @@ function uninstallTool(toolId, repoRoot) {
           }
         }
       }
+      break;
+    }
+    case 'hermes': {
+      const skillsDir = path.join(homeDir, '.hermes', 'skills');
+      if (fs.existsSync(skillsDir)) {
+        for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+          if (!entry.isSymbolicLink()) continue;
+          const target = fs.readlinkSync(path.join(skillsDir, entry.name));
+          if (target.includes('bigpowers') || target.includes('.hermes/skills')) {
+            removeSymlink(path.join(skillsDir, entry.name));
+          }
+        }
+      }
+      removeSymlink(path.join(homeDir, '.hermes', 'hooks', 'session-log'));
       break;
     }
     case 'cursor':

--- a/scripts/test-hermes-adapter.sh
+++ b/scripts/test-hermes-adapter.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# story: e61s01
+# Regression tests for Hermes adapter render + hook templates.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== test-hermes-adapter.sh ==="
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Task 1+2: stdin SkillIR render
+if echo '{"name":"test-skill","description":"test desc","body":"test body"}' \
+  | HERMES_SKILLS="$TMP/skills" bash "$REPO_ROOT/scripts/adapters/hermes.sh" \
+  && [[ -f "$TMP/skills/test-skill/SKILL.md" ]] \
+  && grep -q 'name: test-skill' "$TMP/skills/test-skill/SKILL.md" \
+  && grep -q 'test body' "$TMP/skills/test-skill/SKILL.md"; then
+  pass "render_skill emits SKILL.md from stdin SkillIR"
+else
+  fail "render_skill emits SKILL.md from stdin SkillIR"
+fi
+
+# IR_NAME sanitization rejects path traversal
+if ! echo '{"name":"../escape","description":"d","body":"b"}' \
+  | HERMES_SKILLS="$TMP/bad" bash "$REPO_ROOT/scripts/adapters/hermes.sh" 2>/dev/null; then
+  pass "rejects path traversal in skill name"
+else
+  fail "rejects path traversal in skill name"
+fi
+
+# Gateway template
+if [[ -f "$REPO_ROOT/scripts/hooks/hermes/gateway/session-log/HOOK.yaml" ]] \
+  && [[ -f "$REPO_ROOT/scripts/hooks/hermes/gateway/session-log/handler.py" ]] \
+  && grep -q 'agent:start' "$REPO_ROOT/scripts/hooks/hermes/gateway/session-log/HOOK.yaml" \
+  && grep -q 'async def handle' "$REPO_ROOT/scripts/hooks/hermes/gateway/session-log/handler.py"; then
+  pass "gateway hook template present"
+else
+  fail "gateway hook template present"
+fi
+
+# Shell template
+if [[ -f "$REPO_ROOT/scripts/hooks/hermes/shell/block-dangerous-terminal.sh" ]] \
+  && [[ -f "$REPO_ROOT/scripts/hooks/hermes/shell/hooks-config.example.yaml" ]] \
+  && grep -q 'pre_tool_call' "$REPO_ROOT/scripts/hooks/hermes/shell/hooks-config.example.yaml"; then
+  pass "shell hook template present"
+else
+  fail "shell hook template present"
+fi
+
+# Plugin template
+if [[ -f "$REPO_ROOT/scripts/hooks/hermes/plugin/guard-git-plugin.py" ]] \
+  && grep -q 'register_hook' "$REPO_ROOT/scripts/hooks/hermes/plugin/guard-git-plugin.py"; then
+  pass "plugin hook template present"
+else
+  fail "plugin hook template present"
+fi
+
+# Shell hook block decision shape
+BLOCK_OUT=$(echo '{"tool_name":"terminal","tool_input":{"command":"git push --force origin main"}}' \
+  | bash "$REPO_ROOT/scripts/hooks/hermes/shell/block-dangerous-terminal.sh")
+if echo "$BLOCK_OUT" | grep -q 'block'; then
+  pass "shell hook blocks dangerous terminal command"
+else
+  fail "shell hook blocks dangerous terminal command"
+fi
+
+# test-adapters smoke (exit code may be 1 due to ta_cleanup trap when TA_TMPDIR unset — pre-existing e37)
+ADAPTER_OUT=$(bash "$REPO_ROOT/scripts/test-adapters.sh" hermes 2>&1 || true)
+if echo "$ADAPTER_OUT" | grep -q '0 failed' && echo "$ADAPTER_OUT" | grep -q 'PASS hermes: idempotent wire_context'; then
+  pass "test-adapters.sh hermes"
+else
+  fail "test-adapters.sh hermes"
+  echo "$ADAPTER_OUT"
+fi
+
+echo "test-hermes-adapter: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/scripts/test-hermes-hub.sh
+++ b/scripts/test-hermes-hub.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# story: e61s02
+# Regression tests for Hermes install hub wiring (Wave B).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+echo "=== test-hermes-hub.sh ==="
+
+INSTALL_SH="$REPO_ROOT/scripts/install.sh"
+HELPERS_JS="$REPO_ROOT/scripts/lib/install-helpers.js"
+SETUP_JS="$REPO_ROOT/bin/setup.js"
+TARGETS_YAML="$REPO_ROOT/scripts/targets.yaml"
+
+grep -q 'install_hermes()' "$INSTALL_SH" && pass 'install.sh: install_hermes()' || fail 'install.sh: missing install_hermes()'
+grep -q 'uninstall_hermes()' "$INSTALL_SH" && pass 'install.sh: uninstall_hermes()' || fail 'install.sh: missing uninstall_hermes()'
+grep -q 'HERMES_SKILLS_DIR=' "$INSTALL_SH" && pass 'install.sh: HERMES_SKILLS_DIR' || fail 'install.sh: missing HERMES_SKILLS_DIR'
+grep -q 'install_hermes' "$INSTALL_SH" && grep -q 'uninstall_hermes' "$INSTALL_SH" && pass 'install.sh: dispatch wired' || fail 'install.sh: dispatch missing hermes'
+
+DRY_OUT="$(bash "$INSTALL_SH" --dry-run 2>&1)"
+echo "$DRY_OUT" | grep -q 'Hermes Agent →' && pass 'dry-run: Hermes Agent section' || fail 'dry-run: missing Hermes Agent section'
+DRY_UNINSTALL="$(bash "$INSTALL_SH" --dry-run --uninstall 2>&1)"
+echo "$DRY_UNINSTALL" | grep -q 'Hermes Agent →' && pass 'dry-run uninstall: Hermes Agent section' || fail 'dry-run uninstall: missing Hermes Agent section'
+
+grep -q "case 'hermes'" "$HELPERS_JS" && pass 'install-helpers: hermes global case' || fail 'install-helpers: missing hermes global case'
+grep -q "case 'hermes'" "$HELPERS_JS" && pass 'install-helpers: hermes cases present' || fail 'install-helpers: missing hermes cases'
+
+SETUP_SRC="$(cat "$SETUP_JS")"
+echo "$SETUP_SRC" | grep -q "SUPPORTED_IDS = new Set" && pass 'setup.js: SUPPORTED_IDS set' || fail 'setup.js: missing SUPPORTED_IDS'
+echo "$SETUP_SRC" | grep -q "'hermes'" "$SETUP_JS" && pass 'setup.js: hermes in TOOLS' || fail 'setup.js: hermes missing from TOOLS'
+echo "$SETUP_SRC" | grep -q "'hermes'" && echo "$SETUP_SRC" | grep -q "SUPPORTED_IDS" \
+  && grep -q "'hermes'" <<< "$(sed -n "/SUPPORTED_IDS = new Set/,/);/p" "$SETUP_JS")" \
+  && pass 'setup.js: hermes in SUPPORTED_IDS' || fail 'setup.js: hermes not in SUPPORTED_IDS'
+
+grep -q 'id: hermes' "$TARGETS_YAML" && pass 'targets.yaml: hermes row' || fail 'targets.yaml: missing hermes row'
+grep -q 'adapter: hermes' "$TARGETS_YAML" && pass 'targets.yaml: hermes adapter' || fail 'targets.yaml: missing hermes adapter'
+grep -q 'bridge_key: instructions' "$TARGETS_YAML" && pass 'targets.yaml: instructions bridge_key' || fail 'targets.yaml: missing bridge_key'
+
+grep -q 'install_hermes()' "$REPO_ROOT/scripts/verify-install.sh" && pass 'verify-install: install_hermes assertion' || fail 'verify-install: missing install_hermes assertion'
+
+bash -n "$INSTALL_SH" && pass 'bash -n install.sh' || fail 'bash -n install.sh'
+node --check "$HELPERS_JS" && pass 'node --check install-helpers.js' || fail 'node --check install-helpers.js'
+node --check "$SETUP_JS" && pass 'node --check setup.js' || fail 'node --check setup.js'
+
+echo "test-hermes-hub: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -70,6 +70,7 @@ echo "$DRY_OUT" | grep -qi 'opencode' && ta_fail "install references opencode" |
 echo "$DRY_OUT" | grep -q 'Claude Code →' && ta_pass "install includes Claude Code" || ta_fail "install missing Claude Code"
 echo "$DRY_OUT" | grep -q 'Gemini CLI →' && ta_pass "install includes Gemini CLI" || ta_fail "install missing Gemini CLI"
 echo "$DRY_OUT" | grep -q 'Cursor →' && ta_pass "install includes Cursor" || ta_fail "install missing Cursor"
+echo "$DRY_OUT" | grep -q 'Hermes Agent →' && ta_pass "install includes Hermes Agent" || ta_fail "install missing Hermes Agent"
 
 for tool in "Claude Code" "pi"; do
   section=$(echo "$DRY_OUT" | sed -n "/${tool} →/,/^$/p")
@@ -128,6 +129,11 @@ echo "=== install.sh source ==="
 grep -q 'install_pi()' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: install_pi()" || ta_fail "source: missing install_pi()"
 grep -q 'uninstall_pi()' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: uninstall_pi()" || ta_fail "source: missing uninstall_pi()"
 grep -q 'PI_SKILLS_DIR="$PI_CONFIG_DIR/agent/skills"' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: targets ~/.pi/agent/skills/" || ta_fail "source: wrong pi target"
+grep -q 'install_hermes()' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: install_hermes()" || ta_fail "source: missing install_hermes()"
+grep -q 'uninstall_hermes()' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: uninstall_hermes()" || ta_fail "source: missing uninstall_hermes()"
+grep -q 'HERMES_SKILLS_DIR=' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: targets ~/.hermes/skills/" || ta_fail "source: wrong hermes target"
+grep -q "'hermes'" "$REPO_ROOT/bin/setup.js" && grep -q 'SUPPORTED_IDS' "$REPO_ROOT/bin/setup.js" && ta_pass "setup.js: hermes supported" || ta_fail "setup.js: hermes not in SUPPORTED_IDS"
+grep -q "case 'hermes'" "$REPO_ROOT/scripts/lib/install-helpers.js" && ta_pass "install-helpers: hermes case" || ta_fail "install-helpers: missing hermes case"
 ! grep -q 'install_opencode\|print_opencode_instructions' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: no opencode functions" || ta_fail "source: opencode functions remain"
 
 echo ""

--- a/specs/IMPACT-e61-e61s01.md
+++ b/specs/IMPACT-e61-e61s01.md
@@ -1,0 +1,30 @@
+# Impact Assessment — e61s01 (lightweight)
+
+**Date:** 2026-07-24
+**Risk score:** 3/10 (LOW)
+**Scope:** Adapter-only Wave A — no hub file changes.
+
+## Module purpose
+
+`scripts/adapters/hermes.sh` renders bigpowers skills into Hermes Agent's skills directory and bridges AGENTS.md into `.hermes/config.yaml`.
+
+## Callers
+
+- `scripts/lib/srp-engine.py` / `scripts/sync-skills.sh` (via targets.yaml `skill.adapter: hermes`) — unchanged in Wave A
+- `scripts/test-adapters.sh hermes` — smoke test
+
+## Contracts
+
+- `render_skill` + `wire_context` adapter hooks (e37)
+- Output: `.hermes/skills/<name>/SKILL.md` with YAML frontmatter
+- Hook templates are inert until Wave B install copies them
+
+## Blast radius
+
+| Dependent | Impact |
+|-----------|--------|
+| sync-skills dispatch | Improved — stub now emits real SKILL.md |
+| install.sh / setup.js | None (forbidden Wave A) |
+| Other adapters | None — isolated script |
+
+**Verdict:** Proceed without grill-me session.

--- a/specs/epics/e61-integration-hermes/e61s01-hermes-adapter-hooks.md
+++ b/specs/epics/e61-integration-hermes/e61s01-hermes-adapter-hooks.md
@@ -1,0 +1,29 @@
+# e61s01: Hermes adapter + hook templates (Wave A)
+
+<!-- story: e61s01 -->
+
+Expand the e37s10 Hermes adapter stub to render SkillIR into `.hermes/skills/<name>/SKILL.md` (matching pi/cursor adapters) and add read-only hook templates for Hermes' three hook systems. Hub install wiring is deferred to Wave B.
+
+## Requirements
+
+### ADDED
+
+- `render_skill` in `scripts/adapters/hermes.sh` MUST emit a valid Hermes `SKILL.md` from SkillIR JSON on stdin (name, optional model, description, body frontmatter).
+- `scripts/hooks/hermes/gateway/` MUST ship a gateway hook template (`HOOK.yaml` + `handler.py`) per [Hermes gateway hooks](https://hermes-agent.nousresearch.com/docs/user-guide/features/hooks).
+- `scripts/hooks/hermes/shell/` MUST ship a shell hook script plus an example `hooks:` config snippet for `pre_tool_call` blocking.
+- `scripts/hooks/hermes/plugin/` MUST ship a minimal Python plugin stub using `ctx.register_hook()`.
+- `scripts/test-hermes-adapter.sh` MUST regression-test stdin render and template presence.
+
+## Out of scope (Wave B)
+
+- `scripts/install.sh`, `bin/setup.js`, `scripts/lib/install-helpers.js` hub wiring
+- `scripts/targets.yaml` or `scripts/verify-install.sh` changes
+- Auto-installing hooks into `~/.hermes/` on `bigpowers setup`
+
+## Acceptance
+
+```bash
+bash scripts/test-hermes-adapter.sh &&
+bash scripts/test-adapters.sh hermes &&
+echo OK
+```

--- a/specs/epics/e61-integration-hermes/e61s01-tasks.yaml
+++ b/specs/epics/e61-integration-hermes/e61s01-tasks.yaml
@@ -1,0 +1,142 @@
+story_id: e61s01
+title: "Hermes adapter + hook templates (Wave A)"
+status: passing
+bcps: 3
+risk: P2
+depends_on:
+  - e37s10
+spec: e61s01-hermes-adapter-hooks.md
+tasks:
+  - id: 1
+    description: >-
+      Expand scripts/adapters/hermes.sh render_skill to write
+      .hermes/skills/<name>/SKILL.md from SkillIR globals (name, model,
+      description, body) matching pi/cursor frontmatter. Tag # story: e61s01.
+    verify: >-
+      tmp=$(mktemp -d); echo '{"name":"test-skill","description":"test desc","body":"test body"}'
+      | HERMES_SKILLS="$tmp/skills" bash scripts/adapters/hermes.sh &&
+      grep -q 'name: test-skill' "$tmp/skills/test-skill/SKILL.md" &&
+      grep -q 'test body' "$tmp/skills/test-skill/SKILL.md" && echo OK
+    risk: P2
+    security: low
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - "Integration"
+        - "Hermes"
+        - "Wave A"
+
+  - id: 2
+    description: >-
+      Add SkillIR stdin dispatch block to hermes.sh (jq parse on non-tty stdin),
+      consistent with cursor.sh and pi.sh.
+    verify: >-
+      tmp=$(mktemp -d);
+      echo '{"name":"stdin-skill","description":"d","body":"b"}'
+      | HERMES_SKILLS="$tmp/skills" bash scripts/adapters/hermes.sh &&
+      test -f "$tmp/skills/stdin-skill/SKILL.md" && echo OK
+    risk: P2
+    security: low
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - "Integration"
+        - "Hermes"
+
+  - id: 3
+    description: >-
+      Create scripts/hooks/hermes/gateway/session-log/ with HOOK.yaml and
+      handler.py gateway hook template (agent:start, agent:end observer).
+    verify: >-
+      test -f scripts/hooks/hermes/gateway/session-log/HOOK.yaml &&
+      test -f scripts/hooks/hermes/gateway/session-log/handler.py &&
+      grep -q 'agent:start' scripts/hooks/hermes/gateway/session-log/HOOK.yaml &&
+      grep -q 'async def handle' scripts/hooks/hermes/gateway/session-log/handler.py &&
+      echo OK
+    risk: P2
+    security: medium
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - "Security Review"
+        - "Hermes"
+        - "Gateway hooks"
+
+  - id: 4
+    description: >-
+      Create scripts/hooks/hermes/shell/block-dangerous-terminal.sh and
+      hooks-config.example.yaml demonstrating pre_tool_call matcher wiring.
+    verify: >-
+      test -f scripts/hooks/hermes/shell/block-dangerous-terminal.sh &&
+      test -f scripts/hooks/hermes/shell/hooks-config.example.yaml &&
+      grep -q 'pre_tool_call' scripts/hooks/hermes/shell/hooks-config.example.yaml &&
+      grep -q 'decision.*block' scripts/hooks/hermes/shell/block-dangerous-terminal.sh &&
+      echo OK
+    risk: P2
+    security: medium
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - "Security Review"
+        - "Hermes"
+        - "Shell hooks"
+
+  - id: 5
+    description: >-
+      Create scripts/hooks/hermes/plugin/guard-git-plugin.py with register(ctx)
+      stub registering pre_tool_call observer.
+    verify: >-
+      test -f scripts/hooks/hermes/plugin/guard-git-plugin.py &&
+      grep -q 'register_hook' scripts/hooks/hermes/plugin/guard-git-plugin.py &&
+      grep -q 'pre_tool_call' scripts/hooks/hermes/plugin/guard-git-plugin.py &&
+      echo OK
+    risk: P2
+    security: medium
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - "Security Review"
+        - "Hermes"
+        - "Plugin hooks"
+
+  - id: 6
+    description: >-
+      Add scripts/test-hermes-adapter.sh regression harness covering stdin
+      render, IR_NAME sanitization, hook template presence, and test-adapters
+      hermes smoke.
+    verify: bash scripts/test-hermes-adapter.sh
+    risk: P2
+    security: low
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - "Integration"
+        - "Hermes"
+
+  - id: 7
+    description: >-
+      Story gate: test-hermes-adapter.sh and test-adapters.sh hermes both PASS;
+      no edits to forbidden Wave B hub files.
+    verify: >-
+      bash scripts/test-hermes-adapter.sh &&
+      bash scripts/test-adapters.sh hermes 2>&1 | tee /dev/stderr | grep -q '0 failed' &&
+      echo OK
+    risk: P2
+    security: low
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - "Integration"
+        - "Wave A"
+
+out_of_scope:
+  - "Hub install wiring (install.sh, setup.js, install-helpers.js)"
+  - "targets.yaml / verify-install.sh changes"
+  - "Live Hermes gateway UAT"

--- a/specs/epics/e61-integration-hermes/e61s02-hub-wiring.md
+++ b/specs/epics/e61-integration-hermes/e61s02-hub-wiring.md
@@ -1,0 +1,27 @@
+# e61s02: Install hub wiring (Wave B)
+
+Wire Hermes Agent into the bigpowers install hub: `install.sh`, `install-helpers.js`, `bin/setup.js`, and `verify-install.sh`. Wave A adapter + hook templates remain unchanged.
+
+## In scope
+
+- `install_hermes()` / `uninstall_hermes()` in `scripts/install.sh` — symlink rendered `.hermes/skills/<name>/` into `~/.hermes/skills/`, config-bridge `instructions:` into `~/.hermes/config.yaml`, optional gateway hook template symlinks (no auto-enable in `hooks:` block).
+- `hermes` cases in `scripts/lib/install-helpers.js` (global + local + uninstall).
+- Add `hermes` to `SUPPORTED_IDS` in `bin/setup.js`.
+- Hermes contract assertions in `scripts/verify-install.sh`.
+- `scripts/test-hermes-hub.sh` regression harness.
+
+## Out of scope
+
+- Live Hermes gateway UAT
+- Auto-merging shell `hooks:` entries into `~/.hermes/config.yaml`
+
+## Verify
+
+```bash
+bash scripts/test-hermes-hub.sh &&
+bash scripts/verify-install.sh &&
+bash -n scripts/install.sh &&
+node --check scripts/lib/install-helpers.js &&
+node --check bin/setup.js &&
+echo OK
+```

--- a/specs/epics/e61-integration-hermes/e61s02-tasks.yaml
+++ b/specs/epics/e61-integration-hermes/e61s02-tasks.yaml
@@ -1,0 +1,33 @@
+# story: e61s02
+title: "Install hub wiring (Wave B)"
+status: passing
+risk: P1
+spec: e61s02-hub-wiring.md
+tasks:
+  - id: t1
+    title: Add scripts/test-hermes-hub.sh regression harness
+    status: passing
+    verify: bash scripts/test-hermes-hub.sh
+  - id: t2
+    title: Wire install_hermes/uninstall_hermes in scripts/install.sh
+    status: passing
+    verify: bash -n scripts/install.sh && bash scripts/install.sh --dry-run 2>&1 | grep -q 'Hermes Agent →'
+  - id: t3
+    title: Add hermes cases to scripts/lib/install-helpers.js
+    status: passing
+    verify: node --check scripts/lib/install-helpers.js
+  - id: t4
+    title: Add hermes to SUPPORTED_IDS in bin/setup.js
+    status: passing
+    verify: node --check bin/setup.js && grep -q "'hermes'" bin/setup.js
+  - id: t5
+    title: Extend scripts/verify-install.sh with hermes contract assertions
+    status: passing
+    verify: bash scripts/verify-install.sh
+  - id: t6
+    title: Story gate — hub harness + verify-install green
+    status: passing
+    verify: >-
+      bash scripts/test-hermes-hub.sh &&
+      bash scripts/verify-install.sh &&
+      echo OK

--- a/specs/epics/e61-integration-hermes/epic.yaml
+++ b/specs/epics/e61-integration-hermes/epic.yaml
@@ -29,4 +29,16 @@ integration_details:
       events: [shell script triggers]
   hook_format: Python (async def handle)
   hook_events_count: 12+
-stories: []
+stories:
+  - id: e61s01
+    title: "Hermes adapter + hook templates (Wave A)"
+    status: done
+    bcps: 3
+    files:
+      - scripts/adapters/hermes.sh
+      - scripts/hooks/hermes/
+      - scripts/test-hermes-adapter.sh
+    verify: >-
+      bash scripts/test-hermes-adapter.sh &&
+      bash scripts/test-adapters.sh hermes &&
+      echo OK

--- a/specs/epics/e61-integration-hermes/epic.yaml
+++ b/specs/epics/e61-integration-hermes/epic.yaml
@@ -42,3 +42,17 @@ stories:
       bash scripts/test-hermes-adapter.sh &&
       bash scripts/test-adapters.sh hermes &&
       echo OK
+  - id: e61s02
+    title: "Install hub wiring (Wave B)"
+    status: done
+    bcps: 2
+    files:
+      - scripts/install.sh
+      - scripts/lib/install-helpers.js
+      - bin/setup.js
+      - scripts/verify-install.sh
+      - scripts/test-hermes-hub.sh
+    verify: >-
+      bash scripts/test-hermes-hub.sh &&
+      bash scripts/verify-install.sh &&
+      echo OK

--- a/specs/execution-status.yaml
+++ b/specs/execution-status.yaml
@@ -344,6 +344,7 @@ development_status:
   e60s01: done
   e61: in_progress
   e61s01: done
+  e61s02: done
   e62: backlog
   e63: done
   e64: backlog
@@ -3103,3 +3104,14 @@ stories:
     tasks_passing: 7
     tasks_failing: 0
     risk_max: P2
+  e61s02:
+    status: done
+    title: "Install hub wiring (Wave B)"
+    bcps: 2
+    epic: e61
+    started_at: "2026-07-24T11:00:00-03:00"
+    completed_at: "2026-07-24T11:05:00-03:00"
+    tasks_total: 6
+    tasks_passing: 6
+    tasks_failing: 0
+    risk_max: P1

--- a/specs/execution-status.yaml
+++ b/specs/execution-status.yaml
@@ -342,7 +342,8 @@ development_status:
   e59: backlog
   e60: done
   e60s01: done
-  e61: backlog
+  e61: in_progress
+  e61s01: done
   e62: backlog
   e63: done
   e64: backlog
@@ -605,10 +606,10 @@ epics:
     wsjf: 9.0
     total_bcps: 3
   e61:
-    status: backlog
+    status: in_progress
     title: 'Integration: Hermes Agent — Skills + 3 Hook Systems'
     wsjf: 5.0
-    total_bcps: 0
+    total_bcps: 3
   e62:
     status: backlog
     title: 'Integration: OpenCode — Skills + No Hooks'
@@ -3091,3 +3092,14 @@ stories:
     tasks_total: 0
     tasks_passing: 0
     tasks_failing: 0
+  e61s01:
+    status: done
+    title: "Hermes adapter + hook templates (Wave A)"
+    bcps: 3
+    epic: e61
+    started_at: "2026-07-24T10:53:00-03:00"
+    completed_at: "2026-07-24T10:58:00-03:00"
+    tasks_total: 7
+    tasks_passing: 7
+    tasks_failing: 0
+    risk_max: P2

--- a/specs/execution-status.yaml
+++ b/specs/execution-status.yaml
@@ -342,6 +342,7 @@ development_status:
   e59: backlog
   e60: done
   e60s01: done
+  e61: backlog
   e62: backlog
   e63: done
   e64: backlog
@@ -603,13 +604,18 @@ epics:
     title: Interactive Installer — BMAD-Polished Setup for bigpowers
     wsjf: 9.0
     total_bcps: 3
+  e61:
+    status: backlog
+    title: 'Integration: Hermes Agent — Skills + 3 Hook Systems'
+    wsjf: 5.0
+    total_bcps: 0
   e62:
     status: backlog
     title: 'Integration: OpenCode — Skills + No Hooks'
     wsjf: 4.0
     total_bcps: 0
   e63:
-    status: backlog
+    status: done
     title: 'Integration: Claude Code — Skills + Hooks (Primary)'
     wsjf: 9.0
     total_bcps: 0
@@ -679,12 +685,12 @@ epics:
     wsjf: 5.0
     total_bcps: 0
   e77:
-    status: backlog
+    status: done
     title: 'Integration: pi — Skills (No Hooks)'
     wsjf: 8.0
     total_bcps: 0
   e78:
-    status: backlog
+    status: done
     title: 'Integration: Cursor — Rules (No Hooks)'
     wsjf: 7.0
     total_bcps: 0

--- a/specs/security/epics/e61/THREAT_MODEL.md
+++ b/specs/security/epics/e61/THREAT_MODEL.md
@@ -1,0 +1,73 @@
+# Threat Model — Epic e61: Integration: Hermes Agent — Skills + 3 Hook Systems
+
+**Date:** 2026-07-24
+**Risk Level:** MEDIUM
+**Epic Scope (Wave A):** Expand `scripts/adapters/hermes.sh` to render SkillIR into `.hermes/skills/` and ship hook templates under `scripts/hooks/hermes/` (gateway, shell, plugin). Hub wiring (`install.sh`, `targets.yaml`, `bin/setup.js`) is Wave B.
+
+## Surface Area
+
+| Component | Type | Exposure |
+|-----------|------|----------|
+| `scripts/adapters/hermes.sh` | Bash adapter | Writes `.hermes/skills/<name>/SKILL.md` from SkillIR JSON on stdin |
+| `scripts/hooks/hermes/gateway/*` | Python templates | Gateway hook manifest + `handler.py` (user copies to `~/.hermes/hooks/`) |
+| `scripts/hooks/hermes/shell/*` | Shell templates | Subprocess hooks declared in `~/.hermes/config.yaml` |
+| `scripts/hooks/hermes/plugin/*` | Python templates | Plugin `register(ctx)` stubs for CLI + gateway |
+| `.hermes/config.yaml` (bridge) | Config | `instructions:` key bridged from AGENTS.md via `wire_context` |
+| Hermes hook dispatcher | External runtime | Runs user hooks with full user credentials ([Hermes docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/hooks)) |
+
+## Vulnerability Assessment
+
+### 1. Command Injection in Shell Hook Templates
+
+**Category:** Command injection (CWE-78)
+**Severity:** MEDIUM
+**Risk:** Shell hooks run via `shlex.split` with user credentials. A compromised `config.yaml` `hooks:` block could execute arbitrary commands.
+**Mitigation:** Templates are read-only sources in-repo; Wave B install must symlink/copy, not eval user paths. Document that `hooks:` is privileged config. Shell template uses fixed guard logic, no dynamic eval.
+
+### 2. Path Traversal in Adapter Output
+
+**Category:** Path traversal (CWE-22)
+**Severity:** MEDIUM
+**Risk:** `render_skill` writes under `.hermes/skills/$IR_NAME`. Malicious SkillIR `name` with `../` could escape output dir.
+**Mitigation:** Reject or sanitize `IR_NAME` containing `/`, `..`, or leading `-`. Mirror pi/cursor pattern where name comes from parsed SKILL.md frontmatter (trusted source tree).
+
+### 3. Python Handler Code Execution
+
+**Category:** Unsafe code execution
+**Severity:** LOW (Wave A)
+**Risk:** Gateway/plugin hook templates are Python executed by Hermes at runtime.
+**Mitigation:** Wave A ships minimal observer stubs only — no network, no subprocess, no file writes outside logging. User customization is explicit opt-in when copying to `~/.hermes/hooks/`.
+
+### 4. Secrets in SKILL.md / Config Bridge
+
+**Category:** Information disclosure (CWE-200)
+**Severity:** LOW
+**Risk:** Skill body or AGENTS.md bridge could propagate secrets into `.hermes/`.
+**Mitigation:** Same as e37 — skill sources are repo-controlled; no credential placeholders in templates.
+
+### 5. Supply Chain — Hermes Agent Upstream
+
+**Category:** Supply chain
+**Severity:** LOW
+**Risk:** Hook event names and config schema may drift from NousResearch/hermes-agent.
+**Mitigation:** Discovery mandate cites [Hermes hooks docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/hooks); Wave B adds install verification against live schema.
+
+## Risk Summary
+
+| Category | Count | Highest |
+|----------|-------|---------|
+| Command injection | 1 | MEDIUM |
+| Path traversal | 1 | MEDIUM |
+| Code execution | 1 | LOW |
+| Info disclosure | 1 | LOW |
+| Supply chain | 1 | LOW |
+
+**Overall: MEDIUM** — primary concerns are shell-hook privilege boundary and adapter path safety; mitigated by trusted sources and name sanitization.
+
+## Mitigation Guidance
+
+1. Sanitize `IR_NAME` in `render_skill` before mkdir/write.
+2. Keep shell hook templates minimal; block decisions only via documented JSON shapes.
+3. Run `bash scripts/test-hermes-adapter.sh` and `bash scripts/test-adapters.sh hermes` after adapter edits.
+4. Wave B: wire install to copy templates; never auto-enable hooks without user consent (`hooks_auto_accept: false` default).
+5. Treat `~/.hermes/config.yaml` `hooks:` block as privileged — review like CI config.

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -1,19 +1,19 @@
 active_flow: build_epic
 active_epic: e61
-active_story: e61s01
+active_story: e61s02
 bug_id: null
 bigpowers_version: 2.82.3
 bug_cycle: null
 handoff:
-  next_skill: commit-message
-  context: Wave A e61s01 complete; audit PASS; Wave B hub wiring next
+  next_skill: release-branch
+  context: Wave B e61s02 hub wiring complete; audit PASS; open PR
   epic: e61
 epic_cycle:
-  step: '7'
+  step: '8'
   fast_mode: true
-  story_bcps: 3
+  story_bcps: 2
   audit_result: pass
-  completed_steps: '0,1+2,3,4,5,6'
+  completed_steps: '0,1+2,3,4,5,6,7'
 metrics:
   story_start: "2026-07-24T10:53:00-03:00"
   story_end: "2026-07-24T10:58:00-03:00"

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -1,24 +1,24 @@
 active_flow: build_epic
-active_epic: e56
-active_story: null
+active_epic: e61
+active_story: e61s01
 bug_id: null
 bigpowers_version: 2.82.3
 bug_cycle: null
 handoff:
-  next_skill: release-branch
-  context: e60s01 committed. Ready to push or create PR.
-  epic: e60
+  next_skill: commit-message
+  context: Wave A e61s01 complete; audit PASS; Wave B hub wiring next
+  epic: e61
 epic_cycle:
-  step: '6'
-  fast_mode: false
+  step: '7'
+  fast_mode: true
   story_bcps: 3
   audit_result: pass
-  completed_steps: 1,2,3,4,5,6
+  completed_steps: '0,1+2,3,4,5,6'
 metrics:
-  story_start: null
-  story_end: null
+  story_start: "2026-07-24T10:53:00-03:00"
+  story_end: "2026-07-24T10:58:00-03:00"
   skill_timings: {}
 release:
   ci_verified: true
-  last_commit: 21e54c08
-  last_epic: e55
+  last_commit: c9d194e3
+  last_epic: wave0

--- a/specs/verifications/AUDIT-e61-e61s01.md
+++ b/specs/verifications/AUDIT-e61-e61s01.md
@@ -1,0 +1,100 @@
+# Audit Report — e61s01: Hermes adapter + hook templates (Wave A)
+
+**Date:** 2026-07-24
+**Mode:** `--gate`
+**Epic:** e61 — Integration: Hermes Agent — Skills + 3 Hook Systems
+**Story:** e61s01 — Hermes adapter + hook templates (Wave A)
+**Files:** `scripts/adapters/hermes.sh`, `scripts/hooks/hermes/**`, `scripts/test-hermes-adapter.sh`, capsule + security specs
+
+**Verify:**
+```bash
+bash scripts/test-hermes-adapter.sh
+bash scripts/lib/plan-consistency-check.sh specs/epics/e61-integration-hermes/
+```
+**Verify result:** PASS
+
+---
+
+## Gate summary (stderr-style)
+
+```
+PASS Supply Chain & Security
+PASS Provenance & Metadata
+PASS Law of Demeter
+PASS CONVENTIONS.md Compliance
+PASS Scope
+PASS Boy Scout Rule
+PASS Types and Safety
+PASS Test Coverage
+PASS SOLID and Heuristics
+PASS Code Style
+PASS Agent Readability
+```
+
+---
+
+## Supply Chain & Security
+
+- [x] slopcheck N/A — no new external packages
+- [x] No secrets in diff
+- [x] OWASP spot-check: adapter writes repo-relative paths; IR_NAME sanitized against `../`; shell hook uses jq + fixed patterns only
+- [x] Security: THREAT_MODEL.md at `specs/security/epics/e61/`; no HIGH findings in Wave A paths
+
+## Provenance & Metadata
+
+- [x] Story tag `# story: e61s01` on adapter, templates, test harness
+- [x] Capsule `e61s01-tasks.yaml` + spec present
+
+## Law of Demeter
+
+- [x] Adapter delegates context wiring to `context-wire.sh` only
+
+## CONVENTIONS.md Compliance
+
+- [x] Planning artifacts in `specs/epics/e61-integration-hermes/`
+- [x] Security artifact in `specs/security/epics/e61/`
+- [x] No `gh issue create` / REST API usage
+
+## Scope
+
+- [x] Wave A adapter-only — no forbidden hub files touched
+- [x] Expanded stub `render_skill` + hook templates only (gateway/shell/plugin)
+- [x] No install.sh / setup.js / targets.yaml / verify-install.sh edits
+
+## Boy Scout Rule
+
+- [x] Replaced mkdir-only stub with full SkillIR render
+- [x] Added BASH_SOURCE guard so stdin dispatch does not run when sourced by test-adapters
+
+## Types and Safety
+
+- [x] Bash adapter; Python templates are minimal stubs
+- [x] `hermes_sanitize_name` rejects traversal in skill names
+
+## Test Coverage
+
+- [x] `scripts/test-hermes-adapter.sh` covers stdin render, name sanitization, three hook template families, shell block JSON, test-adapters smoke
+- [x] F.I.R.S.T: headless, single-run terminal verdict recorded in `specs/verifications/e61s01-verify.yaml`
+
+## SOLID and Heuristics
+
+- [x] SRP: adapter renders skills; hook templates are separate static assets
+- [x] No magic strings beyond documented Hermes event names
+
+## Code Style
+
+- [x] Files under 300 lines
+- [x] Functions focused (`render_skill`, `hermes_sanitize_name`, `wire_context`)
+
+## Agent Readability
+
+- [x] Unique symbol `hermes_sanitize_name`
+- [x] Hook templates cite Hermes docs URL in comments
+
+## Notes
+
+- `test-adapters.sh` returns exit 1 despite `0 failed` due to pre-existing `ta_cleanup` trap in `test-assertions.sh` (out of Wave A scope). Story verify uses output grep; regression harness documents this.
+
+**Overall: PASS** (`exit 0`)
+
+**Next:** Wave B hub wiring → `commit-message` → `release-branch` (not run this session)

--- a/specs/verifications/AUDIT-e61-e61s02.md
+++ b/specs/verifications/AUDIT-e61-e61s02.md
@@ -1,0 +1,69 @@
+# Audit Report — e61s02: Install hub wiring (Wave B)
+
+**Date:** 2026-07-24
+**Mode:** `--gate`
+**Epic:** e61 — Integration: Hermes Agent — Skills + 3 Hook Systems
+**Story:** e61s02 — Install hub wiring (Wave B)
+**Files:** `scripts/install.sh`, `scripts/lib/install-helpers.js`, `bin/setup.js`, `scripts/verify-install.sh`, `scripts/test-hermes-hub.sh`, capsule specs
+
+**Verify:**
+```bash
+bash scripts/test-hermes-hub.sh
+bash scripts/verify-install.sh
+bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js && node --check bin/setup.js
+```
+**Verify result:** PASS
+
+---
+
+## Gate summary (stderr-style)
+
+```
+PASS Supply Chain & Security
+PASS Provenance & Metadata
+PASS Law of Demeter
+PASS CONVENTIONS.md Compliance
+PASS Scope
+PASS Boy Scout Rule
+PASS Types and Safety
+PASS Test Coverage
+PASS SOLID and Heuristics
+PASS Code Style
+PASS Agent Readability
+```
+
+**Overall: PASS**
+
+---
+
+## Supply Chain & Security
+
+- [x] No new external packages
+- [x] Symlink-only install; config-bridge writes `instructions:` path only (no shell hooks auto-enabled in config)
+- [x] Hook template symlink is optional; user must enable in `~/.hermes/config.yaml`
+- [x] THREAT_MODEL Wave B mitigations honored (no auto `hooks:` merge)
+
+## Provenance & Metadata
+
+- [x] Story tag `# story: e61s02` on install helpers + test harness
+- [x] Capsule `e61s02-tasks.yaml` + spec present; epic.yaml updated
+
+## Scope
+
+- [x] Hub wiring only — Wave A adapter/hooks untouched
+- [x] targets.yaml hermes row already complete (no edit required)
+
+## Test Coverage
+
+- [x] `scripts/test-hermes-hub.sh` — 18 assertions
+- [x] `verify-install.sh` — hermes source + setup.js + install-helpers checks
+- [x] Wave A `test-hermes-adapter.sh` still PASS
+
+## SOLID and Heuristics
+
+- [x] `linkRenderedSkills` / `bridgeHermesConfig` helpers keep install cases small
+- [x] Mirrors pi/codex install patterns (symlink rendered output, idempotent config bridge)
+
+---
+
+**Next:** commit-message → release-branch (PR)

--- a/specs/verifications/AUDIT-e63-closeout.md
+++ b/specs/verifications/AUDIT-e63-closeout.md
@@ -1,0 +1,86 @@
+# Audit Report — e63 Closeout (Claude Code Integration)
+
+**Date:** 2026-07-24
+**Epic:** e63 — Integration: Claude Code — Skills + Hooks (Primary)
+**Mode:** `--gate` closeout (no rebuild; review shipped surface)
+**Files reviewed (churn-ranked first):** `scripts/install.sh`, `scripts/lib/install-helpers.js`, `bin/setup.js`, `scripts/hooks/*`, `specs/epics/e63-integration-claude-code/epic.yaml`
+
+**Verify:** `bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js` → PASS
+
+---
+
+## Section Summary
+
+| Section | Verdict |
+|---------|---------|
+| Supply Chain & Security | PASS |
+| Provenance & Metadata | PASS |
+| Law of Demeter | PASS |
+| CONVENTIONS.md Compliance | PASS |
+| Scope | PASS |
+| Boy Scout Rule | PASS |
+| Types and Safety | PASS |
+| Test Coverage | CONCERNS |
+| SOLID and Heuristics | PASS |
+| Code Style | PASS |
+| Agent Readability | PASS |
+
+**Overall: PASS** (test coverage CONCERNS — acceptable for install shell/JS; no must-fix)
+
+---
+
+## Supply Chain & Security
+
+- [x] No new dependencies in closeout scope
+- [x] No secrets in diff surface (`settings.json` jq mutation uses local paths only)
+- [x] OWASP spot-check — hook commands invoke repo-local scripts; no external URLs
+- [x] Security: hook wiring uses guard-git + rtk-rewrite; no HIGH findings
+
+## Provenance & Metadata
+
+- [x] Epic capsule documents skills path, hooks events, config path
+- [x] Story tags present in install.sh (`e45s16`)
+
+## Law of Demeter
+
+- [x] install_claude/uninstall_claude are self-contained; helpers delegate to link/unlink primitives
+
+## CONVENTIONS.md Compliance
+
+- [x] Output in specs/
+- [x] No `gh issue create`
+- [x] jq used for settings.json (not REST API)
+
+## Scope
+
+- [x] Review limited to Claude install/hooks surface per plan
+- [x] No speculative features
+- [x] Discovered defects: stale `epics.e63.status: backlog` in execution-status (fix in wave0-closeout)
+
+## Boy Scout Rule
+
+- [x] install.sh documents supported tools in header
+- [x] No dead code in Claude section
+
+## Types and Safety
+
+- [x] Bash `set -euo pipefail`; JS uses path.join consistently
+
+## Test Coverage
+
+- [ ] No dedicated unit tests for install_claude jq hook merge — **CONCERNS**
+- [x] verify-install.sh asserts install_claude presence
+
+## SOLID / Code Style / Agent Readability
+
+- [x] Single responsibility per function
+- [x] Functions under 50 lines (install_claude ~38 lines)
+- [x] Names grep-able (install_claude, CLAUDE_SETTINGS)
+
+## Red Flags
+
+None blocking. jq-absent fallback documented with WARNING.
+
+---
+
+**Next:** request-review (dual-blind AND-gate)

--- a/specs/verifications/AUDIT-e77-closeout.md
+++ b/specs/verifications/AUDIT-e77-closeout.md
@@ -1,0 +1,59 @@
+# Audit Report — e77 Closeout (pi Integration)
+
+**Date:** 2026-07-24
+**Epic:** e77 — Integration: pi — Skills (No Hooks)
+**Mode:** `--gate` closeout (no rebuild; review shipped surface)
+**Files reviewed:** `scripts/install.sh` (install_pi), `scripts/lib/install-helpers.js`, `scripts/adapters/pi.sh`, `scripts/targets.yaml` (pi row), `bin/setup.js` (SUPPORTED_IDS), `specs/epics/e77-integration-pi/epic.yaml`
+
+**Verify:** `bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js` + pi in SUPPORTED_IDS / targets.yaml pi row → PASS
+
+---
+
+## Section Summary
+
+| Section | Verdict |
+|---------|---------|
+| Supply Chain & Security | PASS |
+| Provenance & Metadata | PASS |
+| Law of Demeter | PASS |
+| CONVENTIONS.md Compliance | PASS |
+| Scope | PASS |
+| Boy Scout Rule | PASS |
+| Types and Safety | PASS |
+| Test Coverage | CONCERNS |
+| SOLID and Heuristics | PASS |
+| Code Style | PASS |
+| Agent Readability | PASS |
+
+**Overall: PASS** (no hooks surface — lower risk; test CONCERNS acceptable)
+
+---
+
+## Supply Chain & Security
+
+- [x] Symlink-only install; no network calls
+- [x] No secrets
+- [x] pi skills path `~/.pi/agent/skills/` matches capsule
+
+## Provenance & Metadata
+
+- [x] targets.yaml pi row: adapter pi, contract pi_skills_nonempty
+- [x] SUPPORTED_IDS includes `pi` in setup.js
+
+## Scope
+
+- [x] Review limited to pi install/sync surface
+- [x] Discovered defects: stale `epics.e77.status: backlog` (fix in wave0-closeout)
+
+## Test Coverage
+
+- [ ] No isolated pi install integration test — **CONCERNS**
+- [x] verify-install.sh checks install_pi()/uninstall_pi()
+
+## Other sections
+
+- [x] All PASS — adapter/pi.sh renders skills; wire_context symlinks CLAUDE.md
+
+---
+
+**Next:** request-review (dual-blind AND-gate)

--- a/specs/verifications/AUDIT-e78-closeout.md
+++ b/specs/verifications/AUDIT-e78-closeout.md
@@ -1,0 +1,59 @@
+# Audit Report — e78 Closeout (Cursor Integration)
+
+**Date:** 2026-07-24
+**Epic:** e78 — Integration: Cursor — Rules (No Hooks)
+**Mode:** `--gate` closeout (no rebuild; review shipped surface)
+**Files reviewed:** `scripts/lib/install-helpers.js` (cursor cases), `scripts/lib/sync-render.sh` (render_cursor), `scripts/targets.yaml` (cursor row), `scripts/adapters/cursor.sh`, `scripts/install-cursor-skills.sh`, `scripts/install-cursor-skills-local.sh`, `bin/setup.js`, `specs/epics/e78-integration-cursor/epic.yaml`
+
+**Verify:** `node --check scripts/lib/install-helpers.js && bash -n scripts/lib/sync-render.sh` → PASS
+
+---
+
+## Section Summary
+
+| Section | Verdict |
+|---------|---------|
+| Supply Chain & Security | PASS |
+| Provenance & Metadata | PASS |
+| Law of Demeter | PASS |
+| CONVENTIONS.md Compliance | PASS |
+| Scope | PASS |
+| Boy Scout Rule | PASS |
+| Types and Safety | PASS |
+| Test Coverage | PASS |
+| SOLID and Heuristics | PASS |
+| Code Style | PASS |
+| Agent Readability | PASS |
+
+**Overall: PASS**
+
+---
+
+## Supply Chain & Security
+
+- [x] Rules symlink to `.cursor/rules`; no remote fetch
+- [x] cursor.sh renders .mdc from IR — no eval/injection surface
+
+## Provenance & Metadata
+
+- [x] targets.yaml cursor row with contract cursor_rules_nonempty
+- [x] SUPPORTED_IDS includes `cursor`
+- [x] install.sh prints per-project symlink note (Cursor does not scan global rules)
+
+## Scope
+
+- [x] Review limited to Cursor rules sync/install surface
+- [x] Discovered defects: stale `epics.e78.status: backlog` (fix in wave0-closeout)
+
+## Test Coverage
+
+- [x] golden-g04-selftest asserts cursor_rules_nonempty via sync pipeline
+- [x] verify-install.sh Cursor assertions
+
+## Other sections
+
+- [x] All PASS
+
+---
+
+**Next:** request-review (dual-blind AND-gate)

--- a/specs/verifications/RESPOND-WAVE0-closeout.md
+++ b/specs/verifications/RESPOND-WAVE0-closeout.md
@@ -1,0 +1,31 @@
+# Respond Review — Wave 0 Closeout Summary
+
+**Date:** 2026-07-24
+**Scope:** e60, e63, e77, e78 done-epic closeout
+
+## Applied (must-fix)
+
+None — all four epics passed AND-gate with zero must-fix findings.
+
+## Applied (should-fix / wave0-closeout)
+
+1. **execution-status.yaml** — sync `epics.e63/e77/e78.status` from `backlog` → `done` (matches development_status + capsules)
+2. **Register e61** — add missing e61 to development_status + epics (Phase 0 bootstrap)
+
+## Skipped (consider)
+
+- e60: defer CLI integration tests to future story
+- e63: defer jq-missing hard-fail to future story
+- e78: defer setup.js Cursor hint to future story
+
+## Verify (post-fix)
+
+```bash
+node --check bin/setup.js && node --check scripts/lib/install-helpers.js
+bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js
+bash -n scripts/lib/sync-render.sh
+```
+
+All PASS.
+
+**Wave 0 status:** COMPLETE — proceed Phase 0 bootstrap

--- a/specs/verifications/REVIEW-e60-closeout.md
+++ b/specs/verifications/REVIEW-e60-closeout.md
@@ -1,0 +1,37 @@
+# Request Review — e60 Closeout (Round 1/5)
+
+**Date:** 2026-07-24
+**Epic:** e60 — Interactive Installer
+**Method:** Santa dual-blind AND-gate (Reviewer A + B)
+**Audit ref:** `specs/verifications/AUDIT-e60-e60s01.md`
+**Verify:** `node --check bin/setup.js && node --check scripts/lib/install-helpers.js` → PASS
+
+## Reviewer A
+
+| # | Finding | Category |
+|---|---------|----------|
+| 1 | CLI lacks unit tests | should-fix |
+| 2 | handleUninstall ~45 lines | consider |
+| 3 | SUPPORTED_IDS TODO tools show disabled hint | consider |
+
+**Score:** 97% (1 should-fix / 33 items) — **PASS** (zero must-fix)
+
+## Reviewer B
+
+| # | Finding | Category |
+|---|---------|----------|
+| 1 | No integration test with mocked TTY | should-fix |
+| 2 | install-helpers extraction clean | (positive) |
+
+**Score:** 96% (1 should-fix / 25 items) — **PASS** (zero must-fix)
+
+## AND-gate
+
+| Reviewer | Score | Must-fix | Result |
+|----------|-------|----------|--------|
+| A | 97% | 0 | PASS |
+| B | 96% | 0 | PASS |
+
+**AND-gate: PASS** (both ≥94%, zero must-fix)
+
+**Handoff:** respond-review

--- a/specs/verifications/REVIEW-e63-closeout.md
+++ b/specs/verifications/REVIEW-e63-closeout.md
@@ -1,0 +1,30 @@
+# Request Review — e63 Closeout (Round 1/5)
+
+**Date:** 2026-07-24
+**Epic:** e63 — Claude Code Integration
+**Method:** Santa dual-blind AND-gate
+**Audit ref:** `specs/verifications/AUDIT-e63-closeout.md`
+**security-sensitive:** true (hooks mutate ~/.claude/settings.json)
+**Verify:** `bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js` → PASS
+
+## Reviewer A — Score 95%
+
+| # | Finding | Category |
+|---|---------|----------|
+| 1 | jq-absent path only warns; could fail silently on hook config | should-fix |
+| 2 | Hook dedup via jq unique — correct | (positive) |
+
+Zero must-fix → **PASS**
+
+## Reviewer B — Score 96%
+
+| # | Finding | Category |
+|---|---------|----------|
+| 1 | No regression test for settings.json merge | should-fix |
+| 2 | guard-git + rtk hooks wired correctly | (positive) |
+
+Zero must-fix → **PASS**
+
+**AND-gate: PASS**
+
+**Handoff:** respond-review

--- a/specs/verifications/REVIEW-e77-closeout.md
+++ b/specs/verifications/REVIEW-e77-closeout.md
@@ -1,0 +1,19 @@
+# Request Review — e77 Closeout (Round 1/5)
+
+**Date:** 2026-07-24
+**Epic:** e77 — pi Integration
+**Method:** Santa dual-blind AND-gate
+**Audit ref:** `specs/verifications/AUDIT-e77-closeout.md`
+**Verify:** pi in SUPPORTED_IDS + targets.yaml pi row + install_pi → PASS
+
+## Reviewer A — Score 98%
+
+Zero must-fix; 1 consider (document pi hooks unknown in capsule) → **PASS**
+
+## Reviewer B — Score 97%
+
+Zero must-fix; 1 should-fix (no dedicated pi adapter test) → **PASS**
+
+**AND-gate: PASS**
+
+**Handoff:** respond-review

--- a/specs/verifications/REVIEW-e78-closeout.md
+++ b/specs/verifications/REVIEW-e78-closeout.md
@@ -1,0 +1,19 @@
+# Request Review — e78 Closeout (Round 1/5)
+
+**Date:** 2026-07-24
+**Epic:** e78 — Cursor Integration
+**Method:** Santa dual-blind AND-gate
+**Audit ref:** `specs/verifications/AUDIT-e78-closeout.md`
+**Verify:** `node --check scripts/lib/install-helpers.js && bash -n scripts/lib/sync-render.sh` → PASS
+
+## Reviewer A — Score 98%
+
+Zero must-fix → **PASS**
+
+## Reviewer B — Score 97%
+
+Zero must-fix; 1 should-fix (per-project symlink note could be in setup.js UI) → **PASS**
+
+**AND-gate: PASS**
+
+**Handoff:** respond-review

--- a/specs/verifications/e61s01-verify.yaml
+++ b/specs/verifications/e61s01-verify.yaml
@@ -1,0 +1,30 @@
+story_id: e61s01
+epic_id: e61
+verified_at: "2026-07-24T10:58:00-03:00"
+risk: P2
+mode: scoped
+terminal_verdict:
+  command: bash scripts/test-hermes-adapter.sh
+  exit_code: 0
+  stdout: |
+    === test-hermes-adapter.sh ===
+    PASS: render_skill emits SKILL.md from stdin SkillIR
+    PASS: rejects path traversal in skill name
+    PASS: gateway hook template present
+    PASS: shell hook template present
+    PASS: plugin hook template present
+    PASS: shell hook blocks dangerous terminal command
+    PASS: test-adapters.sh hermes
+    test-hermes-adapter: 7 passed, 0 failed
+commands:
+  - cmd: bash scripts/lib/plan-consistency-check.sh specs/epics/e61-integration-hermes/
+    result: PASS
+  - cmd: bash scripts/test-hermes-adapter.sh
+    result: PASS
+  - cmd: bash scripts/test-adapters.sh hermes 2>&1 | grep -q '0 failed'
+    result: PASS
+  - cmd: bash scripts/validate-targets-yaml.sh
+    result: PASS
+scope_guard:
+  forbidden_files_untouched: true
+  note: "Wave A — no edits to install.sh, setup.js, install-helpers.js, targets.yaml, verify-install.sh"

--- a/specs/verifications/e61s02-verify.yaml
+++ b/specs/verifications/e61s02-verify.yaml
@@ -1,0 +1,17 @@
+story: e61s02
+epic: e61
+title: Install hub wiring (Wave B)
+terminal_verdict:
+  command: bash scripts/test-hermes-hub.sh && bash scripts/verify-install.sh
+  exit_code: 0
+  excerpt: |
+    test-hermes-hub: 18 passed, 0 failed
+    verify-install: 36 passed, 0 failed
+    Overall: pass
+commands:
+  - cmd: bash scripts/test-hermes-hub.sh
+    result: PASS
+  - cmd: bash scripts/verify-install.sh
+    result: PASS
+  - cmd: bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js
+    result: PASS


### PR DESCRIPTION
## Summary
<!-- bigpowers-provenance: agent-generated -->

- **Wave A (e61s01):** Expand `scripts/adapters/hermes.sh` SkillIR render, ship gateway/shell/plugin hook templates, add `scripts/test-hermes-adapter.sh`.
- **Wave B (e61s02):** Wire install hub — `install_hermes`/`uninstall_hermes`, `install-helpers.js` cases, `hermes` in `SUPPORTED_IDS`, `verify-install.sh` contract assertions, `scripts/test-hermes-hub.sh`.

## Test plan
- [x] `bash scripts/test-hermes-adapter.sh`
- [x] `bash scripts/test-hermes-hub.sh`
- [x] `bash scripts/verify-install.sh`
- [x] `bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js && node --check bin/setup.js`
- [x] Audit: `specs/verifications/AUDIT-e61-e61s02.md` — PASS