### PR TITLE
feat(e76): ZCode integration — adapter + install hub

### DIFF
--- a/bin/setup.js
+++ b/bin/setup.js
@@ -53,9 +53,10 @@ const TOOLS = [
   { id: 'qwen', name: 'Qwen Code', globalPath: '~/.qwen', localPath: '.qwen' },
   { id: 'trae', name: 'Trae', globalPath: '~/.trae', localPath: '.trae' },
   { id: 'windsurf', name: 'Windsurf', globalPath: '~/.codeium/windsurf', localPath: '.codeium/windsurf' },
+  { id: 'zcode', name: 'ZCode', globalPath: '~/.zcode', localPath: '.zcode' },
 ];
 const ALL_ID = '__all__';
-const SUPPORTED_IDS = new Set(['claude', 'gemini', 'pi', 'hermes', 'cursor', 'codex']);
+const SUPPORTED_IDS = new Set(['claude', 'gemini', 'pi', 'hermes', 'zcode', 'cursor', 'codex']);
 const UNSUPPORTED_HINT = '(TODO)';
 
 // ── clack helpers (lazy ESM import from CJS) ─────────────────────────────────

--- a/scripts/adapters/zcode.sh
+++ b/scripts/adapters/zcode.sh
@@ -3,7 +3,7 @@
 # ZCode skill adapter — renders SKILL.md to ~/.zcode/skills/<name>/.
 
 render_skill() {
-  local skills_dir="${ZCODE_SKILLS:-${HOME}/.zcode/skills}"
+  local skills_dir="${ZCODE_SKILLS:-.zcode/skills}"
   mkdir -p "${skills_dir}/${IR_NAME}"
   {
     echo "---"
@@ -18,7 +18,7 @@ render_skill() {
 
 wire_context() {
   source "$(dirname "${BASH_SOURCE[0]}")/../lib/context-wire.sh"
-  local dest="${ZCODE_AGENTS:-${HOME}/.zcode/AGENTS.md}"
+  local dest="${ZCODE_AGENTS:-.zcode/AGENTS.md}"
   mkdir -p "$(dirname "$dest")"
   wire_context_mode symlink "$dest" "" "" "" "${1:-AGENTS.md}"
 }

--- a/scripts/adapters/zcode.sh
+++ b/scripts/adapters/zcode.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# story: e76s01
+# ZCode skill adapter — renders SKILL.md to ~/.zcode/skills/<name>/.
+
+render_skill() {
+  local skills_dir="${ZCODE_SKILLS:-${HOME}/.zcode/skills}"
+  mkdir -p "${skills_dir}/${IR_NAME}"
+  {
+    echo "---"
+    echo "name: $IR_NAME"
+    [[ -n "${IR_MODEL:-}" ]] && echo "model: $IR_MODEL"
+    echo "description: \"$IR_DESC_ESCAPED\""
+    echo "---"
+    echo ""
+    echo "$IR_BODY"
+  } > "${skills_dir}/${IR_NAME}/SKILL.md"
+}
+
+wire_context() {
+  source "$(dirname "${BASH_SOURCE[0]}")/../lib/context-wire.sh"
+  local dest="${ZCODE_AGENTS:-${HOME}/.zcode/AGENTS.md}"
+  mkdir -p "$(dirname "$dest")"
+  wire_context_mode symlink "$dest" "" "" "" "${1:-AGENTS.md}"
+}
+
+# If stdin is a pipe/redirect, read the SkillIR JSON and render
+if [[ ! -t 0 ]]; then
+  JSON_INPUT=$(cat)
+  if [[ -n "$JSON_INPUT" ]]; then
+    IR_NAME=$(echo "$JSON_INPUT" | jq -r '.name')
+    IR_MODEL=$(echo "$JSON_INPUT" | jq -r '.model // empty')
+    IR_DESCRIPTION=$(echo "$JSON_INPUT" | jq -r '.description')
+    IR_BODY=$(echo "$JSON_INPUT" | jq -r '.body')
+    IR_DESC_ESCAPED=$(echo "$IR_DESCRIPTION" | sed 's/\\/\\\\/g; s/\"/\\"/g')
+    render_skill
+  fi
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,7 @@
 #   Gemini CLI   → ~/.gemini/config/plugins/bigpowers/ (one dir symlink)
 #   pi           → ~/.pi/agent/skills/<name>/ (one symlink per skill)
 #   Hermes Agent → ~/.hermes/skills/<name>/ (symlink rendered .hermes/skills/)
+#   ZCode        → ~/.zcode/skills/<name>/ (symlink rendered .zcode/skills/)
 #   Cursor       → ~/.cursor/rules/ (one dir symlink; per-project note printed)
 #
 # Usage:
@@ -278,6 +279,46 @@ uninstall_hermes() {
   unlink_if_managed "$HERMES_HOOKS_DIR/session-log" "$REPO_ROOT/"
 }
 
+# ── ZCode (e76s02) ────────────────────────────────────────────────────────────
+
+ZCODE_CONFIG_DIR="$HOME/.zcode"
+ZCODE_SKILLS_DIR="$ZCODE_CONFIG_DIR/skills"
+ZCODE_RENDERED="$REPO_ROOT/.zcode/skills"
+ZCODE_AGENTS="$ZCODE_CONFIG_DIR/AGENTS.md"
+
+install_zcode() {
+  echo ""
+  echo "ZCode → $ZCODE_SKILLS_DIR/"
+  if [[ ! -d "$ZCODE_RENDERED" ]]; then
+    echo "  WARNING: $ZCODE_RENDERED not found — run sync-skills.sh first"
+    return
+  fi
+  local count=0
+  for skill_dir in "$ZCODE_RENDERED"/*/; do
+    [[ -f "${skill_dir}SKILL.md" ]] || continue
+    local name; name="$(basename "$skill_dir")"
+    link "$skill_dir" "$ZCODE_SKILLS_DIR/$name"
+    count=$((count + 1))
+  done
+  echo "  $count skills installed"
+
+  echo "ZCode → context symlink $ZCODE_AGENTS"
+  source "$REPO_ROOT/scripts/lib/context-wire.sh"
+  wire_context_mode symlink "$ZCODE_AGENTS" "" "" "" "$REPO_ROOT/AGENTS.md"
+}
+
+uninstall_zcode() {
+  echo ""
+  echo "ZCode → removing management from $ZCODE_CONFIG_DIR/"
+  if [[ -d "$ZCODE_SKILLS_DIR" ]]; then
+    for dst in "$ZCODE_SKILLS_DIR"/*/; do
+      [[ -L "${dst%/}" ]] || continue
+      unlink_if_managed "${dst%/}" "$REPO_ROOT/"
+    done
+  fi
+  unlink_if_managed "$ZCODE_AGENTS" "$REPO_ROOT/"
+}
+
 # ── Codex CLI (e37s15) ───────────────────────────────────────────────────────
 
 CODEX_DIR="$HOME/.codex"
@@ -308,6 +349,7 @@ if $UNINSTALL; then
   uninstall_gemini
   uninstall_pi
   uninstall_hermes
+  uninstall_zcode
   uninstall_cursor
   uninstall_codex
   echo ""
@@ -317,6 +359,7 @@ else
   install_gemini
   install_pi
   install_hermes
+  install_zcode
   install_cursor
   install_codex
   echo ""

--- a/scripts/lib/install-helpers.js
+++ b/scripts/lib/install-helpers.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // story: e60s01
 // story: e61s02
+// story: e76s02
 // install-helpers.js — symlink helpers for bigpowers setup
 
 const fs = require('fs');
@@ -118,6 +119,16 @@ function installGlobal(tool, repoRoot) {
       }
       break;
     }
+    case 'zcode': {
+      const renderedDir = path.join(repoRoot, '.zcode', 'skills');
+      const targetDir = path.join(homeDir, '.zcode', 'skills');
+      linkRenderedSkills(renderedDir, targetDir);
+      const agentsSrc = path.join(repoRoot, 'AGENTS.md');
+      const agentsDst = path.join(homeDir, '.zcode', 'AGENTS.md');
+      fs.mkdirSync(path.dirname(agentsDst), { recursive: true });
+      linkFile(agentsSrc, agentsDst);
+      break;
+    }
     case 'cursor': {
       const rulesSrc = path.join(repoRoot, '.cursor', 'rules');
       const rulesDst = path.join(homeDir, '.cursor', 'rules');
@@ -164,6 +175,16 @@ function installLocal(tool, repoRoot) {
       const targetDir = path.join(cwd, '.hermes', 'skills');
       linkRenderedSkills(renderedDir, targetDir);
       bridgeHermesConfig(path.join(cwd, '.hermes', 'config.yaml'));
+      break;
+    }
+    case 'zcode': {
+      const renderedDir = path.join(repoRoot, '.zcode', 'skills');
+      const targetDir = path.join(cwd, '.zcode', 'skills');
+      linkRenderedSkills(renderedDir, targetDir);
+      const agentsSrc = path.join(repoRoot, 'AGENTS.md');
+      const agentsDst = path.join(cwd, '.zcode', 'AGENTS.md');
+      fs.mkdirSync(path.dirname(agentsDst), { recursive: true });
+      linkFile(agentsSrc, agentsDst);
       break;
     }
     case 'cursor': {
@@ -233,6 +254,20 @@ function uninstallTool(toolId, repoRoot) {
         }
       }
       removeSymlink(path.join(homeDir, '.hermes', 'hooks', 'session-log'));
+      break;
+    }
+    case 'zcode': {
+      const skillsDir = path.join(homeDir, '.zcode', 'skills');
+      if (fs.existsSync(skillsDir)) {
+        for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+          if (!entry.isSymbolicLink()) continue;
+          const target = fs.readlinkSync(path.join(skillsDir, entry.name));
+          if (target.includes('bigpowers') || target.includes('.zcode/skills')) {
+            removeSymlink(path.join(skillsDir, entry.name));
+          }
+        }
+      }
+      removeSymlink(path.join(homeDir, '.zcode', 'AGENTS.md'));
       break;
     }
     case 'cursor':

--- a/scripts/targets.yaml
+++ b/scripts/targets.yaml
@@ -128,6 +128,19 @@ targets:
     contracts:
       - agents_md_exists
 
+  - id: zcode
+    name: ZCode
+    tier: opt_in
+    skill:
+      adapter: zcode
+      output: .zcode/skills
+    context:
+      adapter: zcode
+      mode: symlink
+      file: AGENTS.md
+    contracts:
+      - agents_md_exists
+
   # Wave C (e37s11)
   - id: qwen
     name: Qwen (Alibaba)

--- a/scripts/test-zcode-hub.sh
+++ b/scripts/test-zcode-hub.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# story: e76s02
+# Regression tests for ZCode install hub wiring (Wave B).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+echo "=== test-zcode-hub.sh ==="
+
+INSTALL_SH="$REPO_ROOT/scripts/install.sh"
+HELPERS_JS="$REPO_ROOT/scripts/lib/install-helpers.js"
+SETUP_JS="$REPO_ROOT/bin/setup.js"
+TARGETS_YAML="$REPO_ROOT/scripts/targets.yaml"
+
+grep -q 'install_zcode()' "$INSTALL_SH" && pass 'install.sh: install_zcode()' || fail 'install.sh: missing install_zcode()'
+grep -q 'uninstall_zcode()' "$INSTALL_SH" && pass 'install.sh: uninstall_zcode()' || fail 'install.sh: missing uninstall_zcode()'
+grep -q 'ZCODE_SKILLS_DIR=' "$INSTALL_SH" && pass 'install.sh: ZCODE_SKILLS_DIR' || fail 'install.sh: missing ZCODE_SKILLS_DIR'
+grep -q 'install_zcode' "$INSTALL_SH" && grep -q 'uninstall_zcode' "$INSTALL_SH" && pass 'install.sh: dispatch wired' || fail 'install.sh: dispatch missing zcode'
+
+DRY_OUT="$(bash "$INSTALL_SH" --dry-run 2>&1)"
+echo "$DRY_OUT" | grep -q 'ZCode →' && pass 'dry-run: ZCode section' || fail 'dry-run: missing ZCode section'
+DRY_UNINSTALL="$(bash "$INSTALL_SH" --dry-run --uninstall 2>&1)"
+echo "$DRY_UNINSTALL" | grep -q 'ZCode →' && pass 'dry-run uninstall: ZCode section' || fail 'dry-run uninstall: missing ZCode section'
+
+grep -q "case 'zcode'" "$HELPERS_JS" && pass 'install-helpers: zcode global case' || fail 'install-helpers: missing zcode global case'
+grep -q "case 'zcode'" "$HELPERS_JS" && pass 'install-helpers: zcode cases present' || fail 'install-helpers: missing zcode cases'
+
+SETUP_SRC="$(cat "$SETUP_JS")"
+echo "$SETUP_SRC" | grep -q "SUPPORTED_IDS = new Set" && pass 'setup.js: SUPPORTED_IDS set' || fail 'setup.js: missing SUPPORTED_IDS'
+echo "$SETUP_SRC" | grep -q "'zcode'" "$SETUP_JS" && pass 'setup.js: zcode in TOOLS' || fail 'setup.js: zcode missing from TOOLS'
+echo "$SETUP_SRC" | grep -q "'zcode'" && echo "$SETUP_SRC" | grep -q "SUPPORTED_IDS" \
+  && grep -q "'zcode'" <<< "$(sed -n "/SUPPORTED_IDS = new Set/,/);/p" "$SETUP_JS")" \
+  && pass 'setup.js: zcode in SUPPORTED_IDS' || fail 'setup.js: zcode not in SUPPORTED_IDS'
+
+grep -q 'id: zcode' "$TARGETS_YAML" && pass 'targets.yaml: zcode row' || fail 'targets.yaml: missing zcode row'
+grep -q 'adapter: zcode' "$TARGETS_YAML" && pass 'targets.yaml: zcode adapter' || fail 'targets.yaml: missing zcode adapter'
+grep -q 'output: .zcode/skills' "$TARGETS_YAML" && pass 'targets.yaml: zcode output path' || fail 'targets.yaml: missing zcode output'
+
+grep -q 'install_zcode()' "$REPO_ROOT/scripts/verify-install.sh" && pass 'verify-install: install_zcode assertion' || fail 'verify-install: missing install_zcode assertion'
+
+bash -n "$INSTALL_SH" && pass 'bash -n install.sh' || fail 'bash -n install.sh'
+node --check "$HELPERS_JS" && pass 'node --check install-helpers.js' || fail 'node --check install-helpers.js'
+node --check "$SETUP_JS" && pass 'node --check setup.js' || fail 'node --check setup.js'
+
+echo "test-zcode-hub: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -134,6 +134,11 @@ grep -q 'uninstall_hermes()' "$REPO_ROOT/scripts/install.sh" && ta_pass "source:
 grep -q 'HERMES_SKILLS_DIR=' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: targets ~/.hermes/skills/" || ta_fail "source: wrong hermes target"
 grep -q "'hermes'" "$REPO_ROOT/bin/setup.js" && grep -q 'SUPPORTED_IDS' "$REPO_ROOT/bin/setup.js" && ta_pass "setup.js: hermes supported" || ta_fail "setup.js: hermes not in SUPPORTED_IDS"
 grep -q "case 'hermes'" "$REPO_ROOT/scripts/lib/install-helpers.js" && ta_pass "install-helpers: hermes case" || ta_fail "install-helpers: missing hermes case"
+grep -q 'install_zcode()' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: install_zcode()" || ta_fail "source: missing install_zcode()"
+grep -q 'uninstall_zcode()' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: uninstall_zcode()" || ta_fail "source: missing uninstall_zcode()"
+grep -q 'ZCODE_SKILLS_DIR=' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: targets ~/.zcode/skills/" || ta_fail "source: wrong zcode target"
+grep -q "'zcode'" "$REPO_ROOT/bin/setup.js" && grep -q 'SUPPORTED_IDS' "$REPO_ROOT/bin/setup.js" && ta_pass "setup.js: zcode supported" || ta_fail "setup.js: zcode not in SUPPORTED_IDS"
+grep -q "case 'zcode'" "$REPO_ROOT/scripts/lib/install-helpers.js" && ta_pass "install-helpers: zcode case" || ta_fail "install-helpers: missing zcode case"
 ! grep -q 'install_opencode\|print_opencode_instructions' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: no opencode functions" || ta_fail "source: opencode functions remain"
 
 echo ""

--- a/specs/TRACEABILITY_LATEST.md
+++ b/specs/TRACEABILITY_LATEST.md
@@ -1,17 +1,17 @@
 # Traceability Matrix
 
-**Generated:** 2026-07-24 01:21:58 UTC
-**Total stories:** 84
-**Tagged stories:** 74
+**Generated:** 2026-07-24 14:07:31 UTC
+**Total stories:** 88
+**Tagged stories:** 78
 **Dark stories:** 0
-**Orphan tags:** 149
-**Stale tags:** 74
+**Orphan tags:** 147
+**Stale tags:** 78
 
 ## Oracle Stats
 
-- **High** (explicit tag): 322
-- **Medium** (file heuristic): 2522
-- **Low** (task reference): 63
+- **High** (explicit tag): 349
+- **Medium** (file heuristic): 1711
+- **Low** (task reference): 64
 
 ## Story Coverage
 
@@ -22,11 +22,11 @@
 | e37s03 | seed-conventions — .aider.conf.yml read:AGENTS.md bridge for | e37 | 1 | 7.0 | done | 8 |
 | e37s04 | verify-install.sh — AGENTS.md spine assertions (OSS P1 + opt | e37 | 2 | 7.0 | done | 4 |
 | e37s05 | scripts/targets.yaml — declarative integration registry for  | e37 | 5 | 7.0 | done | 25 |
-| e37s06 | scripts/generate-context-bundle.sh — AGENTS.md single source | e37 | 3 | 7.0 | done | 12 |
+| e37s06 | scripts/generate-context-bundle.sh — AGENTS.md single source | e37 | 3 | 7.0 | done | 11 |
 | e37s07 | sync-skills.sh — adapter dispatch from targets.yaml | e37 | 5 | 7.0 | done | 12 |
 | e37s08 | verify-install.sh — per-target contract matrix from targets. | e37 | 3 | 7.0 | done | 10 |
 | e37s09 | targets.yaml — Wave A: Goose (OSS) + Antigravity agy (propri | e37 | 3 | 7.0 | done | 5 |
-| e37s10 | targets.yaml — Wave B: zed, omp, hermes (skills-dir adapters | e37 | 4 | 7.0 | done | 7 |
+| e37s10 | targets.yaml — Wave B: zed, omp, hermes (skills-dir adapters | e37 | 4 | 7.0 | done | 8 |
 | e37s11 | targets.yaml — Wave C: qwen, kilocode (markdown commands + r | e37 | 3 | 7.0 | done | 4 |
 | e37s12 | targets.yaml — Wave D: continue (rules adapter; re-opened ac | e37 | 2 | 7.0 | done | 4 |
 | e37s13 | targets.yaml — Wave E: iflow, vibe, shai (markdown commands; | e37 | 2 | 7.0 | done | 6 |
@@ -39,9 +39,9 @@
 | e45s04 | slice-tasks / plan-work: pre-build cross-artifact consistenc | e45 | 3 | 5.0 | done | 15 |
 | e45s05 | verify-work / gate-trace: adversarial gap-finding completene | e45 | 4 | 5.0 | done | 30 |
 | e45s06 | tasks.yaml: literal failing→passing task ledger | e45 | 2 | 5.0 | done | 2 |
-| e45s07 | request-review: dual-blind AND-gate review (Santa Method) | e45 | 2 | 5.0 | done | 31 |
+| e45s07 | request-review: dual-blind AND-gate review (Santa Method) | e45 | 2 | 5.0 | done | 35 |
 | e45s08 | develop-tdd / validate-fix: two-commit red/green regression  | e45 | 2 | 5.0 | done | 11 |
-| e45s09 | verify-work / plan-work: Pre-Implementation and Validation g | e45 | 2 | 5.0 | done | 72 |
+| e45s09 | verify-work / plan-work: Pre-Implementation and Validation g | e45 | 2 | 5.0 | done | 71 |
 | e45s10 | docs/references: auto-regenerate from source-of-truth docs v | e45 | 2 | 5.0 | done | 7 |
 | e45s11 | orchestration / dispatch-agents: typed message protocol + 3- | e45 | 2 | 5.0 | done | 9 |
 | e45s12 | stocktake-skills / craft-skill: code-enforced validator + au | e45 | 2 | 5.0 | done | 33 |
@@ -49,8 +49,8 @@
 | e45s14 | deepen-architecture: declared import-boundary allowlist enfo | e45 | 2 | 5.0 | done | 7 |
 | e45s15 | release-branch / deploy: three-independent-facts verificatio | e45 | 2 | 5.0 | done | 13 |
 | e45s16 | CLAUDE.md rtk mandate: wire rtk-ai/rtk PreToolUse hook | e45 | 2 | 5.0 | done | 4 |
-| e45s17 | request-review: fan-out to parallel review subagents | e45 | 2 | 5.0 | done | 23 |
-| e45s18 | audit-code / security-review: worktree-isolated parallel che | e45 | 2 | 5.0 | done | 531 |
+| e45s17 | request-review: fan-out to parallel review subagents | e45 | 2 | 5.0 | done | 27 |
+| e45s18 | audit-code / security-review: worktree-isolated parallel che | e45 | 2 | 5.0 | done | 267 |
 | e45s19 | Context7: bounded retry cap and explicit fallback block | e45 | 2 | 5.0 | done | 8 |
 | e45s20 | Context7 / bts docs: wrap in ETag-revalidated fetch cache | e45 | 2 | 5.0 | done | 1 |
 | e45s21 | seed-conventions / AGENTS.md: self-installing fenced markers | e45 | 2 | 5.0 | done | 15 |
@@ -63,7 +63,7 @@
 | e45s28 | request-review: hard max-iteration cap | e45 | 2 | 5.0 | done | 10 |
 | e45s29 | requirements: ADDED/MODIFIED/REMOVED/RENAMED tags | e45 | 2 | 5.0 | done | 15 |
 | e45s30 | subagent depth: formalize depth tiers | e45 | 2 | 5.0 | done | 10 |
-| e45s31 | audit-code / deepen-architecture: churn-based look-here-firs | e45 | 2 | 5.0 | done | 528 |
+| e45s31 | audit-code / deepen-architecture: churn-based look-here-firs | e45 | 2 | 5.0 | done | 264 |
 | e45s32 | gate-trace / release-branch: adversarial-review refute frami | e45 | 2 | 5.0 | done | 27 |
 | e45s33 | requirements: per-section approval state | e45 | 2 | 5.0 | done | 3 |
 | e45s34 | develop-tdd: snapshot-before-transition hardening | e45 | 2 | 5.0 | done | 6 |
@@ -74,11 +74,11 @@
 | e45s39 | PR generation: literal provenance marker | e45 | 2 | 5.0 | done | 5 |
 | e45s40 | verify-work: mandatory real-browser verification | e45 | 2 | 5.0 | done | 15 |
 | e45s41 | security-review: proven authorship SQL-safety doctrine | e45 | 2 | 5.0 | done | 10 |
-| e48s01 | Generate epics-wiki and adr-wiki as OKF concept bundles from | e48 | 2 | 2.5 | done | 30 |
-| e48s02 | Emit verification reports as OKF bundles from run-golden-sui | e48 | 2 | 2.5 | done | 39 |
-| e48s03 | OKF-ify bug-registry: specs/bugs/registry.yaml emits concept | e48 | 1 | 2.5 | done | 128 |
+| e48s01 | Generate epics-wiki and adr-wiki as OKF concept bundles from | e48 | 2 | 2.5 | done | 29 |
+| e48s02 | Emit verification reports as OKF bundles from run-golden-sui | e48 | 2 | 2.5 | done | 25 |
+| e48s03 | OKF-ify bug-registry: specs/bugs/registry.yaml emits concept | e48 | 1 | 2.5 | done | 127 |
 | e48s04 | Create viz.html — interactive force-layout graph companion f | e48 | 2 | 2.5 | done | 10 |
-| e48s05 | Wire OKF validation into CI (sync-skills.yml) and document i | e48 | 1 | 2.5 | done | 158 |
+| e48s05 | Wire OKF validation into CI (sync-skills.yml) and document i | e48 | 1 | 2.5 | done | 144 |
 | e48s06 | Add tier: field (core/extended/specialized) to OKF wiki inde | e48 | 2 | 2.5 | done | 9 |
 | e48s07 | Create publish-to-wiki kernel tool | e48 | 3 | 2.5 | done | 2 |
 | e48s08 | Add GitHub Action Template for publish-wiki.yml [HARD GATE] | e48 | 1 | 2.5 | done | 8 |
@@ -92,7 +92,7 @@
 | e51s01 | CONVENTIONS — Always Green, Shift Left, Discovered Defects,  | e51 | 3 | 7.0 | done | 8 |
 | e51s02 | seed-conventions — Preflight default, solo-git default, embe | e51 | 3 | 7.0 | done | 22 |
 | e51s03 | kickoff-branch + verify-work — Preflight hard block and CI g | e51 | 2 | 7.0 | done | 46 |
-| e51s04 | audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log rou | e51 | 2 | 7.0 | done | 576 |
+| e51s04 | audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log rou | e51 | 2 | 7.0 | done | 312 |
 | e51s05 | CLAUDE.md — solo-default agent rules + bigpowers Preflight c | e51 | 2 | 7.0 | done | 7 |
 | e54s01 | Snapshot the current skill catalog as an immutable baseline | e54 | 2 | 6.7 | done | 9 |
 | e54s02 | Add a soft drift-detection gate for the freeze window | e54 | 3 | 6.7 | done | 14 |
@@ -101,6 +101,10 @@
 | e55s02 | Write constitution.md from the mapping, CLAUDE.md/CONVENTION | e55 | 0 | 6.0 | done | 5 |
 | e55s03 | Point CLAUDE.md/CONVENTIONS.md at constitution.md, don't del | e55 | 0 | 6.0 | done | 9 |
 | e60s01 | Interactive installer with ASCII banner, global/local, tool  | e60 | 0 | 9.0 | done | 3 |
+| e61s01 | Hermes adapter + hook templates (Wave A) | e61 | 0 | 5.0 | done | 9 |
+| e61s02 | Install hub wiring (Wave B) | e61 | 0 | 5.0 | done | 7 |
+| e76s01 | ZCode adapter — Wave A greenfield skills-dir | e76 | 0 | 5.0 | done | 7 |
+| e76s02 | Install hub wiring (Wave B) | e76 | 0 | 5.0 | done | 9 |
 
 ## Orphan Tags (tag in code, no matching story)
 
@@ -236,8 +240,6 @@
 - `e42s02`
 - `e42s03`
 - `e42s04`
-- `e43s01`
-- `e43s02`
 - `e44s01`
 - `e44s02`
 - `e44s03`
@@ -330,3 +332,7 @@
 - `e55s02`
 - `e55s03`
 - `e60s01`
+- `e61s01`
+- `e61s02`
+- `e76s01`
+- `e76s02`

--- a/specs/codebase-wiki/e37s06.md
+++ b/specs/codebase-wiki/e37s06.md
@@ -40,10 +40,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: website/src/content/docs/decisions/0007-agents-md-spine-context-derivatives.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/epics/archive/e37-reach/e37s08-tasks.yaml
     line: 0
     confidence: low
@@ -74,7 +70,6 @@ links:
 - `specs/verifications/steps/and-files-should-be-small-enough-to-avoid-context-window-truncation-300-lines.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-i-should-automatically-bootstrap-project-context-at-session-start.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/adr-wiki/0007-agents-md-spine-context-derivatives.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `website/src/content/docs/decisions/0007-agents-md-spine-context-derivatives.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/archive/e37-reach/e37s08-tasks.yaml` (line 0, confidence: low, method: task_reference)
 - `specs/epics/archive/e37-reach/e37s07-tasks.yaml` (line 0, confidence: low, method: task_reference)
 - `specs/epics/archive/e37-reach/e37s10-tasks.yaml` (line 0, confidence: low, method: task_reference)

--- a/specs/codebase-wiki/e37s10.md
+++ b/specs/codebase-wiki/e37s10.md
@@ -36,6 +36,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/epics/e61-integration-hermes/e61s01-tasks.yaml
+    line: 0
+    confidence: low
+    method: task_reference
 ---
 
 # e37s10: targets.yaml — Wave B: zed, omp, hermes (skills-dir adapters)
@@ -53,3 +57,4 @@ links:
 - `scripts/adapters/hermes.sh` (line 2, confidence: high, method: explicit_tag)
 - `specs/bugs/BUG-2026-07-07-compliance-record-cycle-time-oversized.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-07-compliance-record-cycle-time-oversized.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/epics/e61-integration-hermes/e61s01-tasks.yaml` (line 0, confidence: low, method: task_reference)

--- a/specs/codebase-wiki/e45s07.md
+++ b/specs/codebase-wiki/e45s07.md
@@ -44,6 +44,22 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/REVIEW-e63-closeout.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/REVIEW-e60-closeout.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/REVIEW-e77-closeout.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/REVIEW-e78-closeout.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/steps/and-i-should-present-multiple-interpretations-of-ambiguous-requests.sh
     line: 0
     confidence: medium
@@ -151,6 +167,10 @@ links:
 - `specs/adr/0005-hard-gate-mandate.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/wayfinder/doc-templates/tickets/T14-security-review.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/security/REVIEW.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/REVIEW-e63-closeout.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/REVIEW-e60-closeout.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/REVIEW-e77-closeout.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/REVIEW-e78-closeout.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-i-should-present-multiple-interpretations-of-ambiguous-requests.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-i-should-enforce-a-two-stage-review-gate.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-i-should-reject-work-that-fails-its-risk-tier-verification-gate.sh` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s09.md
+++ b/specs/codebase-wiki/e45s09.md
@@ -224,10 +224,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: website/dist/pagefind/pagefind-worker.js
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: website/src/content/docs/guides/WORKFLOW-SOP-v2.md
     line: 0
     confidence: medium
@@ -360,7 +356,6 @@ links:
 - `.continue/rules/verify-work.md` (line 0, confidence: medium, method: file_heuristic)
 - `.continue/rules/compose-workflow.md` (line 0, confidence: medium, method: file_heuristic)
 - `.continue/rules/organize-workspace.md` (line 0, confidence: medium, method: file_heuristic)
-- `website/dist/pagefind/pagefind-worker.js` (line 0, confidence: medium, method: file_heuristic)
 - `website/src/content/docs/guides/WORKFLOW-SOP-v2.md` (line 0, confidence: medium, method: file_heuristic)
 - `website/src/content/docs/skills/scope-work.mdx` (line 0, confidence: medium, method: file_heuristic)
 - `website/src/content/docs/skills/compose-workflow.mdx` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s16.md
+++ b/specs/codebase-wiki/e45s16.md
@@ -13,7 +13,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: scripts/install.sh
-    line: 88
+    line: 90
     confidence: high
     method: explicit_tag
   - file: scripts/hooks/rtk-rewrite.sh
@@ -35,6 +35,6 @@ links:
 ## Implemented In
 
 - `scripts/install.sh` (line 2, confidence: high, method: explicit_tag)
-- `scripts/install.sh` (line 88, confidence: high, method: explicit_tag)
+- `scripts/install.sh` (line 90, confidence: high, method: explicit_tag)
 - `scripts/hooks/rtk-rewrite.sh` (line 2, confidence: high, method: explicit_tag)
 - `specs/agent-guide/rtk-commands-by-workflow.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s17.md
+++ b/specs/codebase-wiki/e45s17.md
@@ -36,6 +36,22 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/REVIEW-e63-closeout.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/REVIEW-e60-closeout.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/REVIEW-e77-closeout.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/REVIEW-e78-closeout.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/steps/and-i-should-enforce-a-two-stage-review-gate.sh
     line: 0
     confidence: medium
@@ -117,6 +133,10 @@ links:
 - `specs/skills-wiki/skills/respond-review.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/wayfinder/doc-templates/tickets/T14-security-review.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/security/REVIEW.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/REVIEW-e63-closeout.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/REVIEW-e60-closeout.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/REVIEW-e77-closeout.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/REVIEW-e78-closeout.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-i-should-enforce-a-two-stage-review-gate.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-i-should-use-fresh-subagent-context-for-independent-reviews.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/workflows/code-review.yaml` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s18.md
+++ b/specs/codebase-wiki/e45s18.md
@@ -48,14 +48,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190334.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-144556.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-175346.md
     line: 0
     confidence: medium
@@ -64,31 +56,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-102313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-103815.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163934.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202335.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145222.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165427.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132836.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -100,23 +68,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-155647.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181947.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212931.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-160106.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-180858.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -125,30 +77,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-143153.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215320.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-172717.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174039.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132651.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212830.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182718.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -161,10 +89,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-122420.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183547.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -192,10 +116,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-160627.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-165137.md
     line: 0
     confidence: medium
@@ -204,27 +124,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-205519.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101228.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-102150.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214411.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260622-001710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-165047.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -233,18 +133,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-000102.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133327.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001605.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105239.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -260,35 +148,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101847.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173628.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182629.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154217.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-165703.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-143839.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163159.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260711-001225.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -300,23 +164,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-185319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183644.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260629-132810.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001328.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -328,19 +176,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-202226.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164609.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192340.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165651.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -352,27 +188,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-160550.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-134603.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091641.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163954.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-210053.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190002.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -381,18 +197,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164251.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132615.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-172212.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-140513.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -412,23 +216,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154135.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170532.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154323.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-082500.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101730.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -440,67 +232,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-165007.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-205711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-182236.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-135136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-103737.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-213042.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-134029.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164826.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-162400.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110426.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-223023.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-134126.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-162245.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-105652.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-114127.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154055.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -516,19 +252,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164801.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131809.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-175313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181604.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -544,19 +268,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-110149.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-181656.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174414.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -564,15 +276,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192541.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-233740.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173515.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -580,27 +284,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190415.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192435.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-125910.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215656.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-135950.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092605.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -616,14 +300,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154936.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132530.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174045.md
     line: 0
     confidence: medium
@@ -636,23 +312,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091938.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-133945.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174055.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001312.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110458.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -692,39 +352,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105145.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-193609.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174351.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-154353.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-131211.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-130715.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182555.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-124641.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -736,23 +368,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120114.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-234357.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110242.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-143756.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-235505.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -776,10 +392,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001100.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-150417.md
     line: 0
     confidence: medium
@@ -796,27 +408,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-185913.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-154427.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-140559.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001518.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-184837.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -832,31 +428,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-154541.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-105728.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-111510.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-180901.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-133532.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145423.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-141624.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -872,18 +448,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181236.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163830.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092533.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174025.md
     line: 0
     confidence: medium
@@ -892,35 +456,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145349.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-205433.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132944.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163746.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-091141.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184856.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-143844.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133446.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -929,30 +465,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-223425.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-182836.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202450.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194130.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-213831.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174245.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -972,19 +484,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-005225.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-143007.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-171058.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-150742.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1024,31 +524,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-154637.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001919.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-220941.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174117.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-093202.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110206.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120150.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1064,31 +540,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131734.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182807.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173917.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-185210.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-101322.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165256.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192433.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1096,23 +548,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105013.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-200110.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-114242.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001233.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-162439.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1120,27 +556,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002229.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-144202.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183102.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-133837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-233707.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212919.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1156,19 +576,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164345.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120250.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165035.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-112952.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1180,39 +588,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194053.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001439.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202651.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-143840.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-000955.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-144557.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174133.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115538.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-113034.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1224,31 +604,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-161502.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170255.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164704.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132813.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164342.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-120815.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154835.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1260,27 +620,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-155747.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173218.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260626-204822.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202348.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-161543.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1292,10 +636,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-113257.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-181044.md
     line: 0
     confidence: medium
@@ -1304,23 +644,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-133458.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164823.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-180900.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-104009.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1333,10 +657,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-081735.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-154818.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1356,10 +676,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170738.md
     line: 0
     confidence: medium
@@ -1373,10 +689,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-153801.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194215.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1396,23 +708,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084719.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132017.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-171157.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183350.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-150937.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1428,14 +724,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-110050.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001337.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260627-133613.md
     line: 0
     confidence: medium
@@ -1448,27 +736,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-220404.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-085740.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-223359.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-193756.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163218.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163309.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1484,15 +756,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202442.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164036.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1508,27 +772,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214125.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132604.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-142359.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132933.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-175550.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174408.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1540,10 +788,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182339.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165418.md
     line: 0
     confidence: medium
@@ -1552,23 +796,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-155114.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133637.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-005655.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165222.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-131140.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1608,35 +840,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202558.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170940.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-163657.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215213.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-204345.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-153739.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175227.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1645,38 +853,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-225313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164721.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-093336.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132207.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130940.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105058.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084617.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084805.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174631.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1692,27 +868,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002322.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-220022.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-135838.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-152233.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181159.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1724,27 +880,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131350.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-083101.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260626-214501.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115557.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-114525.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-093128.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1756,43 +896,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212552.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181706.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092013.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001702.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132130.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-163956.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001902.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-093246.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-204300.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1808,14 +912,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132858.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165902.md
     line: 0
     confidence: medium
@@ -1824,19 +920,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001029.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-172425.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145255.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-133730.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1844,43 +928,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175929.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-172525.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133254.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184658.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164258.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194009.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260629-130359.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130821.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190539.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1892,27 +944,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-163613.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-142458.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-005318.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-235409.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001952.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1924,27 +956,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002154.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-171134.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-182630.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165733.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091717.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084911.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1960,31 +972,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182346.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115503.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-101402.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-231038.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-123626.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184355.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-172751.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1992,27 +980,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101633.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130900.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-103924.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101425.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-163837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175105.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2028,15 +996,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-234704.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163238.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-172133.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2044,19 +1004,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214329.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-144506.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-210010.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173306.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2073,10 +1021,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-151341.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131314.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2152,158 +1096,73 @@ links:
 - `specs/skills-wiki/skills/security-review.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/audit-code.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/wayfinder/doc-templates/tickets/T14-security-review.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190334.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-144556.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-175346.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-165245.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-102313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-103815.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163934.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202335.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145222.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165427.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132836.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180022.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163733.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-155647.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181947.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212931.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160106.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-180858.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181109.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143153.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215320.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-172717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174039.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132651.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212830.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182718.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170744.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005609.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-122420.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183547.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-205129.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-081618.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-162136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234209.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-160627.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-165137.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223301.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-205519.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101228.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-102150.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214411.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260622-001710.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-165047.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165920.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000102.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133327.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001605.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105239.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181904.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150326.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170432.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101847.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173628.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182629.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154217.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-165703.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-143839.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163159.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260711-001225.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-010055.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163108.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-185319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183644.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215759.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132810.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001328.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-235439.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164718.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-202226.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192340.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165651.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172406.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173408.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-160550.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-134603.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091641.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163954.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-210053.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190002.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-222132.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164251.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132615.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-172212.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-140513.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170547.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173125.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180244.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170506.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154135.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170532.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154323.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082500.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101730.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170710.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-205844.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-165007.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-205711.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-182236.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-135136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-103737.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-213042.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-134029.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164826.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-162400.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110426.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223023.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-134126.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-162245.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-105652.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-114127.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154055.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170704.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173014.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174734.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164801.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131809.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181604.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163821.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-201018.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-165945.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-110149.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105711.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181656.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174414.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142931.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192541.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-233740.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173515.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-090946.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190415.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192435.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-125910.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215656.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-135950.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092605.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-225914.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165619.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154936.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132530.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174045.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-131004.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091938.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-133945.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174055.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001312.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164534.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005128.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-235526.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2313,80 +1172,40 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260703-005444.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223636.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181759.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105145.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-193609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174351.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154353.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-131211.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130715.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182555.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-124641.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-083430.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080042.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120114.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234357.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110242.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-143756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-235505.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-220905.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160732.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164627.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143840.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-214041.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001100.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150417.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155813.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164603.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143504.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-185913.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-154427.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-140559.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001518.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-184837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170909.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154246.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-154541.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-105728.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-111510.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180901.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-133532.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145423.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-141624.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164911.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174207.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181236.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163830.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092533.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174025.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204652.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145349.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-205433.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132944.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163746.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-091141.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184856.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-143844.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133446.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-154339.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223425.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-182836.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202450.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133710.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194130.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-213831.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174245.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005800.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173348.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005515.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165022.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-005225.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-143007.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-171058.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-150742.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164733.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165618.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164707.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2396,143 +1215,76 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260704-083149.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170223.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164441.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-154637.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001919.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-220941.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174117.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-093202.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110206.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120150.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080057.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170448.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131734.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182807.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173917.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-185210.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-101322.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165256.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192433.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165207.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105013.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200110.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-114242.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001233.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-162439.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130939.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002229.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-144202.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183102.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-133837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-233707.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212919.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163256.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005720.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164345.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120250.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165035.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-112952.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130756.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130915.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194053.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001439.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202651.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-143840.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-000955.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-144557.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174133.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115538.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-113034.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164833.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181114.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-161502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170255.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164704.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132813.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164342.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-120815.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154835.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165959.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164817.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164759.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155747.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173218.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204822.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202348.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-161543.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155551.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-125842.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-113257.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181044.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223249.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-133458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164823.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-180900.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-104009.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234324.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180916.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-081735.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-154818.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-161735.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005423.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130845.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200055.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170738.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163839.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005546.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153801.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194215.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200030.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-004248.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154311.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204755.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084719.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132017.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-171157.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183350.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-150937.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-091017.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082326.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175521.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-110050.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001337.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260627-133613.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-195653.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005358.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-220404.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-085740.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-193756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163218.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163309.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130821.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-145833.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142423.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202442.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164036.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165346.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080024.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142902.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214125.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132604.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132933.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175550.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174408.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-080343.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082306.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182339.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165418.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143447.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-155114.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133637.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005655.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165222.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-131140.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165111.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154214.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181546.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2542,124 +1294,52 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260629-132750.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164343.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163338.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202558.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170940.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-163657.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215213.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-204345.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212711.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153739.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175227.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180125.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-225313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164721.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-093336.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132207.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130940.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105058.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084617.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084805.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174631.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174148.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000357.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-222115.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002322.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-220022.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164429.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-135838.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-152233.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181159.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164518.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131350.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-083101.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-214501.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115557.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-114525.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-093128.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-221847.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-004226.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212552.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181706.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092013.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001702.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132130.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182429.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163956.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001902.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-093246.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-204300.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164141.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173033.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164050.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132858.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174710.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165902.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005336.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001029.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172425.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145255.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-133730.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154726.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154759.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175929.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172525.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133254.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184658.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164258.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194009.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130821.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190539.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170706.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170757.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-163613.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173429.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142458.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-005318.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-235409.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001952.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-195845.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-164155.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002154.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-171134.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-182630.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165733.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084911.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130700.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172925.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182346.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115503.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-101402.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-231038.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-123626.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184355.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-172751.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170431.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101633.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130900.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-103924.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101425.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163837.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175105.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000548.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150200.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175152.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-234704.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163238.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-172133.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180948.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214329.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-144506.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-210010.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173306.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260622-001925.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164958.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165537.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-151341.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131314.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-185054.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-audit-code-auditor-oversized.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-audit-code-auditor-oversized.okf.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s31.md
+++ b/specs/codebase-wiki/e45s31.md
@@ -48,14 +48,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190334.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-144556.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-175346.md
     line: 0
     confidence: medium
@@ -64,31 +56,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-102313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-103815.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163934.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202335.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145222.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165427.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132836.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -100,23 +68,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-155647.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181947.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212931.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-160106.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-180858.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -125,30 +77,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-143153.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215320.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-172717.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174039.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132651.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212830.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182718.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -161,10 +89,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-122420.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183547.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -192,10 +116,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-160627.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-165137.md
     line: 0
     confidence: medium
@@ -204,27 +124,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-205519.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101228.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-102150.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214411.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260622-001710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-165047.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -233,18 +133,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-000102.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133327.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001605.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105239.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -260,35 +148,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101847.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173628.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182629.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154217.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-165703.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-143839.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163159.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260711-001225.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -300,23 +164,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-185319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183644.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260629-132810.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001328.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -328,19 +176,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-202226.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164609.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192340.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165651.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -352,27 +188,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-160550.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-134603.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091641.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163954.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-210053.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190002.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -381,18 +197,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164251.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132615.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-172212.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-140513.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -412,23 +216,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154135.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170532.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154323.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-082500.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101730.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -440,67 +232,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-165007.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-205711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-182236.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-135136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-103737.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-213042.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-134029.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164826.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-162400.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110426.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-223023.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-134126.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-162245.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-105652.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-114127.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154055.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -516,19 +252,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164801.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131809.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-175313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181604.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -544,19 +268,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-110149.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-181656.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174414.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -564,15 +276,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192541.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-233740.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173515.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -580,27 +284,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190415.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192435.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-125910.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215656.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-135950.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092605.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -616,14 +300,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154936.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132530.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174045.md
     line: 0
     confidence: medium
@@ -636,23 +312,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091938.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-133945.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174055.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001312.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110458.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -692,39 +352,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105145.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-193609.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174351.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-154353.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-131211.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-130715.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182555.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-124641.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -736,23 +368,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120114.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-234357.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110242.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-143756.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-235505.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -776,10 +392,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001100.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-150417.md
     line: 0
     confidence: medium
@@ -796,27 +408,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-185913.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-154427.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-140559.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001518.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-184837.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -832,31 +428,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-154541.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-105728.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-111510.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-180901.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-133532.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145423.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-141624.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -872,18 +448,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181236.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163830.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092533.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174025.md
     line: 0
     confidence: medium
@@ -892,35 +456,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145349.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-205433.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132944.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163746.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-091141.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184856.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-143844.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133446.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -929,30 +465,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-223425.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-182836.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202450.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194130.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-213831.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174245.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -972,19 +484,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-005225.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-143007.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-171058.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-150742.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1024,31 +524,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-154637.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001919.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-220941.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174117.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-093202.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110206.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120150.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1064,31 +540,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131734.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182807.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173917.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-185210.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-101322.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165256.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192433.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1096,23 +548,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105013.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-200110.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-114242.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001233.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-162439.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1120,27 +556,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002229.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-144202.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183102.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-133837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-233707.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212919.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1156,19 +576,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164345.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120250.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165035.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-112952.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1180,39 +588,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194053.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001439.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202651.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-143840.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-000955.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-144557.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174133.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115538.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-113034.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1224,31 +604,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-161502.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170255.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164704.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132813.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164342.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-120815.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154835.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1260,27 +620,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-155747.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173218.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260626-204822.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202348.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-161543.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1292,10 +636,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-113257.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-181044.md
     line: 0
     confidence: medium
@@ -1304,23 +644,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-133458.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164823.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-180900.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-104009.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1333,10 +657,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-081735.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-154818.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1356,10 +676,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170738.md
     line: 0
     confidence: medium
@@ -1373,10 +689,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-153801.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194215.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1396,23 +708,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084719.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132017.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-171157.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183350.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-150937.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1428,14 +724,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-110050.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001337.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260627-133613.md
     line: 0
     confidence: medium
@@ -1448,27 +736,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-220404.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-085740.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-223359.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-193756.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163218.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163309.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1484,15 +756,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202442.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164036.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1508,27 +772,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214125.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132604.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-142359.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132933.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-175550.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174408.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1540,10 +788,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182339.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165418.md
     line: 0
     confidence: medium
@@ -1552,23 +796,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-155114.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133637.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-005655.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165222.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-131140.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1608,35 +840,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202558.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170940.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-163657.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215213.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-204345.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-153739.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175227.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1645,38 +853,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-225313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164721.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-093336.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132207.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130940.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105058.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084617.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084805.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174631.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1692,27 +868,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002322.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-220022.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-135838.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-152233.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181159.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1724,27 +880,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131350.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-083101.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260626-214501.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115557.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-114525.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-093128.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1756,43 +896,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212552.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181706.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092013.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001702.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132130.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-163956.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001902.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-093246.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-204300.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1808,14 +912,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132858.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165902.md
     line: 0
     confidence: medium
@@ -1824,19 +920,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001029.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-172425.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145255.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-133730.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1844,43 +928,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175929.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-172525.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133254.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184658.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164258.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194009.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260629-130359.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130821.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190539.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1892,27 +944,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-163613.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-142458.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-005318.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-235409.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001952.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1924,27 +956,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002154.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-171134.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-182630.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165733.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091717.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084911.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1960,31 +972,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182346.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115503.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-101402.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-231038.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-123626.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184355.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-172751.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1992,27 +980,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101633.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130900.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-103924.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101425.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-163837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175105.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2028,15 +996,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-234704.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163238.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-172133.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2044,19 +1004,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214329.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-144506.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-210010.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173306.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2073,10 +1021,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-151341.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131314.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2140,158 +1084,73 @@ links:
 - `specs/verifications/steps/and-there-should-be-no-commented-out-code-c5.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-there-should-be-no-code-duplication-dry-g5.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-there-should-be-no-redundant-comments-that-restate-code.sh` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190334.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-144556.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-175346.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-165245.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-102313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-103815.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163934.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202335.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145222.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165427.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132836.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180022.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163733.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-155647.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181947.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212931.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160106.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-180858.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181109.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143153.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215320.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-172717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174039.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132651.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212830.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182718.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170744.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005609.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-122420.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183547.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-205129.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-081618.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-162136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234209.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-160627.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-165137.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223301.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-205519.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101228.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-102150.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214411.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260622-001710.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-165047.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165920.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000102.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133327.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001605.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105239.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181904.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150326.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170432.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101847.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173628.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182629.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154217.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-165703.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-143839.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163159.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260711-001225.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-010055.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163108.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-185319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183644.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215759.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132810.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001328.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-235439.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164718.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-202226.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192340.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165651.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172406.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173408.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-160550.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-134603.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091641.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163954.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-210053.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190002.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-222132.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164251.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132615.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-172212.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-140513.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170547.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173125.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180244.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170506.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154135.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170532.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154323.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082500.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101730.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170710.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-205844.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-165007.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-205711.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-182236.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-135136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-103737.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-213042.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-134029.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164826.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-162400.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110426.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223023.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-134126.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-162245.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-105652.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-114127.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154055.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170704.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173014.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174734.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164801.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131809.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181604.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163821.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-201018.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-165945.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-110149.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105711.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181656.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174414.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142931.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192541.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-233740.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173515.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-090946.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190415.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192435.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-125910.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215656.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-135950.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092605.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-225914.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165619.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154936.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132530.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174045.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-131004.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091938.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-133945.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174055.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001312.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164534.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005128.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-235526.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2301,80 +1160,40 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260703-005444.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223636.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181759.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105145.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-193609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174351.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154353.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-131211.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130715.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182555.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-124641.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-083430.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080042.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120114.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234357.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110242.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-143756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-235505.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-220905.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160732.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164627.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143840.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-214041.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001100.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150417.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155813.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164603.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143504.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-185913.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-154427.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-140559.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001518.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-184837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170909.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154246.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-154541.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-105728.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-111510.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180901.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-133532.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145423.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-141624.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164911.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174207.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181236.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163830.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092533.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174025.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204652.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145349.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-205433.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132944.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163746.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-091141.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184856.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-143844.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133446.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-154339.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223425.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-182836.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202450.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133710.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194130.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-213831.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174245.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005800.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173348.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005515.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165022.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-005225.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-143007.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-171058.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-150742.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164733.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165618.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164707.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2384,143 +1203,76 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260704-083149.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170223.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164441.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-154637.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001919.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-220941.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174117.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-093202.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110206.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120150.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080057.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170448.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131734.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182807.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173917.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-185210.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-101322.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165256.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192433.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165207.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105013.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200110.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-114242.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001233.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-162439.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130939.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002229.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-144202.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183102.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-133837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-233707.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212919.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163256.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005720.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164345.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120250.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165035.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-112952.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130756.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130915.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194053.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001439.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202651.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-143840.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-000955.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-144557.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174133.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115538.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-113034.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164833.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181114.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-161502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170255.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164704.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132813.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164342.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-120815.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154835.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165959.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164817.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164759.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155747.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173218.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204822.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202348.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-161543.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155551.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-125842.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-113257.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181044.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223249.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-133458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164823.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-180900.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-104009.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234324.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180916.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-081735.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-154818.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-161735.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005423.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130845.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200055.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170738.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163839.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005546.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153801.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194215.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200030.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-004248.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154311.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204755.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084719.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132017.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-171157.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183350.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-150937.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-091017.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082326.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175521.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-110050.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001337.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260627-133613.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-195653.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005358.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-220404.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-085740.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-193756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163218.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163309.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130821.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-145833.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142423.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202442.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164036.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165346.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080024.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142902.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214125.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132604.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132933.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175550.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174408.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-080343.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082306.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182339.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165418.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143447.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-155114.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133637.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005655.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165222.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-131140.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165111.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154214.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181546.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2530,124 +1282,52 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260629-132750.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164343.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163338.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202558.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170940.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-163657.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215213.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-204345.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212711.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153739.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175227.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180125.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-225313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164721.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-093336.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132207.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130940.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105058.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084617.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084805.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174631.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174148.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000357.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-222115.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002322.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-220022.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164429.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-135838.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-152233.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181159.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164518.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131350.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-083101.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-214501.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115557.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-114525.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-093128.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-221847.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-004226.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212552.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181706.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092013.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001702.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132130.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182429.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163956.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001902.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-093246.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-204300.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164141.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173033.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164050.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132858.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174710.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165902.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005336.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001029.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172425.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145255.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-133730.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154726.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154759.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175929.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172525.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133254.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184658.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164258.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194009.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130821.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190539.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170706.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170757.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-163613.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173429.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142458.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-005318.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-235409.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001952.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-195845.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-164155.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002154.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-171134.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-182630.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165733.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084911.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130700.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172925.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182346.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115503.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-101402.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-231038.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-123626.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184355.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-172751.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170431.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101633.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130900.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-103924.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101425.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163837.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175105.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000548.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150200.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175152.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-234704.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163238.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-172133.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180948.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214329.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-144506.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-210010.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173306.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260622-001925.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164958.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165537.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-151341.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131314.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-185054.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-audit-code-auditor-oversized.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-audit-code-auditor-oversized.okf.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e48s01.md
+++ b/specs/codebase-wiki/e48s01.md
@@ -92,10 +92,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: website/src/content/docs/skills/maintain-wiki.mdx
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: docs/references/agent-config-files-and-okf.md
     line: 0
     confidence: medium
@@ -159,7 +155,6 @@ links:
 - `specs/epics/archive/e39-knowledge-graph/e39s08-integrate-maintain-wiki.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/archive/e39-knowledge-graph/e39s07-maintain-wiki-skill.md` (line 0, confidence: medium, method: file_heuristic)
 - `.continue/rules/maintain-wiki.md` (line 0, confidence: medium, method: file_heuristic)
-- `website/src/content/docs/skills/maintain-wiki.mdx` (line 0, confidence: medium, method: file_heuristic)
 - `docs/references/agent-config-files-and-okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `.kilocode/rules/maintain-wiki.md` (line 0, confidence: medium, method: file_heuristic)
 - `scripts/okf-post-sync.sh` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e48s02.md
+++ b/specs/codebase-wiki/e48s02.md
@@ -36,67 +36,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-09.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-18.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/GOLDEN-2026-07-05.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-06.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-07.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-23.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-13.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-23.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-07.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-21.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-06.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-18.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-2026-07-05.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-09.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-13.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-11.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -181,22 +125,8 @@ links:
 - `specs/verifications/steps/and-every-change-should-include-runnable-tests-as-verification.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-tests-should-be-fast-and-run-with-a-single-command-t9.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-the-skill-packaging-pipeline-round-trips-a-golden-fixture-without-data-loss.sh` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-09.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-18.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-05.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-06.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-07.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-23.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-13.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-23.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-07.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-21.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-06.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-18.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-05.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-09.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-13.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-11.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-g06-migrate-version-golden.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-07-e48-audit-gaps.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-run-evals-golden-suite-oversized.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e48s03.md
+++ b/specs/codebase-wiki/e48s03.md
@@ -516,10 +516,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: bigpowers-showcase/specs/bugs/BUG-2026-07-05-race-condition.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
 ---
 
 # e48s03: OKF-ify bug-registry: specs/bugs/registry.yaml emits concept bundles per bug
@@ -657,4 +653,3 @@ links:
 - `.kilocode/rules/fix-bug.md` (line 0, confidence: medium, method: file_heuristic)
 - `.kilocode/rules/investigate-bug.md` (line 0, confidence: medium, method: file_heuristic)
 - `scripts/sync-bugs-registry.sh` (line 0, confidence: medium, method: file_heuristic)
-- `bigpowers-showcase/specs/bugs/BUG-2026-07-05-race-condition.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e48s05.md
+++ b/specs/codebase-wiki/e48s05.md
@@ -48,67 +48,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-09.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-18.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/GOLDEN-2026-07-05.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-06.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-07.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-23.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-13.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-23.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-07.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-21.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-06.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-18.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-2026-07-05.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-09.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-13.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-11.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -660,22 +604,8 @@ links:
 - `specs/verifications/steps/and-i-should-enforce-a-two-stage-review-gate.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/then-skills-should-include-bold-hard-gate-callout-blocks.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-i-should-reject-work-that-fails-its-risk-tier-verification-gate.sh` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-09.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-18.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-05.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-06.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-07.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-23.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-13.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-23.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-07.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-21.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-06.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-18.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-05.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-09.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-13.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-11.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-03-venv-not-gitignored.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-07-compliance-skill-catalog-n7.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-g06-migrate-version-golden.okf.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e51s04.md
+++ b/specs/codebase-wiki/e51s04.md
@@ -84,14 +84,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190334.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-144556.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-175346.md
     line: 0
     confidence: medium
@@ -100,31 +92,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-102313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-103815.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163934.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202335.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145222.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165427.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132836.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -136,23 +104,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-155647.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181947.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212931.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-160106.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-180858.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -161,30 +113,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-143153.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215320.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-172717.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174039.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132651.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212830.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182718.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -197,10 +125,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-122420.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183547.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -228,10 +152,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-160627.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-165137.md
     line: 0
     confidence: medium
@@ -240,27 +160,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-205519.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101228.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-102150.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214411.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260622-001710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-165047.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -269,18 +169,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-000102.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133327.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001605.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105239.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -296,35 +184,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101847.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173628.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182629.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154217.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-165703.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-143839.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163159.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260711-001225.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -336,23 +200,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-185319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183644.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260629-132810.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001328.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -364,19 +212,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-202226.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164609.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192340.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165651.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -388,27 +224,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-160550.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-134603.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091641.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163954.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-210053.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190002.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -417,18 +233,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164251.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132615.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-172212.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-140513.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -448,23 +252,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154135.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170532.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154323.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-082500.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101730.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -476,67 +268,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-165007.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-205711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-182236.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-135136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-103737.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-213042.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-134029.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164826.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-162400.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110426.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-223023.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-134126.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-162245.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-105652.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-114127.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154055.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -552,19 +288,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164801.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131809.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-175313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181604.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -580,19 +304,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-110149.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-181656.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174414.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -600,15 +312,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192541.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-233740.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173515.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -616,27 +320,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190415.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192435.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-125910.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215656.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-135950.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092605.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -652,14 +336,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154936.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132530.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174045.md
     line: 0
     confidence: medium
@@ -672,23 +348,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091938.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-133945.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174055.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001312.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110458.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -728,39 +388,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105145.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-193609.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174351.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-154353.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-131211.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-130715.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182555.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-124641.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -772,23 +404,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120114.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-234357.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110242.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-143756.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-235505.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -812,10 +428,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001100.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-150417.md
     line: 0
     confidence: medium
@@ -832,27 +444,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-185913.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-154427.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-140559.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001518.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-184837.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -868,31 +464,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-154541.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-105728.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-111510.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-180901.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-133532.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145423.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-141624.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -908,18 +484,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181236.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163830.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092533.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174025.md
     line: 0
     confidence: medium
@@ -928,35 +492,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145349.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-205433.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132944.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163746.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-091141.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184856.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-143844.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133446.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -965,30 +501,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-223425.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-182836.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202450.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194130.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-213831.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174245.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1008,19 +520,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-005225.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-143007.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-171058.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-150742.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1060,31 +560,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-154637.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001919.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-220941.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174117.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-093202.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110206.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120150.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1100,31 +576,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131734.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182807.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173917.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-185210.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-101322.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165256.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192433.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1132,23 +584,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105013.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-200110.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-114242.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001233.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-162439.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1156,27 +592,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002229.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-144202.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183102.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-133837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-233707.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212919.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1192,19 +612,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164345.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120250.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165035.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-112952.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1216,39 +624,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194053.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001439.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202651.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-143840.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-000955.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-144557.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174133.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115538.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-113034.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1260,31 +640,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-161502.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170255.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164704.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132813.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164342.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-120815.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154835.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1296,27 +656,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-155747.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173218.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260626-204822.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202348.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-161543.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1328,10 +672,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-113257.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-181044.md
     line: 0
     confidence: medium
@@ -1340,23 +680,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-133458.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164823.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-180900.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-104009.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1369,10 +693,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-081735.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-154818.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1392,10 +712,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170738.md
     line: 0
     confidence: medium
@@ -1409,10 +725,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-153801.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194215.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1432,23 +744,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084719.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132017.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-171157.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183350.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-150937.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1464,14 +760,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-110050.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001337.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260627-133613.md
     line: 0
     confidence: medium
@@ -1484,27 +772,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-220404.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-085740.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-223359.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-193756.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163218.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163309.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1520,15 +792,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202442.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164036.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1544,27 +808,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214125.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132604.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-142359.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132933.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-175550.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174408.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1576,10 +824,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182339.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165418.md
     line: 0
     confidence: medium
@@ -1588,23 +832,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-155114.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133637.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-005655.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165222.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-131140.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1644,35 +876,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202558.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170940.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-163657.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215213.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-204345.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-153739.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175227.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1681,38 +889,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-225313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164721.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-093336.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132207.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130940.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105058.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084617.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084805.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174631.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1728,27 +904,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002322.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-220022.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-135838.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-152233.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181159.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1760,27 +916,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131350.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-083101.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260626-214501.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115557.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-114525.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-093128.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1792,43 +932,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212552.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181706.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092013.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001702.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132130.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-163956.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001902.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-093246.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-204300.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1844,14 +948,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132858.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165902.md
     line: 0
     confidence: medium
@@ -1860,19 +956,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001029.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-172425.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145255.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-133730.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1880,43 +964,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175929.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-172525.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133254.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184658.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164258.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194009.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260629-130359.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130821.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190539.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1928,27 +980,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-163613.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-142458.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-005318.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-235409.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001952.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1960,27 +992,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002154.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-171134.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-182630.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165733.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091717.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084911.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1996,31 +1008,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182346.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115503.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-101402.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-231038.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-123626.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184355.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-172751.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2028,27 +1016,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101633.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130900.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-103924.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101425.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-163837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175105.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2064,15 +1032,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-234704.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163238.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-172133.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2080,19 +1040,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214329.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-144506.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-210010.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173306.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2109,10 +1057,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-151341.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131314.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2341,158 +1285,73 @@ links:
 - `specs/conventions-wiki/p1-high-fix-before-merge.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-the-plan-specifies-test-levels-and-fixture-architectures.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-the-skill-packaging-pipeline-round-trips-a-golden-fixture-without-data-loss.sh` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190334.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-144556.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-175346.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-165245.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-102313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-103815.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163934.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202335.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145222.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165427.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132836.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180022.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163733.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-155647.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181947.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212931.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160106.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-180858.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181109.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143153.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215320.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-172717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174039.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132651.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212830.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182718.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170744.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005609.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-122420.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183547.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-205129.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-081618.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-162136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234209.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-160627.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-165137.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223301.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-205519.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101228.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-102150.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214411.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260622-001710.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-165047.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165920.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000102.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133327.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001605.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105239.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181904.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150326.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170432.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101847.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173628.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182629.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154217.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-165703.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-143839.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163159.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260711-001225.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-010055.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163108.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-185319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183644.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215759.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132810.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001328.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-235439.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164718.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-202226.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192340.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165651.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172406.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173408.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-160550.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-134603.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091641.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163954.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-210053.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190002.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-222132.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164251.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132615.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-172212.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-140513.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170547.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173125.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180244.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170506.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154135.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170532.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154323.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082500.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101730.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170710.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-205844.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-165007.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-205711.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-182236.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-135136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-103737.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-213042.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-134029.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164826.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-162400.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110426.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223023.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-134126.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-162245.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-105652.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-114127.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154055.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170704.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173014.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174734.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164801.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131809.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181604.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163821.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-201018.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-165945.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-110149.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105711.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181656.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174414.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142931.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192541.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-233740.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173515.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-090946.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190415.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192435.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-125910.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215656.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-135950.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092605.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-225914.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165619.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154936.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132530.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174045.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-131004.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091938.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-133945.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174055.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001312.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164534.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005128.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-235526.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2502,80 +1361,40 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260703-005444.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223636.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181759.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105145.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-193609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174351.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154353.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-131211.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130715.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182555.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-124641.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-083430.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080042.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120114.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234357.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110242.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-143756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-235505.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-220905.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160732.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164627.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143840.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-214041.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001100.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150417.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155813.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164603.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143504.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-185913.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-154427.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-140559.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001518.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-184837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170909.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154246.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-154541.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-105728.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-111510.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180901.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-133532.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145423.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-141624.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164911.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174207.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181236.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163830.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092533.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174025.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204652.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145349.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-205433.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132944.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163746.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-091141.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184856.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-143844.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133446.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-154339.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223425.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-182836.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202450.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133710.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194130.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-213831.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174245.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005800.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173348.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005515.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165022.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-005225.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-143007.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-171058.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-150742.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164733.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165618.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164707.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2585,143 +1404,76 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260704-083149.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170223.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164441.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-154637.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001919.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-220941.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174117.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-093202.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110206.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120150.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080057.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170448.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131734.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182807.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173917.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-185210.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-101322.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165256.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192433.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165207.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105013.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200110.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-114242.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001233.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-162439.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130939.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002229.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-144202.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183102.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-133837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-233707.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212919.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163256.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005720.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164345.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120250.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165035.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-112952.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130756.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130915.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194053.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001439.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202651.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-143840.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-000955.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-144557.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174133.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115538.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-113034.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164833.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181114.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-161502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170255.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164704.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132813.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164342.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-120815.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154835.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165959.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164817.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164759.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155747.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173218.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204822.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202348.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-161543.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155551.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-125842.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-113257.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181044.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223249.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-133458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164823.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-180900.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-104009.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234324.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180916.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-081735.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-154818.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-161735.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005423.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130845.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200055.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170738.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163839.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005546.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153801.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194215.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200030.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-004248.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154311.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204755.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084719.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132017.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-171157.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183350.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-150937.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-091017.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082326.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175521.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-110050.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001337.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260627-133613.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-195653.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005358.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-220404.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-085740.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-193756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163218.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163309.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130821.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-145833.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142423.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202442.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164036.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165346.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080024.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142902.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214125.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132604.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132933.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175550.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174408.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-080343.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082306.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182339.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165418.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143447.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-155114.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133637.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005655.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165222.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-131140.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165111.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154214.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181546.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2731,124 +1483,52 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260629-132750.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164343.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163338.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202558.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170940.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-163657.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215213.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-204345.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212711.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153739.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175227.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180125.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-225313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164721.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-093336.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132207.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130940.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105058.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084617.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084805.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174631.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174148.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000357.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-222115.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002322.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-220022.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164429.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-135838.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-152233.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181159.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164518.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131350.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-083101.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-214501.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115557.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-114525.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-093128.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-221847.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-004226.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212552.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181706.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092013.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001702.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132130.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182429.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163956.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001902.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-093246.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-204300.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164141.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173033.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164050.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132858.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174710.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165902.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005336.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001029.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172425.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145255.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-133730.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154726.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154759.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175929.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172525.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133254.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184658.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164258.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194009.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130821.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190539.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170706.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170757.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-163613.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173429.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142458.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-005318.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-235409.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001952.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-195845.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-164155.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002154.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-171134.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-182630.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165733.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084911.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130700.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172925.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182346.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115503.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-101402.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-231038.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-123626.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184355.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-172751.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170431.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101633.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130900.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-103924.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101425.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163837.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175105.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000548.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150200.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175152.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-234704.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163238.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-172133.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180948.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214329.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-144506.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-210010.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173306.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260622-001925.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164958.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165537.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-151341.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131314.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-185054.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-07-compliance-skill-catalog-n7.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-04-filesize-gate-python-blindspot.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e61s01.md
+++ b/specs/codebase-wiki/e61s01.md
@@ -1,0 +1,65 @@
+---
+type: Story
+id: e61s01
+epic: e61
+bcps: 0
+wsjf: 5.0
+implementation_status: done
+coverage_status: covered
+confidence: high
+links:
+  - file: specs/verifications/AUDIT-e61-e61s01.md
+    line: 45
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e61-integration-hermes/e61s01-tasks.yaml
+    line: 14
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e61-integration-hermes/e61s01-hermes-adapter-hooks.md
+    line: 3
+    confidence: high
+    method: explicit_tag
+  - file: scripts/test-hermes-adapter.sh
+    line: 2
+    confidence: high
+    method: explicit_tag
+  - file: scripts/adapters/hermes.sh
+    line: 3
+    confidence: high
+    method: explicit_tag
+  - file: scripts/hooks/hermes/shell/hooks-config.example.yaml
+    line: 1
+    confidence: high
+    method: explicit_tag
+  - file: scripts/hooks/hermes/shell/block-dangerous-terminal.sh
+    line: 2
+    confidence: high
+    method: explicit_tag
+  - file: scripts/hooks/hermes/plugin/guard-git-plugin.py
+    line: 1
+    confidence: high
+    method: explicit_tag
+  - file: scripts/hooks/hermes/gateway/session-log/handler.py
+    line: 1
+    confidence: high
+    method: explicit_tag
+---
+
+# e61s01: Hermes adapter + hook templates (Wave A)
+
+**Epic:** e61 — Integration: Hermes Agent — Skills + 3 Hook Systems
+**Status:** done
+**BCP:** 0 | **WSJF:** 5.0
+
+## Implemented In
+
+- `specs/verifications/AUDIT-e61-e61s01.md` (line 45, confidence: high, method: explicit_tag)
+- `specs/epics/e61-integration-hermes/e61s01-tasks.yaml` (line 14, confidence: high, method: explicit_tag)
+- `specs/epics/e61-integration-hermes/e61s01-hermes-adapter-hooks.md` (line 3, confidence: high, method: explicit_tag)
+- `scripts/test-hermes-adapter.sh` (line 2, confidence: high, method: explicit_tag)
+- `scripts/adapters/hermes.sh` (line 3, confidence: high, method: explicit_tag)
+- `scripts/hooks/hermes/shell/hooks-config.example.yaml` (line 1, confidence: high, method: explicit_tag)
+- `scripts/hooks/hermes/shell/block-dangerous-terminal.sh` (line 2, confidence: high, method: explicit_tag)
+- `scripts/hooks/hermes/plugin/guard-git-plugin.py` (line 1, confidence: high, method: explicit_tag)
+- `scripts/hooks/hermes/gateway/session-log/handler.py` (line 1, confidence: high, method: explicit_tag)

--- a/specs/codebase-wiki/e61s02.md
+++ b/specs/codebase-wiki/e61s02.md
@@ -1,0 +1,55 @@
+---
+type: Story
+id: e61s02
+epic: e61
+bcps: 0
+wsjf: 5.0
+implementation_status: done
+coverage_status: covered
+confidence: high
+links:
+  - file: specs/verifications/e61s02-verify.yaml
+    line: 1
+    confidence: high
+    method: explicit_tag
+  - file: specs/verifications/AUDIT-e61-e61s02.md
+    line: 48
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e61-integration-hermes/e61s02-tasks.yaml
+    line: 1
+    confidence: high
+    method: explicit_tag
+  - file: scripts/test-hermes-hub.sh
+    line: 2
+    confidence: high
+    method: explicit_tag
+  - file: scripts/lib/install-helpers.js
+    line: 3
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e76-integration-zcode/e76s02-hub-wiring.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/epics/e61-integration-hermes/e61s02-hub-wiring.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+---
+
+# e61s02: Install hub wiring (Wave B)
+
+**Epic:** e61 — Integration: Hermes Agent — Skills + 3 Hook Systems
+**Status:** done
+**BCP:** 0 | **WSJF:** 5.0
+
+## Implemented In
+
+- `specs/verifications/e61s02-verify.yaml` (line 1, confidence: high, method: explicit_tag)
+- `specs/verifications/AUDIT-e61-e61s02.md` (line 48, confidence: high, method: explicit_tag)
+- `specs/epics/e61-integration-hermes/e61s02-tasks.yaml` (line 1, confidence: high, method: explicit_tag)
+- `scripts/test-hermes-hub.sh` (line 2, confidence: high, method: explicit_tag)
+- `scripts/lib/install-helpers.js` (line 3, confidence: high, method: explicit_tag)
+- `specs/epics/e76-integration-zcode/e76s02-hub-wiring.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/epics/e61-integration-hermes/e61s02-hub-wiring.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e76s01.md
+++ b/specs/codebase-wiki/e76s01.md
@@ -1,0 +1,55 @@
+---
+type: Story
+id: e76s01
+epic: e76
+bcps: 0
+wsjf: 5.0
+implementation_status: done
+coverage_status: covered
+confidence: high
+links:
+  - file: specs/verifications/AUDIT-e76-e76s01.md
+    line: 57
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e76-integration-zcode/e76s01-tasks.yaml
+    line: 13
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e76-integration-zcode/e76s01-tasks.yaml
+    line: 17
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e76-integration-zcode/epic.yaml
+    line: 36
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e76-integration-zcode/e76s01-zcode-adapter.md
+    line: 1
+    confidence: high
+    method: explicit_tag
+  - file: scripts/adapters/zcode.sh
+    line: 2
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/archive/e37-reach/e37s10-wave-b-skills-dir.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+---
+
+# e76s01: ZCode adapter — Wave A greenfield skills-dir
+
+**Epic:** e76 — Integration: ZCode — Skills + Plugin Hooks
+**Status:** done
+**BCP:** 0 | **WSJF:** 5.0
+
+## Implemented In
+
+- `specs/verifications/AUDIT-e76-e76s01.md` (line 57, confidence: high, method: explicit_tag)
+- `specs/epics/e76-integration-zcode/e76s01-tasks.yaml` (line 13, confidence: high, method: explicit_tag)
+- `specs/epics/e76-integration-zcode/e76s01-tasks.yaml` (line 17, confidence: high, method: explicit_tag)
+- `specs/epics/e76-integration-zcode/epic.yaml` (line 36, confidence: high, method: explicit_tag)
+- `specs/epics/e76-integration-zcode/e76s01-zcode-adapter.md` (line 1, confidence: high, method: explicit_tag)
+- `scripts/adapters/zcode.sh` (line 2, confidence: high, method: explicit_tag)
+- `specs/epics/archive/e37-reach/e37s10-wave-b-skills-dir.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e76s02.md
+++ b/specs/codebase-wiki/e76s02.md
@@ -1,0 +1,65 @@
+---
+type: Story
+id: e76s02
+epic: e76
+bcps: 0
+wsjf: 5.0
+implementation_status: done
+coverage_status: covered
+confidence: high
+links:
+  - file: specs/state.yaml
+    line: 3
+    confidence: high
+    method: explicit_tag
+  - file: specs/verifications/AUDIT-e76-e76s02.md
+    line: 47
+    confidence: high
+    method: explicit_tag
+  - file: specs/verifications/e76s02-verify.yaml
+    line: 1
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e76-integration-zcode/epic.yaml
+    line: 53
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e76-integration-zcode/e76s02-tasks.yaml
+    line: 1
+    confidence: high
+    method: explicit_tag
+  - file: scripts/test-zcode-hub.sh
+    line: 2
+    confidence: high
+    method: explicit_tag
+  - file: scripts/lib/install-helpers.js
+    line: 4
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e76-integration-zcode/e76s02-hub-wiring.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/epics/e61-integration-hermes/e61s02-hub-wiring.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+---
+
+# e76s02: Install hub wiring (Wave B)
+
+**Epic:** e76 — Integration: ZCode — Skills + Plugin Hooks
+**Status:** done
+**BCP:** 0 | **WSJF:** 5.0
+
+## Implemented In
+
+- `specs/state.yaml` (line 3, confidence: high, method: explicit_tag)
+- `specs/verifications/AUDIT-e76-e76s02.md` (line 47, confidence: high, method: explicit_tag)
+- `specs/verifications/e76s02-verify.yaml` (line 1, confidence: high, method: explicit_tag)
+- `specs/epics/e76-integration-zcode/epic.yaml` (line 53, confidence: high, method: explicit_tag)
+- `specs/epics/e76-integration-zcode/e76s02-tasks.yaml` (line 1, confidence: high, method: explicit_tag)
+- `scripts/test-zcode-hub.sh` (line 2, confidence: high, method: explicit_tag)
+- `scripts/lib/install-helpers.js` (line 4, confidence: high, method: explicit_tag)
+- `specs/epics/e76-integration-zcode/e76s02-hub-wiring.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/epics/e61-integration-hermes/e61s02-hub-wiring.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/index.md
+++ b/specs/codebase-wiki/index.md
@@ -1,7 +1,7 @@
 ---
 type: Index
-generated_at: 2026-07-24T01:21:58.184664+00:00
-total_concepts: 84
+generated_at: 2026-07-24T14:07:31.265475+00:00
+total_concepts: 88
 ---
 
 # Codebase Wiki — Story Traceability
@@ -15,11 +15,11 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e37s03](./e37s03.md) | seed-conventions — .aider.conf.yml read:AGENTS.md bridge for | high | 8 |
 | [e37s04](./e37s04.md) | verify-install.sh — AGENTS.md spine assertions (OSS P1 + opt | high | 4 |
 | [e37s05](./e37s05.md) | scripts/targets.yaml — declarative integration registry for  | high | 25 |
-| [e37s06](./e37s06.md) | scripts/generate-context-bundle.sh — AGENTS.md single source | high | 12 |
+| [e37s06](./e37s06.md) | scripts/generate-context-bundle.sh — AGENTS.md single source | high | 11 |
 | [e37s07](./e37s07.md) | sync-skills.sh — adapter dispatch from targets.yaml | high | 12 |
 | [e37s08](./e37s08.md) | verify-install.sh — per-target contract matrix from targets. | high | 10 |
 | [e37s09](./e37s09.md) | targets.yaml — Wave A: Goose (OSS) + Antigravity agy (propri | high | 5 |
-| [e37s10](./e37s10.md) | targets.yaml — Wave B: zed, omp, hermes (skills-dir adapters | high | 7 |
+| [e37s10](./e37s10.md) | targets.yaml — Wave B: zed, omp, hermes (skills-dir adapters | high | 8 |
 | [e37s11](./e37s11.md) | targets.yaml — Wave C: qwen, kilocode (markdown commands + r | high | 4 |
 | [e37s12](./e37s12.md) | targets.yaml — Wave D: continue (rules adapter; re-opened ac | high | 4 |
 | [e37s13](./e37s13.md) | targets.yaml — Wave E: iflow, vibe, shai (markdown commands; | high | 6 |
@@ -32,9 +32,9 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e45s04](./e45s04.md) | slice-tasks / plan-work: pre-build cross-artifact consistenc | high | 15 |
 | [e45s05](./e45s05.md) | verify-work / gate-trace: adversarial gap-finding completene | high | 30 |
 | [e45s06](./e45s06.md) | tasks.yaml: literal failing→passing task ledger | high | 2 |
-| [e45s07](./e45s07.md) | request-review: dual-blind AND-gate review (Santa Method) | high | 31 |
+| [e45s07](./e45s07.md) | request-review: dual-blind AND-gate review (Santa Method) | high | 35 |
 | [e45s08](./e45s08.md) | develop-tdd / validate-fix: two-commit red/green regression  | high | 11 |
-| [e45s09](./e45s09.md) | verify-work / plan-work: Pre-Implementation and Validation g | high | 72 |
+| [e45s09](./e45s09.md) | verify-work / plan-work: Pre-Implementation and Validation g | high | 71 |
 | [e45s10](./e45s10.md) | docs/references: auto-regenerate from source-of-truth docs v | high | 7 |
 | [e45s11](./e45s11.md) | orchestration / dispatch-agents: typed message protocol + 3- | high | 9 |
 | [e45s12](./e45s12.md) | stocktake-skills / craft-skill: code-enforced validator + au | high | 33 |
@@ -42,8 +42,8 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e45s14](./e45s14.md) | deepen-architecture: declared import-boundary allowlist enfo | high | 7 |
 | [e45s15](./e45s15.md) | release-branch / deploy: three-independent-facts verificatio | high | 13 |
 | [e45s16](./e45s16.md) | CLAUDE.md rtk mandate: wire rtk-ai/rtk PreToolUse hook | high | 4 |
-| [e45s17](./e45s17.md) | request-review: fan-out to parallel review subagents | high | 23 |
-| [e45s18](./e45s18.md) | audit-code / security-review: worktree-isolated parallel che | high | 531 |
+| [e45s17](./e45s17.md) | request-review: fan-out to parallel review subagents | high | 27 |
+| [e45s18](./e45s18.md) | audit-code / security-review: worktree-isolated parallel che | high | 267 |
 | [e45s19](./e45s19.md) | Context7: bounded retry cap and explicit fallback block | high | 8 |
 | [e45s20](./e45s20.md) | Context7 / bts docs: wrap in ETag-revalidated fetch cache | high | 1 |
 | [e45s21](./e45s21.md) | seed-conventions / AGENTS.md: self-installing fenced markers | high | 15 |
@@ -56,7 +56,7 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e45s28](./e45s28.md) | request-review: hard max-iteration cap | high | 10 |
 | [e45s29](./e45s29.md) | requirements: ADDED/MODIFIED/REMOVED/RENAMED tags | high | 15 |
 | [e45s30](./e45s30.md) | subagent depth: formalize depth tiers | high | 10 |
-| [e45s31](./e45s31.md) | audit-code / deepen-architecture: churn-based look-here-firs | high | 528 |
+| [e45s31](./e45s31.md) | audit-code / deepen-architecture: churn-based look-here-firs | high | 264 |
 | [e45s32](./e45s32.md) | gate-trace / release-branch: adversarial-review refute frami | high | 27 |
 | [e45s33](./e45s33.md) | requirements: per-section approval state | high | 3 |
 | [e45s34](./e45s34.md) | develop-tdd: snapshot-before-transition hardening | high | 6 |
@@ -67,11 +67,11 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e45s39](./e45s39.md) | PR generation: literal provenance marker | high | 5 |
 | [e45s40](./e45s40.md) | verify-work: mandatory real-browser verification | high | 15 |
 | [e45s41](./e45s41.md) | security-review: proven authorship SQL-safety doctrine | high | 10 |
-| [e48s01](./e48s01.md) | Generate epics-wiki and adr-wiki as OKF concept bundles from | high | 30 |
-| [e48s02](./e48s02.md) | Emit verification reports as OKF bundles from run-golden-sui | medium | 39 |
-| [e48s03](./e48s03.md) | OKF-ify bug-registry: specs/bugs/registry.yaml emits concept | high | 128 |
+| [e48s01](./e48s01.md) | Generate epics-wiki and adr-wiki as OKF concept bundles from | high | 29 |
+| [e48s02](./e48s02.md) | Emit verification reports as OKF bundles from run-golden-sui | medium | 25 |
+| [e48s03](./e48s03.md) | OKF-ify bug-registry: specs/bugs/registry.yaml emits concept | high | 127 |
 | [e48s04](./e48s04.md) | Create viz.html — interactive force-layout graph companion f | medium | 10 |
-| [e48s05](./e48s05.md) | Wire OKF validation into CI (sync-skills.yml) and document i | medium | 158 |
+| [e48s05](./e48s05.md) | Wire OKF validation into CI (sync-skills.yml) and document i | medium | 144 |
 | [e48s06](./e48s06.md) | Add tier: field (core/extended/specialized) to OKF wiki inde | medium | 9 |
 | [e48s07](./e48s07.md) | Create publish-to-wiki kernel tool | high | 2 |
 | [e48s08](./e48s08.md) | Add GitHub Action Template for publish-wiki.yml [HARD GATE] | high | 8 |
@@ -85,7 +85,7 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e51s01](./e51s01.md) | CONVENTIONS — Always Green, Shift Left, Discovered Defects,  | high | 8 |
 | [e51s02](./e51s02.md) | seed-conventions — Preflight default, solo-git default, embe | high | 22 |
 | [e51s03](./e51s03.md) | kickoff-branch + verify-work — Preflight hard block and CI g | high | 46 |
-| [e51s04](./e51s04.md) | audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log rou | high | 576 |
+| [e51s04](./e51s04.md) | audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log rou | high | 312 |
 | [e51s05](./e51s05.md) | CLAUDE.md — solo-default agent rules + bigpowers Preflight c | high | 7 |
 | [e54s01](./e54s01.md) | Snapshot the current skill catalog as an immutable baseline | high | 9 |
 | [e54s02](./e54s02.md) | Add a soft drift-detection gate for the freeze window | high | 14 |
@@ -94,3 +94,7 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e55s02](./e55s02.md) | Write constitution.md from the mapping, CLAUDE.md/CONVENTION | high | 5 |
 | [e55s03](./e55s03.md) | Point CLAUDE.md/CONVENTIONS.md at constitution.md, don't del | high | 9 |
 | [e60s01](./e60s01.md) | Interactive installer with ASCII banner, global/local, tool  | high | 3 |
+| [e61s01](./e61s01.md) | Hermes adapter + hook templates (Wave A) | high | 9 |
+| [e61s02](./e61s02.md) | Install hub wiring (Wave B) | high | 7 |
+| [e76s01](./e76s01.md) | ZCode adapter — Wave A greenfield skills-dir | high | 7 |
+| [e76s02](./e76s02.md) | Install hub wiring (Wave B) | high | 9 |

--- a/specs/epics/e76-integration-zcode/e76s01-tasks.yaml
+++ b/specs/epics/e76-integration-zcode/e76s01-tasks.yaml
@@ -1,0 +1,87 @@
+story_id: e76s01
+title: "ZCode adapter — Wave A greenfield skills-dir"
+spec: e76s01-zcode-adapter.md
+status: passing
+bcps: 3
+risk: P2
+depends_on: []
+tasks:
+  - id: 1
+    description: >-
+      Create scripts/adapters/zcode.sh with render_skill writing SKILL.md to
+      ${ZCODE_SKILLS:-~/.zcode/skills}/<name>/ and wire_context symlinking
+      AGENTS.md to ${ZCODE_AGENTS:-~/.zcode/AGENTS.md}. Tag # story: e76s01.
+    verify: >-
+      test -f scripts/adapters/zcode.sh &&
+      bash -n scripts/adapters/zcode.sh &&
+      grep -q 'story: e76s01' scripts/adapters/zcode.sh &&
+      echo OK
+    risk: P2
+    security: low
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - "Wave A"
+        - "Integration"
+
+  - id: 2
+    description: >-
+      Verify render_skill creates SKILL.md under ZCODE_SKILLS override in a
+      temp directory (no writes to live ~/.zcode/).
+    verify: >-
+      tmpdir=$(mktemp -d) &&
+      export ZCODE_SKILLS="$tmpdir/skills" &&
+      IR_NAME=zcode-test IR_DESC_ESCAPED=test IR_BODY="# test" &&
+      source scripts/adapters/zcode.sh &&
+      render_skill &&
+      test -f "$tmpdir/skills/zcode-test/SKILL.md" &&
+      rm -rf "$tmpdir" &&
+      echo OK
+    risk: P2
+    security: low
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - "Wave A"
+
+  - id: 3
+    description: >-
+      Verify adapter exports render_skill and wire_context when sourced.
+    verify: >-
+      source scripts/adapters/zcode.sh &&
+      declare -f render_skill >/dev/null &&
+      declare -f wire_context >/dev/null &&
+      echo OK
+    risk: P2
+    security: none
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - "Wave A"
+
+  - id: 4
+    description: >-
+      Story verify: adapter file present, bash -n clean, skills path documented
+      in capsule-aligned default.
+    verify: >-
+      test -f scripts/adapters/zcode.sh &&
+      bash -n scripts/adapters/zcode.sh &&
+      grep -q '\.zcode/skills' scripts/adapters/zcode.sh &&
+      grep -q 'wire_context' scripts/adapters/zcode.sh &&
+      echo OK
+    risk: P2
+    security: none
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - "Wave A"
+
+out_of_scope:
+  - "targets.yaml row (blocked_until: wave-b)"
+  - "install.sh / install-helpers.js / setup.js hub wiring"
+  - "verify-install.sh contract"
+  - "ZCode plugin hooks"

--- a/specs/epics/e76-integration-zcode/e76s01-zcode-adapter.md
+++ b/specs/epics/e76-integration-zcode/e76s01-zcode-adapter.md
@@ -1,0 +1,37 @@
+# story: e76s01
+# ZCode adapter — Wave A greenfield skills-dir
+
+## Requirements
+
+### ADDED
+
+- **R1:** `scripts/adapters/zcode.sh` renders skills to `~/.zcode/skills/<name>/SKILL.md` (override via `ZCODE_SKILLS`).
+- **R2:** `wire_context` wires project AGENTS.md to `~/.zcode/AGENTS.md` (override via `ZCODE_AGENTS`).
+- **R3:** Adapter is sourceable; exposes `render_skill` and `wire_context` for Wave B registry dispatch.
+
+## Acceptance Criteria
+
+```bash
+test -f scripts/adapters/zcode.sh &&
+bash -n scripts/adapters/zcode.sh &&
+grep -q 'render_skill' scripts/adapters/zcode.sh &&
+grep -q 'wire_context' scripts/adapters/zcode.sh &&
+grep -q '\.zcode/skills' scripts/adapters/zcode.sh &&
+echo OK
+```
+
+## Out of scope
+
+- `scripts/targets.yaml` row (Wave B — e76s02)
+- `scripts/install.sh`, `scripts/lib/install-helpers.js`, `bin/setup.js` hub wiring
+- `scripts/verify-install.sh` contract
+- ZCode plugin hook templates (unknown event names)
+- E2E with ZCode binary
+
+## Adapter guidance
+
+- Skills path: `~/.zcode/skills/` per epic capsule (`integration_details.skills_path`)
+- Config path: `~/.zcode/AGENTS.md` per capsule (`integration_details.config_path`)
+- Pattern: skills-dir adapter like `gemini.sh` / `cursor.sh` (SKILL.md frontmatter + stdin SkillIR)
+- Context: symlink project AGENTS.md → `~/.zcode/AGENTS.md` via `context-wire.sh`
+- Test gate: scoped verify with `ZCODE_SKILLS` temp dir (no live home writes in CI)

--- a/specs/epics/e76-integration-zcode/e76s02-hub-wiring.md
+++ b/specs/epics/e76-integration-zcode/e76s02-hub-wiring.md
@@ -1,0 +1,28 @@
+# e76s02: Install hub wiring (Wave B)
+
+Wire ZCode into the bigpowers install hub: `install.sh`, `install-helpers.js`, `bin/setup.js`, `targets.yaml`, and `verify-install.sh`. Wave A adapter remains unchanged except repo-relative default paths for sync.
+
+## In scope
+
+- `install_zcode()` / `uninstall_zcode()` in `scripts/install.sh` — symlink rendered `.zcode/skills/<name>/` into `~/.zcode/skills/`, symlink `AGENTS.md` into `~/.zcode/AGENTS.md`.
+- `zcode` cases in `scripts/lib/install-helpers.js` (global + local + uninstall).
+- Add `zcode` to `SUPPORTED_IDS` in `bin/setup.js`.
+- `zcode` row in `scripts/targets.yaml`.
+- ZCode contract assertions in `scripts/verify-install.sh`.
+- `scripts/test-zcode-hub.sh` regression harness.
+
+## Out of scope
+
+- Live ZCode UAT
+- ZCode plugin hooks
+
+## Verify
+
+```bash
+bash scripts/test-zcode-hub.sh &&
+bash scripts/verify-install.sh &&
+bash -n scripts/install.sh &&
+node --check scripts/lib/install-helpers.js &&
+node --check bin/setup.js &&
+echo OK
+```

--- a/specs/epics/e76-integration-zcode/e76s02-tasks.yaml
+++ b/specs/epics/e76-integration-zcode/e76s02-tasks.yaml
@@ -1,0 +1,37 @@
+# story: e76s02
+title: "Install hub wiring (Wave B)"
+status: passing
+risk: P1
+spec: e76s02-hub-wiring.md
+tasks:
+  - id: t1
+    title: Add scripts/test-zcode-hub.sh regression harness
+    status: passing
+    verify: bash scripts/test-zcode-hub.sh
+  - id: t2
+    title: Wire install_zcode/uninstall_zcode in scripts/install.sh
+    status: passing
+    verify: bash -n scripts/install.sh && bash scripts/install.sh --dry-run 2>&1 | grep -q 'ZCode →'
+  - id: t3
+    title: Add zcode cases to scripts/lib/install-helpers.js
+    status: passing
+    verify: node --check scripts/lib/install-helpers.js
+  - id: t4
+    title: Add zcode to SUPPORTED_IDS in bin/setup.js
+    status: passing
+    verify: node --check bin/setup.js && grep -q "'zcode'" bin/setup.js
+  - id: t5
+    title: Add zcode row to scripts/targets.yaml
+    status: passing
+    verify: grep -q 'id: zcode' scripts/targets.yaml && grep -q 'adapter: zcode' scripts/targets.yaml
+  - id: t6
+    title: Extend scripts/verify-install.sh with zcode contract assertions
+    status: passing
+    verify: bash scripts/verify-install.sh
+  - id: t7
+    title: Story gate — hub harness + verify-install green
+    status: passing
+    verify: >-
+      bash scripts/test-zcode-hub.sh &&
+      bash scripts/verify-install.sh &&
+      echo OK

--- a/specs/epics/e76-integration-zcode/epic.yaml
+++ b/specs/epics/e76-integration-zcode/epic.yaml
@@ -34,3 +34,20 @@ stories:
     verify: test -f scripts/adapters/zcode.sh && bash -n scripts/adapters/zcode.sh
     tags:
       - "story: e76s01"
+  - id: e76s02
+    title: Install hub wiring (Wave B)
+    status: done
+    bcps: 2
+    description: >
+      Wire ZCode into install.sh, install-helpers.js, setup.js, targets.yaml,
+      and verify-install.sh. Regression via test-zcode-hub.sh.
+    files:
+      - scripts/install.sh
+      - scripts/lib/install-helpers.js
+      - bin/setup.js
+      - scripts/targets.yaml
+      - scripts/verify-install.sh
+      - scripts/test-zcode-hub.sh
+    verify: bash scripts/test-zcode-hub.sh && bash scripts/verify-install.sh
+    tags:
+      - "story: e76s02"

--- a/specs/epics/e76-integration-zcode/epic.yaml
+++ b/specs/epics/e76-integration-zcode/epic.yaml
@@ -21,4 +21,16 @@ integration_details:
   hook_events: [unknown - plugin-scoped]
   hook_format: Plugin directory
   hook_events_count: unknown
-stories: []
+stories:
+  - id: e76s01
+    title: ZCode adapter — Wave A greenfield skills-dir
+    status: done
+    bcps: 3
+    description: >
+      Greenfield scripts/adapters/zcode.sh for ZCode skills at ~/.zcode/skills/
+      and context at ~/.zcode/AGENTS.md. Hub wiring deferred to Wave B.
+    files:
+      - scripts/adapters/zcode.sh
+    verify: test -f scripts/adapters/zcode.sh && bash -n scripts/adapters/zcode.sh
+    tags:
+      - "story: e76s01"

--- a/specs/execution-status.yaml
+++ b/specs/execution-status.yaml
@@ -361,6 +361,7 @@ development_status:
   e75: backlog
   e76: in_progress
   e76s01: done
+  e76s02: done
   e77: done
   e78: done
   generated_at: '2026-07-07T04:00:00Z'
@@ -3126,3 +3127,14 @@ stories:
     tasks_total: 4
     tasks_passing: 4
     tasks_failing: 0
+  e76s02:
+    status: done
+    title: "Install hub wiring (Wave B)"
+    bcps: 2
+    epic: e76
+    started_at: "2026-07-24T11:10:00-03:00"
+    completed_at: "2026-07-24T11:20:00-03:00"
+    tasks_total: 7
+    tasks_passing: 7
+    tasks_failing: 0
+    risk_max: P1

--- a/specs/execution-status.yaml
+++ b/specs/execution-status.yaml
@@ -359,7 +359,8 @@ development_status:
   e73: backlog
   e74: backlog
   e75: backlog
-  e76: backlog
+  e76: in_progress
+  e76s01: done
   e77: done
   e78: done
   generated_at: '2026-07-07T04:00:00Z'
@@ -682,10 +683,10 @@ epics:
     wsjf: 3.0
     total_bcps: 0
   e76:
-    status: backlog
+    status: in_progress
     title: 'Integration: ZCode — Skills + Plugin Hooks'
     wsjf: 5.0
-    total_bcps: 0
+    total_bcps: 3
   e77:
     status: done
     title: 'Integration: pi — Skills (No Hooks)'
@@ -3115,3 +3116,13 @@ stories:
     tasks_passing: 6
     tasks_failing: 0
     risk_max: P1
+  e76s01:
+    status: done
+    title: ZCode adapter — Wave A greenfield skills-dir
+    bcps: 3
+    epic: e76
+    started_at: "2026-07-24T10:53:00-03:00"
+    completed_at: "2026-07-24T11:05:00-03:00"
+    tasks_total: 4
+    tasks_passing: 4
+    tasks_failing: 0

--- a/specs/security/epics/e76/THREAT_MODEL.md
+++ b/specs/security/epics/e76/THREAT_MODEL.md
@@ -1,0 +1,61 @@
+# Threat Model — Epic e76: Integration: ZCode — Skills + Plugin Hooks
+
+**Date:** 2026-07-24
+**Risk Level:** LOW (Wave A adapter-only)
+**Epic Scope:** Greenfield ZCode adapter (`scripts/adapters/zcode.sh`), skills at `~/.zcode/skills/`, context at `~/.zcode/AGENTS.md`. Wave B will wire install hub + `targets.yaml`.
+
+## Surface Area
+
+| Component | Type | Exposure |
+|-----------|------|----------|
+| `scripts/adapters/zcode.sh` | Bash adapter | Writes SKILL.md under `~/.zcode/skills/`; wires AGENTS.md to `~/.zcode/AGENTS.md` |
+| `~/.zcode/skills/` | User home dir | Global skill install path per ZCode docs |
+| `~/.zcode/AGENTS.md` | User home config | Context derivative from project AGENTS.md |
+| ZCode plugin hooks | Plugin-scoped | Out of Wave A scope — event names unknown |
+
+## Vulnerability Assessment
+
+### 1. Path Traversal via IR_NAME
+
+**Category:** Path traversal / unsafe file write
+**Severity:** LOW
+**Risk:** Malformed SkillIR `name` could escape the skills directory if unvalidated.
+**Mitigation:** Adapter writes only under `${ZCODE_SKILLS}/${IR_NAME}/SKILL.md`; Wave B registry validation; no user-controlled path segments in Wave A.
+
+### 2. Home Directory Writes
+
+**Category:** Filesystem write outside project
+**Severity:** LOW
+**Risk:** `wire_context` symlinks/copies into `~/.zcode/AGENTS.md`.
+**Mitigation:** Expected for global agent tools (same pattern as Codex `~/.codex/`); opt-in via install in Wave B; test overrides use `ZCODE_SKILLS` / temp dirs.
+
+### 3. Command Injection in Adapter
+
+**Category:** Command injection
+**Severity:** LOW
+**Risk:** Shell adapter sources shared libs and writes files from IR globals.
+**Mitigation:** Quoted paths; no `eval`; IR fields from sync pipeline only — not raw CLI args in Wave A.
+
+### 4. Plugin Hook Surface (Deferred)
+
+**Category:** Hook event injection
+**Severity:** UNKNOWN
+**Risk:** ZCode hooks are plugin-scoped with unknown event names.
+**Mitigation:** Deferred to Wave B+ after research; no hook templates in Wave A.
+
+## Risk Summary
+
+| Category | Count | Highest |
+|----------|-------|---------|
+| Path traversal | 1 | LOW |
+| Home dir writes | 1 | LOW |
+| Command injection | 1 | LOW |
+| Hook injection | 1 | UNKNOWN (deferred) |
+
+**Overall: LOW** for Wave A — single adapter file with repo-relative test overrides.
+
+## Mitigation Guidance
+
+1. Wave A verify uses `ZCODE_SKILLS` temp override — never assert against live `~/.zcode/` in CI.
+2. Wave B must add `targets.yaml` row + `validate-targets-yaml.sh` before hub dispatch.
+3. Plugin hooks require threat-model update when event names are documented.

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -6,17 +6,17 @@ bigpowers_version: 2.82.4
 bug_cycle: null
 handoff:
   next_skill: release-branch
-  context: Wave B e76s02 hub wiring in progress
+  context: Wave B e76s02 hub wiring complete; audit PASS; open PR
   epic: e76
 epic_cycle:
-  step: '6'
+  step: '8'
   fast_mode: true
   story_bcps: 2
-  audit_result: pending
-  completed_steps: '0,1,2,3,4,5'
+  audit_result: pass
+  completed_steps: '0,1+2,3,4,5,6,7'
 metrics:
   story_start: "2026-07-24T11:10:00-03:00"
-  story_end: null
+  story_end: "2026-07-24T11:20:00-03:00"
   skill_timings: {}
 release:
   ci_verified: true

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -1,22 +1,22 @@
 active_flow: build_epic
-active_epic: e61
-active_story: e61s02
+active_epic: e76
+active_story: e76s02
 bug_id: null
 bigpowers_version: 2.82.4
 bug_cycle: null
 handoff:
   next_skill: release-branch
-  context: Wave B e61s02 hub wiring complete; audit PASS; open PR
-  epic: e61
+  context: Wave B e76s02 hub wiring in progress
+  epic: e76
 epic_cycle:
-  step: '8'
+  step: '6'
   fast_mode: true
   story_bcps: 2
-  audit_result: pass
-  completed_steps: '0,1+2,3,4,5,6,7'
+  audit_result: pending
+  completed_steps: '0,1,2,3,4,5'
 metrics:
-  story_start: "2026-07-24T10:53:00-03:00"
-  story_end: "2026-07-24T10:58:00-03:00"
+  story_start: "2026-07-24T11:10:00-03:00"
+  story_end: null
   skill_timings: {}
 release:
   ci_verified: true

--- a/specs/traceability-matrix.json
+++ b/specs/traceability-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-24T01:21:58.182012+00:00",
+  "generated_at": "2026-07-24T14:07:31.263194+00:00",
   "matrix_version": "1.0",
   "stories": [
     {
@@ -468,12 +468,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "website/src/content/docs/decisions/0007-agents-md-spine-context-derivatives.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/epics/archive/e37-reach/e37s08-tasks.yaml",
           "line": 0,
           "confidence": "low",
@@ -492,7 +486,7 @@
           "method": "task_reference"
         }
       ],
-      "link_count": 12
+      "link_count": 11
     },
     {
       "id": "e37s07",
@@ -742,9 +736,15 @@
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
+        },
+        {
+          "file": "specs/epics/e61-integration-hermes/e61s01-tasks.yaml",
+          "line": 0,
+          "confidence": "low",
+          "method": "task_reference"
         }
       ],
-      "link_count": 7
+      "link_count": 8
     },
     {
       "id": "e37s11",
@@ -1626,6 +1626,30 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/REVIEW-e63-closeout.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/REVIEW-e60-closeout.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/REVIEW-e77-closeout.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/REVIEW-e78-closeout.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/steps/and-i-should-present-multiple-interpretations-of-ambiguous-requests.sh",
           "line": 0,
           "confidence": "medium",
@@ -1758,7 +1782,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 31
+      "link_count": 35
     },
     {
       "id": "e45s08",
@@ -2172,12 +2196,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "website/dist/pagefind/pagefind-worker.js",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "website/src/content/docs/guides/WORKFLOW-SOP-v2.md",
           "line": 0,
           "confidence": "medium",
@@ -2280,7 +2298,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 72
+      "link_count": 71
     },
     {
       "id": "e45s10",
@@ -2887,7 +2905,7 @@
         },
         {
           "file": "scripts/install.sh",
-          "line": 88,
+          "line": 90,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -2953,6 +2971,30 @@
         },
         {
           "file": "specs/security/REVIEW.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/REVIEW-e63-closeout.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/REVIEW-e60-closeout.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/REVIEW-e77-closeout.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/REVIEW-e78-closeout.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3054,7 +3096,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 23
+      "link_count": 27
     },
     {
       "id": "e45s18",
@@ -3126,18 +3168,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190334.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-144556.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-175346.md",
           "line": 0,
           "confidence": "medium",
@@ -3150,43 +3180,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-102313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-103815.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163934.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202335.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145222.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165427.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132836.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3204,31 +3198,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-155647.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181947.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212931.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-160106.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-180858.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3241,42 +3211,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-143153.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215320.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-172717.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174039.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132651.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212830.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182718.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3295,12 +3229,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-122420.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183547.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3342,12 +3270,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-160627.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-165137.md",
           "line": 0,
           "confidence": "medium",
@@ -3360,37 +3282,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-205519.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101228.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-102150.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214411.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260622-001710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-165047.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3403,24 +3295,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-000102.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133327.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001605.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105239.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3444,49 +3318,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101847.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173628.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182629.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154217.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-165703.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-143839.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163159.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260711-001225.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3504,31 +3342,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-185319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183644.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260629-132810.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001328.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3546,25 +3360,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-202226.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164609.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192340.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165651.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3582,37 +3378,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-160550.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-134603.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091641.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163954.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-210053.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190002.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3625,24 +3391,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164251.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132615.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-172212.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-140513.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3672,31 +3420,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154135.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170532.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154323.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-082500.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101730.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3714,97 +3444,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-165007.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-205711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-182236.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-135136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-103737.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-213042.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-134029.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164826.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-162400.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110426.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-223023.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-134126.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-162245.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-105652.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-114127.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154055.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3828,25 +3474,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164801.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131809.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-175313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181604.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3870,25 +3498,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-110149.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-181656.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174414.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3900,19 +3510,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192541.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-233740.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173515.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3924,37 +3522,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190415.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192435.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-125910.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215656.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-135950.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092605.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3978,18 +3546,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154936.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132530.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174045.md",
           "line": 0,
           "confidence": "medium",
@@ -4008,31 +3564,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091938.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-133945.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174055.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001312.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110458.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4092,55 +3624,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105145.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-193609.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174351.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-154353.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-131211.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-130715.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182555.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-124641.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4158,31 +3648,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120114.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-234357.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110242.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-143756.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-235505.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4218,12 +3684,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001100.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-150417.md",
           "line": 0,
           "confidence": "medium",
@@ -4248,37 +3708,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-185913.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-154427.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-140559.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001518.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-184837.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4302,24 +3738,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-154541.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-105728.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-111510.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-180901.md",
           "line": 0,
           "confidence": "medium",
@@ -4327,18 +3745,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260702-133532.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145423.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-141624.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4362,24 +3768,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181236.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163830.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092533.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174025.md",
           "line": 0,
           "confidence": "medium",
@@ -4392,49 +3780,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145349.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-205433.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132944.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163746.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-091141.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184856.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-143844.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133446.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4447,42 +3793,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260702-223425.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-182836.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202450.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194130.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-213831.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174245.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4512,25 +3822,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-005225.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-143007.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-171058.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-150742.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4590,43 +3882,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-154637.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001919.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-220941.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174117.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-093202.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110206.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120150.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4650,43 +3906,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131734.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182807.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173917.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-185210.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-101322.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165256.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192433.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4698,31 +3918,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105013.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-200110.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-114242.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001233.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-162439.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4734,37 +3930,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002229.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-144202.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183102.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-133837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-233707.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212919.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4788,25 +3960,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164345.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120250.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165035.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-112952.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4824,36 +3978,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194053.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001439.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202651.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-143840.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-000955.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-144557.md",
           "line": 0,
           "confidence": "medium",
@@ -4861,18 +3985,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174133.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115538.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-113034.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4890,12 +4002,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-161502.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170255.md",
           "line": 0,
           "confidence": "medium",
@@ -4903,30 +4009,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164704.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132813.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164342.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-120815.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154835.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4944,37 +4026,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-155747.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173218.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260626-204822.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202348.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-161543.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4992,12 +4050,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-113257.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-181044.md",
           "line": 0,
           "confidence": "medium",
@@ -5010,31 +4062,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-133458.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164823.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-180900.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-104009.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5053,12 +4081,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-081735.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-154818.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5088,12 +4110,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170738.md",
           "line": 0,
           "confidence": "medium",
@@ -5113,12 +4129,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-153801.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194215.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5148,31 +4158,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084719.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132017.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-171157.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183350.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-150937.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5196,18 +4182,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-110050.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001337.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260627-133613.md",
           "line": 0,
           "confidence": "medium",
@@ -5226,12 +4200,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-220404.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-085740.md",
           "line": 0,
           "confidence": "medium",
@@ -5239,24 +4207,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260702-223359.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-193756.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163218.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163309.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5280,19 +4230,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202442.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164036.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5316,37 +4254,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214125.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132604.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-142359.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132933.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-175550.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174408.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5364,12 +4278,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182339.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165418.md",
           "line": 0,
           "confidence": "medium",
@@ -5382,18 +4290,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-155114.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133637.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-005655.md",
           "line": 0,
           "confidence": "medium",
@@ -5401,12 +4297,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165222.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-131140.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5466,49 +4356,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202558.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170940.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-163657.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215213.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-204345.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-153739.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175227.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5521,54 +4375,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260621-225313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164721.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-093336.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132207.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130940.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105058.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084617.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084805.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174631.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5592,37 +4398,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002322.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-220022.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-135838.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-152233.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181159.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5640,12 +4416,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131350.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-083101.md",
           "line": 0,
           "confidence": "medium",
@@ -5653,24 +4423,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260626-214501.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115557.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-114525.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-093128.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5688,61 +4440,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212552.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181706.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092013.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001702.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132130.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-163956.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001902.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-093246.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-204300.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5766,18 +4464,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132858.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165902.md",
           "line": 0,
           "confidence": "medium",
@@ -5790,25 +4476,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001029.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-172425.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145255.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-133730.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5820,61 +4488,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175929.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-172525.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133254.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184658.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164258.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194009.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260629-130359.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130821.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190539.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5892,37 +4512,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-163613.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-142458.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-005318.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-235409.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001952.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5940,37 +4530,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002154.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-171134.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260621-182630.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165733.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091717.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084911.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5994,43 +4554,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182346.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115503.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-101402.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260621-231038.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-123626.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184355.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-172751.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6042,37 +4566,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101633.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130900.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-103924.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101425.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-163837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175105.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6096,19 +4590,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-234704.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163238.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-172133.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6120,25 +4602,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214329.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-144506.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-210010.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173306.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6163,12 +4627,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-151341.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131314.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6252,7 +4710,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 531
+      "link_count": 267
     },
     {
       "id": "e45s19",
@@ -7038,18 +5496,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190334.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-144556.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-175346.md",
           "line": 0,
           "confidence": "medium",
@@ -7062,43 +5508,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-102313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-103815.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163934.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202335.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145222.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165427.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132836.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7116,31 +5526,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-155647.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181947.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212931.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-160106.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-180858.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7153,42 +5539,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-143153.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215320.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-172717.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174039.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132651.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212830.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182718.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7207,12 +5557,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-122420.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183547.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7254,12 +5598,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-160627.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-165137.md",
           "line": 0,
           "confidence": "medium",
@@ -7272,37 +5610,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-205519.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101228.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-102150.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214411.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260622-001710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-165047.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7315,24 +5623,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-000102.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133327.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001605.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105239.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7356,49 +5646,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101847.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173628.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182629.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154217.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-165703.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-143839.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163159.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260711-001225.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7416,31 +5670,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-185319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183644.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260629-132810.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001328.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7458,25 +5688,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-202226.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164609.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192340.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165651.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7494,37 +5706,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-160550.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-134603.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091641.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163954.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-210053.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190002.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7537,24 +5719,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164251.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132615.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-172212.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-140513.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7584,31 +5748,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154135.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170532.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154323.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-082500.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101730.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7626,97 +5772,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-165007.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-205711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-182236.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-135136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-103737.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-213042.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-134029.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164826.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-162400.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110426.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-223023.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-134126.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-162245.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-105652.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-114127.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154055.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7740,25 +5802,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164801.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131809.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-175313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181604.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7782,25 +5826,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-110149.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-181656.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174414.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7812,19 +5838,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192541.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-233740.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173515.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7836,37 +5850,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190415.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192435.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-125910.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215656.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-135950.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092605.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7890,18 +5874,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154936.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132530.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174045.md",
           "line": 0,
           "confidence": "medium",
@@ -7920,31 +5892,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091938.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-133945.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174055.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001312.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110458.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8004,55 +5952,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105145.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-193609.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174351.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-154353.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-131211.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-130715.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182555.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-124641.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8070,31 +5976,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120114.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-234357.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110242.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-143756.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-235505.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8130,12 +6012,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001100.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-150417.md",
           "line": 0,
           "confidence": "medium",
@@ -8160,37 +6036,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-185913.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-154427.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-140559.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001518.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-184837.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8214,24 +6066,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-154541.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-105728.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-111510.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-180901.md",
           "line": 0,
           "confidence": "medium",
@@ -8239,18 +6073,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260702-133532.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145423.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-141624.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8274,24 +6096,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181236.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163830.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092533.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174025.md",
           "line": 0,
           "confidence": "medium",
@@ -8304,49 +6108,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145349.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-205433.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132944.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163746.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-091141.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184856.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-143844.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133446.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8359,42 +6121,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260702-223425.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-182836.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202450.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194130.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-213831.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174245.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8424,25 +6150,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-005225.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-143007.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-171058.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-150742.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8502,43 +6210,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-154637.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001919.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-220941.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174117.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-093202.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110206.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120150.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8562,43 +6234,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131734.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182807.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173917.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-185210.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-101322.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165256.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192433.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8610,31 +6246,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105013.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-200110.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-114242.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001233.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-162439.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8646,37 +6258,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002229.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-144202.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183102.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-133837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-233707.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212919.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8700,25 +6288,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164345.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120250.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165035.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-112952.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8736,36 +6306,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194053.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001439.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202651.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-143840.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-000955.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-144557.md",
           "line": 0,
           "confidence": "medium",
@@ -8773,18 +6313,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174133.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115538.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-113034.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8802,12 +6330,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-161502.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170255.md",
           "line": 0,
           "confidence": "medium",
@@ -8815,30 +6337,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164704.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132813.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164342.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-120815.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154835.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8856,37 +6354,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-155747.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173218.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260626-204822.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202348.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-161543.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8904,12 +6378,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-113257.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-181044.md",
           "line": 0,
           "confidence": "medium",
@@ -8922,31 +6390,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-133458.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164823.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-180900.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-104009.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8965,12 +6409,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-081735.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-154818.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9000,12 +6438,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170738.md",
           "line": 0,
           "confidence": "medium",
@@ -9025,12 +6457,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-153801.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194215.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9060,31 +6486,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084719.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132017.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-171157.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183350.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-150937.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9108,18 +6510,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-110050.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001337.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260627-133613.md",
           "line": 0,
           "confidence": "medium",
@@ -9138,12 +6528,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-220404.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-085740.md",
           "line": 0,
           "confidence": "medium",
@@ -9151,24 +6535,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260702-223359.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-193756.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163218.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163309.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9192,19 +6558,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202442.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164036.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9228,37 +6582,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214125.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132604.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-142359.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132933.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-175550.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174408.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9276,12 +6606,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182339.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165418.md",
           "line": 0,
           "confidence": "medium",
@@ -9294,18 +6618,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-155114.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133637.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-005655.md",
           "line": 0,
           "confidence": "medium",
@@ -9313,12 +6625,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165222.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-131140.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9378,49 +6684,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202558.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170940.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-163657.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215213.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-204345.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-153739.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175227.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9433,54 +6703,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260621-225313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164721.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-093336.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132207.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130940.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105058.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084617.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084805.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174631.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9504,37 +6726,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002322.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-220022.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-135838.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-152233.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181159.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9552,12 +6744,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131350.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-083101.md",
           "line": 0,
           "confidence": "medium",
@@ -9565,24 +6751,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260626-214501.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115557.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-114525.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-093128.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9600,61 +6768,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212552.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181706.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092013.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001702.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132130.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-163956.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001902.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-093246.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-204300.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9678,18 +6792,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132858.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165902.md",
           "line": 0,
           "confidence": "medium",
@@ -9702,25 +6804,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001029.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-172425.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145255.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-133730.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9732,61 +6816,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175929.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-172525.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133254.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184658.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164258.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194009.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260629-130359.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130821.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190539.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9804,37 +6840,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-163613.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-142458.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-005318.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-235409.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001952.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9852,37 +6858,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002154.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-171134.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260621-182630.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165733.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091717.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084911.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9906,43 +6882,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182346.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115503.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-101402.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260621-231038.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-123626.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184355.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-172751.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9954,37 +6894,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101633.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130900.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-103924.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101425.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-163837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175105.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10008,19 +6918,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-234704.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163238.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-172133.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10032,25 +6930,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214329.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-144506.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-210010.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173306.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10075,12 +6955,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-151341.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131314.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10146,7 +7020,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 528
+      "link_count": 264
     },
     {
       "id": "e45s32",
@@ -10938,12 +7812,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "website/src/content/docs/skills/maintain-wiki.mdx",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "docs/references/agent-config-files-and-okf.md",
           "line": 0,
           "confidence": "medium",
@@ -10992,7 +7860,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 30
+      "link_count": 29
     },
     {
       "id": "e48s02",
@@ -11046,97 +7914,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-09.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-18.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/GOLDEN-2026-07-05.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-2026-07-06.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-07.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-23.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-13.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-23.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-07.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-21.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-06.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-18.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-2026-07-05.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-09.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-13.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-11.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -11238,7 +8022,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 39
+      "link_count": 25
     },
     {
       "id": "e48s03",
@@ -12010,15 +8794,9 @@
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
-        },
-        {
-          "file": "bigpowers-showcase/specs/bugs/BUG-2026-07-05-race-condition.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
         }
       ],
-      "link_count": 128
+      "link_count": 127
     },
     {
       "id": "e48s04",
@@ -12162,97 +8940,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-09.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-18.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/GOLDEN-2026-07-05.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-2026-07-06.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-07.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-23.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-13.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-23.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-07.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-21.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-06.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-18.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-2026-07-05.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-09.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-13.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-11.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -13050,7 +9744,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 158
+      "link_count": 144
     },
     {
       "id": "e48s06",
@@ -14412,18 +11106,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190334.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-144556.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-175346.md",
           "line": 0,
           "confidence": "medium",
@@ -14436,43 +11118,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-102313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-103815.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163934.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202335.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145222.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165427.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132836.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -14490,31 +11136,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-155647.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181947.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212931.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-160106.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-180858.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -14527,42 +11149,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-143153.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215320.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-172717.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174039.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132651.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212830.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182718.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -14581,12 +11167,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-122420.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183547.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -14628,12 +11208,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-160627.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-165137.md",
           "line": 0,
           "confidence": "medium",
@@ -14646,37 +11220,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-205519.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101228.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-102150.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214411.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260622-001710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-165047.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -14689,24 +11233,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-000102.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133327.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001605.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105239.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -14730,49 +11256,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101847.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173628.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182629.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154217.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-165703.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-143839.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163159.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260711-001225.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -14790,31 +11280,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-185319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183644.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260629-132810.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001328.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -14832,25 +11298,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-202226.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164609.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192340.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165651.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -14868,37 +11316,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-160550.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-134603.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091641.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163954.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-210053.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190002.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -14911,24 +11329,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164251.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132615.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-172212.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-140513.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -14958,31 +11358,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154135.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170532.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154323.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-082500.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101730.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15000,97 +11382,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-165007.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-205711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-182236.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-135136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-103737.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-213042.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-134029.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164826.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-162400.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110426.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-223023.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-134126.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-162245.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-105652.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-114127.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154055.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15114,25 +11412,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164801.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131809.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-175313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181604.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15156,25 +11436,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-110149.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-181656.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174414.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15186,19 +11448,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192541.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-233740.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173515.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15210,37 +11460,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190415.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192435.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-125910.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215656.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-135950.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092605.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15264,18 +11484,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154936.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132530.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174045.md",
           "line": 0,
           "confidence": "medium",
@@ -15294,31 +11502,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091938.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-133945.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174055.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001312.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110458.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15378,55 +11562,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105145.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-193609.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174351.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-154353.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-131211.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-130715.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182555.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-124641.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15444,31 +11586,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120114.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-234357.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110242.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-143756.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-235505.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15504,12 +11622,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001100.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-150417.md",
           "line": 0,
           "confidence": "medium",
@@ -15534,37 +11646,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-185913.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-154427.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-140559.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001518.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-184837.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15588,24 +11676,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-154541.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-105728.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-111510.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-180901.md",
           "line": 0,
           "confidence": "medium",
@@ -15613,18 +11683,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260702-133532.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145423.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-141624.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15648,24 +11706,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181236.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163830.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092533.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174025.md",
           "line": 0,
           "confidence": "medium",
@@ -15678,49 +11718,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145349.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-205433.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132944.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163746.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-091141.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184856.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-143844.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133446.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15733,42 +11731,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260702-223425.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-182836.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202450.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194130.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-213831.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174245.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15798,25 +11760,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-005225.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-143007.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-171058.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-150742.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15876,43 +11820,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-154637.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001919.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-220941.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174117.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-093202.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110206.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120150.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15936,43 +11844,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131734.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182807.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173917.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-185210.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-101322.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165256.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192433.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15984,31 +11856,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105013.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-200110.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-114242.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001233.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-162439.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16020,37 +11868,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002229.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-144202.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183102.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-133837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-233707.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212919.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16074,25 +11898,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164345.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120250.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165035.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-112952.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16110,36 +11916,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194053.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001439.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202651.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-143840.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-000955.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-144557.md",
           "line": 0,
           "confidence": "medium",
@@ -16147,18 +11923,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174133.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115538.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-113034.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16176,12 +11940,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-161502.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170255.md",
           "line": 0,
           "confidence": "medium",
@@ -16189,30 +11947,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164704.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132813.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164342.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-120815.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154835.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16230,37 +11964,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-155747.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173218.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260626-204822.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202348.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-161543.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16278,12 +11988,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-113257.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-181044.md",
           "line": 0,
           "confidence": "medium",
@@ -16296,31 +12000,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-133458.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164823.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-180900.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-104009.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16339,12 +12019,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-081735.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-154818.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16374,12 +12048,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170738.md",
           "line": 0,
           "confidence": "medium",
@@ -16399,12 +12067,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-153801.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194215.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16434,31 +12096,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084719.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132017.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-171157.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183350.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-150937.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16482,18 +12120,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-110050.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001337.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260627-133613.md",
           "line": 0,
           "confidence": "medium",
@@ -16512,12 +12138,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-220404.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-085740.md",
           "line": 0,
           "confidence": "medium",
@@ -16525,24 +12145,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260702-223359.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-193756.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163218.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163309.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16566,19 +12168,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202442.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164036.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16602,37 +12192,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214125.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132604.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-142359.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132933.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-175550.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174408.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16650,12 +12216,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182339.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165418.md",
           "line": 0,
           "confidence": "medium",
@@ -16668,18 +12228,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-155114.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133637.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-005655.md",
           "line": 0,
           "confidence": "medium",
@@ -16687,12 +12235,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165222.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-131140.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16752,49 +12294,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202558.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170940.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-163657.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215213.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-204345.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-153739.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175227.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16807,54 +12313,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260621-225313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164721.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-093336.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132207.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130940.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105058.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084617.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084805.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174631.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16878,37 +12336,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002322.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-220022.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-135838.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-152233.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181159.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16926,12 +12354,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131350.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-083101.md",
           "line": 0,
           "confidence": "medium",
@@ -16939,24 +12361,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260626-214501.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115557.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-114525.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-093128.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16974,61 +12378,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212552.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181706.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092013.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001702.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132130.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-163956.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001902.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-093246.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-204300.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17052,18 +12402,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132858.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165902.md",
           "line": 0,
           "confidence": "medium",
@@ -17076,25 +12414,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001029.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-172425.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145255.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-133730.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17106,61 +12426,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175929.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-172525.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133254.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184658.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164258.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194009.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260629-130359.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130821.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190539.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17178,37 +12450,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-163613.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-142458.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-005318.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-235409.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001952.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17226,37 +12468,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002154.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-171134.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260621-182630.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165733.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091717.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084911.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17280,43 +12492,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182346.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115503.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-101402.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260621-231038.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-123626.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184355.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-172751.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17328,37 +12504,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101633.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130900.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-103924.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101425.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-163837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175105.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17382,19 +12528,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-234704.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163238.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-172133.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17406,25 +12540,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214329.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-144506.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-210010.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173306.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17449,12 +12565,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-151341.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131314.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17754,7 +12864,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 576
+      "link_count": 312
     },
     {
       "id": "e51s05",
@@ -18451,11 +13561,251 @@
         }
       ],
       "link_count": 3
+    },
+    {
+      "id": "e61s01",
+      "title": "Hermes adapter + hook templates (Wave A)",
+      "epic_id": "e61",
+      "epic_title": "Integration: Hermes Agent \u2014 Skills + 3 Hook Systems",
+      "bcp": 0,
+      "wsjf": 5.0,
+      "status": "done",
+      "links": [
+        {
+          "file": "specs/verifications/AUDIT-e61-e61s01.md",
+          "line": 45,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e61-integration-hermes/e61s01-tasks.yaml",
+          "line": 14,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e61-integration-hermes/e61s01-hermes-adapter-hooks.md",
+          "line": 3,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "scripts/test-hermes-adapter.sh",
+          "line": 2,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "scripts/adapters/hermes.sh",
+          "line": 3,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "scripts/hooks/hermes/shell/hooks-config.example.yaml",
+          "line": 1,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "scripts/hooks/hermes/shell/block-dangerous-terminal.sh",
+          "line": 2,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "scripts/hooks/hermes/plugin/guard-git-plugin.py",
+          "line": 1,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "scripts/hooks/hermes/gateway/session-log/handler.py",
+          "line": 1,
+          "confidence": "high",
+          "method": "explicit_tag"
+        }
+      ],
+      "link_count": 9
+    },
+    {
+      "id": "e61s02",
+      "title": "Install hub wiring (Wave B)",
+      "epic_id": "e61",
+      "epic_title": "Integration: Hermes Agent \u2014 Skills + 3 Hook Systems",
+      "bcp": 0,
+      "wsjf": 5.0,
+      "status": "done",
+      "links": [
+        {
+          "file": "specs/verifications/e61s02-verify.yaml",
+          "line": 1,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/verifications/AUDIT-e61-e61s02.md",
+          "line": 48,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e61-integration-hermes/e61s02-tasks.yaml",
+          "line": 1,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "scripts/test-hermes-hub.sh",
+          "line": 2,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "scripts/lib/install-helpers.js",
+          "line": 3,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e76-integration-zcode/e76s02-hub-wiring.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/epics/e61-integration-hermes/e61s02-hub-wiring.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        }
+      ],
+      "link_count": 7
+    },
+    {
+      "id": "e76s01",
+      "title": "ZCode adapter \u2014 Wave A greenfield skills-dir",
+      "epic_id": "e76",
+      "epic_title": "Integration: ZCode \u2014 Skills + Plugin Hooks",
+      "bcp": 0,
+      "wsjf": 5.0,
+      "status": "done",
+      "links": [
+        {
+          "file": "specs/verifications/AUDIT-e76-e76s01.md",
+          "line": 57,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e76-integration-zcode/e76s01-tasks.yaml",
+          "line": 13,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e76-integration-zcode/e76s01-tasks.yaml",
+          "line": 17,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e76-integration-zcode/epic.yaml",
+          "line": 36,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e76-integration-zcode/e76s01-zcode-adapter.md",
+          "line": 1,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "scripts/adapters/zcode.sh",
+          "line": 2,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/archive/e37-reach/e37s10-wave-b-skills-dir.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        }
+      ],
+      "link_count": 7
+    },
+    {
+      "id": "e76s02",
+      "title": "Install hub wiring (Wave B)",
+      "epic_id": "e76",
+      "epic_title": "Integration: ZCode \u2014 Skills + Plugin Hooks",
+      "bcp": 0,
+      "wsjf": 5.0,
+      "status": "done",
+      "links": [
+        {
+          "file": "specs/state.yaml",
+          "line": 3,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/verifications/AUDIT-e76-e76s02.md",
+          "line": 47,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/verifications/e76s02-verify.yaml",
+          "line": 1,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e76-integration-zcode/epic.yaml",
+          "line": 53,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e76-integration-zcode/e76s02-tasks.yaml",
+          "line": 1,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "scripts/test-zcode-hub.sh",
+          "line": 2,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "scripts/lib/install-helpers.js",
+          "line": 4,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e76-integration-zcode/e76s02-hub-wiring.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/epics/e61-integration-hermes/e61s02-hub-wiring.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        }
+      ],
+      "link_count": 9
     }
   ],
   "summary": {
-    "total_stories": 84,
-    "tagged_stories": 74,
+    "total_stories": 88,
+    "tagged_stories": 78,
     "dark_stories": [],
     "dark_count": 0,
     "orphan_tags": [
@@ -18591,8 +13941,6 @@
       "e42s02",
       "e42s03",
       "e42s04",
-      "e43s01",
-      "e43s02",
       "e44s01",
       "e44s02",
       "e44s03",
@@ -18609,7 +13957,7 @@
       "e99s01",
       "e99s99"
     ],
-    "orphan_count": 149,
+    "orphan_count": 147,
     "stale_tags": [
       "e37s01",
       "e37s02",
@@ -18684,13 +14032,17 @@
       "e55s01",
       "e55s02",
       "e55s03",
-      "e60s01"
+      "e60s01",
+      "e61s01",
+      "e61s02",
+      "e76s01",
+      "e76s02"
     ],
-    "stale_count": 74,
+    "stale_count": 78,
     "oracle_stats": {
-      "high": 322,
-      "medium": 2522,
-      "low": 63
+      "high": 349,
+      "medium": 1711,
+      "low": 64
     }
   }
 }

--- a/specs/verifications/AUDIT-e76-e76s01.md
+++ b/specs/verifications/AUDIT-e76-e76s01.md
@@ -1,0 +1,66 @@
+# Audit Report — e76s01 (ZCode Adapter — Wave A)
+
+**Date:** 2026-07-24
+**Epic:** e76 — Integration: ZCode
+**Story:** e76s01 — ZCode adapter — Wave A greenfield skills-dir
+**Mode:** build-epic --fast, Wave A adapter-only
+**Verdict:** PASS
+
+## Scope reviewed
+
+| File | Change |
+|------|--------|
+| `scripts/adapters/zcode.sh` | NEW — greenfield adapter |
+| `specs/epics/e76-integration-zcode/epic.yaml` | Story manifest |
+| `specs/epics/e76-integration-zcode/e76s01-zcode-adapter.md` | Story spec |
+| `specs/epics/e76-integration-zcode/e76s01-tasks.yaml` | Tasks (all passing) |
+| `specs/security/epics/e76/THREAT_MODEL.md` | Step 0 threat model |
+| `specs/state.yaml` | epic_cycle progress |
+
+**Forbidden files (Wave A gate):** `install.sh`, `install-helpers.js`, `setup.js`, `targets.yaml`, `verify-install.sh` — **not modified** ✓
+
+## Verify evidence
+
+```text
+plan-consistency-check: CRITICAL=0 HIGH=0 MED=0 PASS
+Task 1–4 verify commands: all exit 0
+bash -n scripts/adapters/zcode.sh: OK
+render_skill temp-dir test: OK
+```
+
+## Checklist (audit-code --gate)
+
+### Supply Chain & Security
+- [x] No new external dependencies
+- [x] No secrets in diff
+- [x] Threat model at `specs/security/epics/e76/THREAT_MODEL.md`
+- [x] Home-dir writes documented; test uses `ZCODE_SKILLS` override
+
+### CONVENTIONS.md Compliance
+- [x] Spec output under `specs/`
+- [x] No gh issue create / REST API usage
+
+### Scope
+- [x] Changes limited to Wave A allowed paths
+- [x] No hub files touched
+- [x] No speculative plugin hook implementation
+
+### Boy Scout Rule
+- [x] New file only; no dead code
+
+### Test Coverage
+- [x] Adapter verified via temp-dir render_skill test and bash -n
+- [x] Behavior tested through public `render_skill` / `wire_context` interface
+
+### Code Style
+- [x] Matches existing adapter patterns (gemini.sh, cursor.sh)
+- [x] Story tag `# story: e76s01` present
+- [x] Quoted paths; shared context-wire.sh used
+
+## F.I.R.S.T (enforce-first --quick)
+
+N/A — bash adapter; headless verify commands cover observable outcomes. No new unit test file required for Wave A skeleton.
+
+## Result
+
+**PASS** — Ready for commit. Wave B hub wiring (targets.yaml, install hub) remains blocked per plan.

--- a/specs/verifications/AUDIT-e76-e76s02.md
+++ b/specs/verifications/AUDIT-e76-e76s02.md
@@ -1,0 +1,68 @@
+# Audit Report — e76s02: Install hub wiring (Wave B)
+
+**Date:** 2026-07-24
+**Mode:** `--gate`
+**Epic:** e76 — Integration: ZCode — Skills + Plugin Hooks
+**Story:** e76s02 — Install hub wiring (Wave B)
+**Files:** `scripts/install.sh`, `scripts/lib/install-helpers.js`, `bin/setup.js`, `scripts/targets.yaml`, `scripts/verify-install.sh`, `scripts/test-zcode-hub.sh`, `scripts/adapters/zcode.sh` (repo-relative defaults), capsule specs
+
+**Verify:**
+```bash
+bash scripts/test-zcode-hub.sh
+bash scripts/verify-install.sh
+bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js && node --check bin/setup.js
+```
+**Verify result:** PASS
+
+---
+
+## Gate summary (stderr-style)
+
+```
+PASS Supply Chain & Security
+PASS Provenance & Metadata
+PASS Law of Demeter
+PASS CONVENTIONS.md Compliance
+PASS Scope
+PASS Boy Scout Rule
+PASS Types and Safety
+PASS Test Coverage
+PASS SOLID and Heuristics
+PASS Code Style
+PASS Agent Readability
+```
+
+**Overall: PASS**
+
+---
+
+## Supply Chain & Security
+
+- [x] No new external packages
+- [x] Symlink-only install; AGENTS.md symlink to repo template (no home-dir skill writes during sync)
+- [x] THREAT_MODEL Wave B mitigations honored (no plugin hooks auto-installed)
+
+## Provenance & Metadata
+
+- [x] Story tag `# story: e76s02` on install helpers + test harness
+- [x] Capsule `e76s02-tasks.yaml` + spec present; epic.yaml updated
+
+## Scope
+
+- [x] Hub wiring only — Wave A adapter behavior preserved; defaults aligned to `.zcode/skills` for sync pipeline
+- [x] targets.yaml zcode row added
+
+## Test Coverage
+
+- [x] `scripts/test-zcode-hub.sh` — 18 assertions
+- [x] `verify-install.sh` — zcode source + setup.js + install-helpers checks
+- [x] Wave A e76s01 adapter verify commands still valid
+
+## SOLID and Heuristics
+
+- [x] `linkRenderedSkills` reused for zcode install cases
+- [x] Mirrors hermes/pi install patterns (symlink rendered output, context wiring)
+
+---
+
+**Next:** commit → push → release-branch (PR)

--- a/specs/verifications/e76s02-verify.yaml
+++ b/specs/verifications/e76s02-verify.yaml
@@ -1,0 +1,17 @@
+story: e76s02
+title: ZCode install hub wiring (Wave B)
+command: bash scripts/test-zcode-hub.sh && bash scripts/verify-install.sh
+expected_output: |
+  test-zcode-hub: 18 passed, 0 failed
+  Overall: pass
+checks:
+  - cmd: bash scripts/test-zcode-hub.sh
+    expect_exit: 0
+  - cmd: bash scripts/verify-install.sh
+    expect_exit: 0
+  - cmd: bash -n scripts/install.sh
+    expect_exit: 0
+  - cmd: node --check scripts/lib/install-helpers.js
+    expect_exit: 0
+  - cmd: node --check bin/setup.js
+    expect_exit: 0


### PR DESCRIPTION
## Summary

- **Wave A (e76s01):** Greenfield `scripts/adapters/zcode.sh` — skills at `.zcode/skills/`, context symlink to `.zcode/AGENTS.md`
- **Wave B (e76s02):** Install hub wiring — `install_zcode`/`uninstall_zcode`, `install-helpers.js` cases, `zcode` in `SUPPORTED_IDS`, `targets.yaml` row, `verify-install.sh` assertions, `test-zcode-hub.sh` harness (18/18 PASS)

Rebased onto `origin/main` (includes merged e61 PR #84).

## Test plan

- [x] `bash scripts/test-zcode-hub.sh` — 18 passed, 0 failed
- [x] `bash scripts/verify-install.sh` — 41 passed, 0 failed
- [x] `bash scripts/trace-stories.sh --strict`
- [x] audit-code `--gate` — PASS (`specs/verifications/AUDIT-e76-e76s02.md`)


Made with [Cursor](https://cursor.com)