### PR TITLE
feat(e69): MiMo Code integration — adapter + install hub

### DIFF
--- a/bin/setup.js
+++ b/bin/setup.js
@@ -48,6 +48,7 @@ const TOOLS = [
   { id: 'cursor', name: 'Cursor', globalPath: '~/.cursor', localPath: '.cursor' },
   { id: 'gemini', name: 'Gemini', globalPath: '~/.gemini', localPath: '.gemini' },
   { id: 'hermes', name: 'Hermes Agent', globalPath: '~/.hermes', localPath: '.hermes' },
+  { id: 'mimo', name: 'MiMo Code', globalPath: '~/.mimocode', localPath: '.mimocode' },
   { id: 'kilo', name: 'Kilo', globalPath: '~/.config/kilo', localPath: '.config/kilo' },
   { id: 'opencode', name: 'OpenCode', globalPath: '~/.config/opencode', localPath: '.config/opencode' },
   { id: 'qwen', name: 'Qwen Code', globalPath: '~/.qwen', localPath: '.qwen' },
@@ -56,7 +57,7 @@ const TOOLS = [
   { id: 'zcode', name: 'ZCode', globalPath: '~/.zcode', localPath: '.zcode' },
 ];
 const ALL_ID = '__all__';
-const SUPPORTED_IDS = new Set(['claude', 'gemini', 'pi', 'hermes', 'zcode', 'cursor', 'codex']);
+const SUPPORTED_IDS = new Set(['claude', 'gemini', 'pi', 'hermes', 'mimo', 'zcode', 'cursor', 'codex']);
 const UNSUPPORTED_HINT = '(TODO)';
 
 // ── clack helpers (lazy ESM import from CJS) ─────────────────────────────────

--- a/scripts/adapters/mimo.sh
+++ b/scripts/adapters/mimo.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# story: e69s01
+
+render_skill() {
+  if declare -f render_mimo_skill >/dev/null 2>&1; then
+    render_mimo_skill
+    return
+  fi
+  mkdir -p "${MIMO_SKILLS:-.mimocode/skills}/$IR_NAME"
+  cp "${SKILL_MD_PATH:-}" "${MIMO_SKILLS}/$IR_NAME/SKILL.md" 2>/dev/null || {
+    {
+      echo "---"
+      echo "name: $IR_NAME"
+      [[ -n "$IR_MODEL" ]] && echo "model: $IR_MODEL"
+      echo "description: \"$IR_DESC_ESCAPED\""
+      echo "---"
+      echo ""
+      echo "${IR_BODY_SKILL:-$IR_BODY}"
+    } > "${MIMO_SKILLS}/$IR_NAME/SKILL.md"
+  }
+}
+
+wire_context() {
+  source "$(dirname "${BASH_SOURCE[0]}")/../lib/context-wire.sh"
+  wire_context_mode symlink "${1:-AGENTS.md}"
+}
+
+# If stdin is a pipe/redirect, read the SkillIR JSON and render
+if [[ ! -t 0 ]]; then
+  JSON_INPUT=$(cat)
+  if [[ -n "$JSON_INPUT" ]]; then
+    IR_NAME=$(echo "$JSON_INPUT" | jq -r '.name')
+    IR_MODEL=$(echo "$JSON_INPUT" | jq -r '.model // empty')
+    IR_DESCRIPTION=$(echo "$JSON_INPUT" | jq -r '.description')
+    IR_BODY=$(echo "$JSON_INPUT" | jq -r '.body')
+    IR_BODY_SKILL=$(echo "$JSON_INPUT" | jq -r '.body_mimo_skill // .body')
+    IR_DESC_ESCAPED=$(echo "$IR_DESCRIPTION" | sed 's/\\/\\\\/g; s/\"/\\"/g')
+    render_skill
+  fi
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,6 +8,7 @@
 #   pi           → ~/.pi/agent/skills/<name>/ (one symlink per skill)
 #   Hermes Agent → ~/.hermes/skills/<name>/ (symlink rendered .hermes/skills/)
 #   ZCode        → ~/.zcode/skills/<name>/ (symlink rendered .zcode/skills/)
+#   MiMo Code    → ~/.mimocode/skills/<name>/ (symlink rendered .mimocode/skills/)
 #   Cursor       → ~/.cursor/rules/ (one dir symlink; per-project note printed)
 #
 # Usage:
@@ -319,6 +320,46 @@ uninstall_zcode() {
   unlink_if_managed "$ZCODE_AGENTS" "$REPO_ROOT/"
 }
 
+# ── MiMo Code (e69s02) ────────────────────────────────────────────────────────
+
+MIMO_CONFIG_DIR="$HOME/.mimocode"
+MIMO_SKILLS_DIR="$MIMO_CONFIG_DIR/skills"
+MIMO_RENDERED="$REPO_ROOT/.mimocode/skills"
+MIMO_AGENTS="$MIMO_CONFIG_DIR/AGENTS.md"
+
+install_mimo() {
+  echo ""
+  echo "MiMo Code → $MIMO_SKILLS_DIR/"
+  if [[ ! -d "$MIMO_RENDERED" ]]; then
+    echo "  WARNING: $MIMO_RENDERED not found — run sync-skills.sh first"
+    return
+  fi
+  local count=0
+  for skill_dir in "$MIMO_RENDERED"/*/; do
+    [[ -f "${skill_dir}SKILL.md" ]] || continue
+    local name; name="$(basename "$skill_dir")"
+    link "$skill_dir" "$MIMO_SKILLS_DIR/$name"
+    count=$((count + 1))
+  done
+  echo "  $count skills installed"
+
+  echo "MiMo Code → context symlink $MIMO_AGENTS"
+  source "$REPO_ROOT/scripts/lib/context-wire.sh"
+  wire_context_mode symlink "$MIMO_AGENTS" "" "" "" "$REPO_ROOT/AGENTS.md"
+}
+
+uninstall_mimo() {
+  echo ""
+  echo "MiMo Code → removing management from $MIMO_CONFIG_DIR/"
+  if [[ -d "$MIMO_SKILLS_DIR" ]]; then
+    for dst in "$MIMO_SKILLS_DIR"/*/; do
+      [[ -L "${dst%/}" ]] || continue
+      unlink_if_managed "${dst%/}" "$REPO_ROOT/"
+    done
+  fi
+  unlink_if_managed "$MIMO_AGENTS" "$REPO_ROOT/"
+}
+
 # ── Codex CLI (e37s15) ───────────────────────────────────────────────────────
 
 CODEX_DIR="$HOME/.codex"
@@ -350,6 +391,7 @@ if $UNINSTALL; then
   uninstall_pi
   uninstall_hermes
   uninstall_zcode
+  uninstall_mimo
   uninstall_cursor
   uninstall_codex
   echo ""
@@ -360,6 +402,7 @@ else
   install_pi
   install_hermes
   install_zcode
+  install_mimo
   install_cursor
   install_codex
   echo ""

--- a/scripts/lib/install-helpers.js
+++ b/scripts/lib/install-helpers.js
@@ -2,6 +2,7 @@
 // story: e60s01
 // story: e61s02
 // story: e76s02
+// story: e69s02
 // install-helpers.js — symlink helpers for bigpowers setup
 
 const fs = require('fs');
@@ -129,6 +130,16 @@ function installGlobal(tool, repoRoot) {
       linkFile(agentsSrc, agentsDst);
       break;
     }
+    case 'mimo': {
+      const renderedDir = path.join(repoRoot, '.mimocode', 'skills');
+      const targetDir = path.join(homeDir, '.mimocode', 'skills');
+      linkRenderedSkills(renderedDir, targetDir);
+      const agentsSrc = path.join(repoRoot, 'AGENTS.md');
+      const agentsDst = path.join(homeDir, '.mimocode', 'AGENTS.md');
+      fs.mkdirSync(path.dirname(agentsDst), { recursive: true });
+      linkFile(agentsSrc, agentsDst);
+      break;
+    }
     case 'cursor': {
       const rulesSrc = path.join(repoRoot, '.cursor', 'rules');
       const rulesDst = path.join(homeDir, '.cursor', 'rules');
@@ -183,6 +194,16 @@ function installLocal(tool, repoRoot) {
       linkRenderedSkills(renderedDir, targetDir);
       const agentsSrc = path.join(repoRoot, 'AGENTS.md');
       const agentsDst = path.join(cwd, '.zcode', 'AGENTS.md');
+      fs.mkdirSync(path.dirname(agentsDst), { recursive: true });
+      linkFile(agentsSrc, agentsDst);
+      break;
+    }
+    case 'mimo': {
+      const renderedDir = path.join(repoRoot, '.mimocode', 'skills');
+      const targetDir = path.join(cwd, '.mimocode', 'skills');
+      linkRenderedSkills(renderedDir, targetDir);
+      const agentsSrc = path.join(repoRoot, 'AGENTS.md');
+      const agentsDst = path.join(cwd, '.mimocode', 'AGENTS.md');
       fs.mkdirSync(path.dirname(agentsDst), { recursive: true });
       linkFile(agentsSrc, agentsDst);
       break;
@@ -268,6 +289,20 @@ function uninstallTool(toolId, repoRoot) {
         }
       }
       removeSymlink(path.join(homeDir, '.zcode', 'AGENTS.md'));
+      break;
+    }
+    case 'mimo': {
+      const skillsDir = path.join(homeDir, '.mimocode', 'skills');
+      if (fs.existsSync(skillsDir)) {
+        for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+          if (!entry.isSymbolicLink()) continue;
+          const target = fs.readlinkSync(path.join(skillsDir, entry.name));
+          if (target.includes('bigpowers') || target.includes('.mimocode/skills')) {
+            removeSymlink(path.join(skillsDir, entry.name));
+          }
+        }
+      }
+      removeSymlink(path.join(homeDir, '.mimocode', 'AGENTS.md'));
       break;
     }
     case 'cursor':

--- a/scripts/targets.yaml
+++ b/scripts/targets.yaml
@@ -141,6 +141,19 @@ targets:
     contracts:
       - agents_md_exists
 
+  - id: mimo
+    name: MiMo Code
+    tier: opt_in
+    skill:
+      adapter: mimo
+      output: .mimocode/skills
+    context:
+      adapter: mimo
+      mode: symlink
+      file: AGENTS.md
+    contracts:
+      - agents_md_exists
+
   # Wave C (e37s11)
   - id: qwen
     name: Qwen (Alibaba)

--- a/scripts/test-mimo-hub.sh
+++ b/scripts/test-mimo-hub.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# story: e69s02
+# Regression tests for MiMo Code install hub wiring (Wave B).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+echo "=== test-mimo-hub.sh ==="
+
+INSTALL_SH="$REPO_ROOT/scripts/install.sh"
+HELPERS_JS="$REPO_ROOT/scripts/lib/install-helpers.js"
+SETUP_JS="$REPO_ROOT/bin/setup.js"
+TARGETS_YAML="$REPO_ROOT/scripts/targets.yaml"
+
+grep -q 'install_mimo()' "$INSTALL_SH" && pass 'install.sh: install_mimo()' || fail 'install.sh: missing install_mimo()'
+grep -q 'uninstall_mimo()' "$INSTALL_SH" && pass 'install.sh: uninstall_mimo()' || fail 'install.sh: missing uninstall_mimo()'
+grep -q 'MIMO_SKILLS_DIR=' "$INSTALL_SH" && pass 'install.sh: MIMO_SKILLS_DIR' || fail 'install.sh: missing MIMO_SKILLS_DIR'
+grep -q 'install_mimo' "$INSTALL_SH" && grep -q 'uninstall_mimo' "$INSTALL_SH" && pass 'install.sh: dispatch wired' || fail 'install.sh: dispatch missing mimo'
+
+DRY_OUT="$(bash "$INSTALL_SH" --dry-run 2>&1)"
+echo "$DRY_OUT" | grep -q 'MiMo Code →' && pass 'dry-run: MiMo Code section' || fail 'dry-run: missing MiMo Code section'
+DRY_UNINSTALL="$(bash "$INSTALL_SH" --dry-run --uninstall 2>&1)"
+echo "$DRY_UNINSTALL" | grep -q 'MiMo Code →' && pass 'dry-run uninstall: MiMo Code section' || fail 'dry-run uninstall: missing MiMo Code section'
+
+grep -q "case 'mimo'" "$HELPERS_JS" && pass 'install-helpers: mimo global case' || fail 'install-helpers: missing mimo global case'
+grep -q "case 'mimo'" "$HELPERS_JS" && pass 'install-helpers: mimo cases present' || fail 'install-helpers: missing mimo cases'
+
+SETUP_SRC="$(cat "$SETUP_JS")"
+echo "$SETUP_SRC" | grep -q "SUPPORTED_IDS = new Set" && pass 'setup.js: SUPPORTED_IDS set' || fail 'setup.js: missing SUPPORTED_IDS'
+echo "$SETUP_SRC" | grep -q "'mimo'" "$SETUP_JS" && pass 'setup.js: mimo in TOOLS' || fail 'setup.js: mimo missing from TOOLS'
+echo "$SETUP_SRC" | grep -q "'mimo'" && echo "$SETUP_SRC" | grep -q "SUPPORTED_IDS" \
+  && grep -q "'mimo'" <<< "$(sed -n "/SUPPORTED_IDS = new Set/,/);/p" "$SETUP_JS")" \
+  && pass 'setup.js: mimo in SUPPORTED_IDS' || fail 'setup.js: mimo not in SUPPORTED_IDS'
+
+grep -q 'id: mimo' "$TARGETS_YAML" && pass 'targets.yaml: mimo row' || fail 'targets.yaml: missing mimo row'
+grep -q 'adapter: mimo' "$TARGETS_YAML" && pass 'targets.yaml: mimo adapter' || fail 'targets.yaml: missing mimo adapter'
+grep -q 'output: .mimocode/skills' "$TARGETS_YAML" && pass 'targets.yaml: mimo output path' || fail 'targets.yaml: missing mimo output'
+
+grep -q 'install_mimo()' "$REPO_ROOT/scripts/verify-install.sh" && pass 'verify-install: install_mimo assertion' || fail 'verify-install: missing install_mimo assertion'
+
+bash -n "$INSTALL_SH" && pass 'bash -n install.sh' || fail 'bash -n install.sh'
+node --check "$HELPERS_JS" && pass 'node --check install-helpers.js' || fail 'node --check install-helpers.js'
+node --check "$SETUP_JS" && pass 'node --check setup.js' || fail 'node --check setup.js'
+
+echo "test-mimo-hub: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -139,6 +139,11 @@ grep -q 'uninstall_zcode()' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: 
 grep -q 'ZCODE_SKILLS_DIR=' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: targets ~/.zcode/skills/" || ta_fail "source: wrong zcode target"
 grep -q "'zcode'" "$REPO_ROOT/bin/setup.js" && grep -q 'SUPPORTED_IDS' "$REPO_ROOT/bin/setup.js" && ta_pass "setup.js: zcode supported" || ta_fail "setup.js: zcode not in SUPPORTED_IDS"
 grep -q "case 'zcode'" "$REPO_ROOT/scripts/lib/install-helpers.js" && ta_pass "install-helpers: zcode case" || ta_fail "install-helpers: missing zcode case"
+grep -q 'install_mimo()' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: install_mimo()" || ta_fail "source: missing install_mimo()"
+grep -q 'uninstall_mimo()' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: uninstall_mimo()" || ta_fail "source: missing uninstall_mimo()"
+grep -q 'MIMO_SKILLS_DIR=' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: targets ~/.mimocode/skills/" || ta_fail "source: wrong mimo target"
+grep -q "'mimo'" "$REPO_ROOT/bin/setup.js" && grep -q 'SUPPORTED_IDS' "$REPO_ROOT/bin/setup.js" && ta_pass "setup.js: mimo supported" || ta_fail "setup.js: mimo not in SUPPORTED_IDS"
+grep -q "case 'mimo'" "$REPO_ROOT/scripts/lib/install-helpers.js" && ta_pass "install-helpers: mimo case" || ta_fail "install-helpers: missing mimo case"
 ! grep -q 'install_opencode\|print_opencode_instructions' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: no opencode functions" || ta_fail "source: opencode functions remain"
 
 echo ""

--- a/specs/benchmarks/reports/GOLDEN-2026-07-24.yaml
+++ b/specs/benchmarks/reports/GOLDEN-2026-07-24.yaml
@@ -1,0 +1,64 @@
+timestamp: "2026-07-24T13:55:47Z"
+git_commit: "c9d194e3b57d093e8a3f4eeb342dd1f267f57fdc"
+suite: "golden-combined"
+mode: "daily"
+deterministic:
+  total: 11
+  passed: 11
+  failed: 0
+  skipped: 0
+  pass_rate: 1.00
+gates:
+  - name: compliance
+    exit_code: 0
+    duration_seconds: 33.09
+    status: pass
+  - name: g04-selftest
+    exit_code: 0
+    duration_seconds: .03
+    status: pass
+  - name: g06-migrate-version
+    exit_code: 0
+    duration_seconds: 38.49
+    status: pass
+  - name: g07-negative-path
+    exit_code: 0
+    duration_seconds: .06
+    status: pass
+  - name: g08-anti-vacuity
+    exit_code: 0
+    duration_seconds: .56
+    status: pass
+  - name: g09-yaml-roundtrip
+    exit_code: 0
+    duration_seconds: 1.00
+    status: pass
+  - name: g10-trace-anti-vacuity
+    exit_code: 0
+    duration_seconds: .80
+    status: pass
+  - name: g11-gitignore-venv
+    exit_code: 0
+    duration_seconds: .14
+    status: pass
+  - name: import-boundaries
+    exit_code: 0
+    duration_seconds: .32
+    status: pass
+  - name: skill-catalog
+    exit_code: 0
+    duration_seconds: 2.27
+    status: pass
+  - name: specs-parse
+    exit_code: 0
+    duration_seconds: 3.46
+    status: pass
+agent_stories:
+  total: 0
+  passed: 0
+  failed: 0
+  skipped: 0
+  flake_count: 0
+  pass_rate: n/a
+summary:
+  combined_verdict: "pass"

--- a/specs/codebase-wiki/e69s01.md
+++ b/specs/codebase-wiki/e69s01.md
@@ -1,0 +1,50 @@
+---
+type: Story
+id: e69s01
+epic: e69
+bcps: 0
+wsjf: 5.0
+implementation_status: backlog
+coverage_status: covered
+confidence: high
+links:
+  - file: specs/state.yaml
+    line: 3
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e69-integration-mimo-code/e69s01-tasks.yaml
+    line: 14
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e69-integration-mimo-code/e69s01-mimo-adapter.md
+    line: 1
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e69-integration-mimo-code/e69s01-mimo-adapter.md
+    line: 20
+    confidence: high
+    method: explicit_tag
+  - file: scripts/adapters/mimo.sh
+    line: 2
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/archive/e37-reach/e37s10-wave-b-skills-dir.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+---
+
+# e69s01: MiMo Code adapter — Wave A skills-dir (.mimocode/skills/)
+
+**Epic:** e69 — Integration: MiMo Code — Skills + Plugins (No Hooks)
+**Status:** backlog
+**BCP:** 0 | **WSJF:** 5.0
+
+## Implemented In
+
+- `specs/state.yaml` (line 3, confidence: high, method: explicit_tag)
+- `specs/epics/e69-integration-mimo-code/e69s01-tasks.yaml` (line 14, confidence: high, method: explicit_tag)
+- `specs/epics/e69-integration-mimo-code/e69s01-mimo-adapter.md` (line 1, confidence: high, method: explicit_tag)
+- `specs/epics/e69-integration-mimo-code/e69s01-mimo-adapter.md` (line 20, confidence: high, method: explicit_tag)
+- `scripts/adapters/mimo.sh` (line 2, confidence: high, method: explicit_tag)
+- `specs/epics/archive/e37-reach/e37s10-wave-b-skills-dir.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/epics-wiki/e69.okf.md
+++ b/specs/epics-wiki/e69.okf.md
@@ -1,0 +1,25 @@
+---
+okf_kind: concept
+okf_version: "0.1"
+type: epic
+id: "e69"
+title: "Integration: MiMo Code — Skills + Plugins (No Hooks)"
+category: epic
+tier: specialized
+wsjf: 5.0
+bcps: 0
+status: scoped
+release: unknown
+codename: ""
+story_count: 1
+generator: scripts/generate-epics-wiki.sh
+references:
+    - e69s01
+---
+
+# Integration: MiMo Code — Skills + Plugins (No Hooks)
+
+**Epic:** e69 | **WSJF:** 5.0 | **BCP:** 0 | **Status:** scoped
+**Release:** unknown | **Tier:** specialized
+
+1 stories. See `/Users/danielvm/Developer/bp-e69/specs/epics/e69-integration-mimo-code/epic.yaml` for full specifications.

--- a/specs/epics/e69-integration-mimo-code/e69s01-mimo-adapter.md
+++ b/specs/epics/e69-integration-mimo-code/e69s01-mimo-adapter.md
@@ -1,0 +1,49 @@
+# story: e69s01
+# MiMo Code adapter — Wave A skills-dir (.mimocode/skills/)
+
+**type:** feat  
+**risk:** P2  
+**context:** infra  
+**bcps:** 2
+
+## Context
+
+Wave A adapter-only story for epic e69. MiMo Code (XiaomiMiMo/MiMo-Code) discovers skills at `.mimocode/skills/<name>/SKILL.md`. No adapter exists yet. This story adds `scripts/adapters/mimo.sh` following the pi.sh/cursor.sh SkillIR pattern. Registry wiring (`targets.yaml`), install hub files, and verify-install assertions are **Wave B** — explicitly out of scope here.
+
+## Requirements
+
+### ADDED
+
+- `scripts/adapters/mimo.sh` exports `render_skill` writing SKILL.md frontmatter + body to `${MIMO_SKILLS:-.mimocode/skills}/$IR_NAME/SKILL.md`
+- Adapter accepts SkillIR JSON on stdin (same contract as pi.sh/cursor.sh)
+- Adapter exports `wire_context` symlinking AGENTS.md via `context-wire.sh`
+- Story tagged `# story: e69s01` in adapter source
+
+## 17. Acceptance Criteria
+
+```bash
+test -f scripts/adapters/mimo.sh &&
+bash -c 'source scripts/adapters/mimo.sh && declare -f render_skill wire_context >/dev/null' &&
+REPO="$(git rev-parse --show-toplevel)" &&
+TMP="$(mktemp -d)" &&
+cd "$TMP" &&
+export IR_NAME=smoke IR_DESC_ESCAPED=Smoke IR_BODY='# Smoke' MIMO_SKILLS=.mimocode/skills &&
+source "$REPO/scripts/adapters/mimo.sh" &&
+render_skill &&
+test -f .mimocode/skills/smoke/SKILL.md &&
+grep -q smoke .mimocode/skills/smoke/SKILL.md &&
+echo OK
+```
+
+## Out of scope
+
+- `scripts/targets.yaml` mimo row (Wave B)
+- `install.sh`, `install-helpers.js`, `setup.js`, `verify-install.sh` changes
+- MiMo plugin rendering (`.mimocode/plugins/` — future story)
+- Hooks (MiMo has none per epic research)
+- E2E with MiMo Code binary
+
+## Risks
+
+- **Registry gap:** `test-adapters.sh mimo` fails until Wave B adds targets.yaml row — mitigated by standalone smoke verify above.
+- **Context file:** MiMo may prefer project-specific config; Wave A uses AGENTS.md symlink per e37 context spine.

--- a/specs/epics/e69-integration-mimo-code/e69s01-tasks.yaml
+++ b/specs/epics/e69-integration-mimo-code/e69s01-tasks.yaml
@@ -1,0 +1,93 @@
+story_id: e69s01
+title: "MiMo Code adapter — Wave A skills-dir (.mimocode/skills/)"
+spec: e69s01-mimo-adapter.md
+status: passing
+bcps: 2
+risk: P2
+depends_on: []
+tasks:
+  - id: 1
+    description: >-
+      Create scripts/adapters/mimo.sh: skills-dir adapter targeting
+      .mimocode/skills/<name>/SKILL.md per XiaomiMiMo/MiMo-Code layout.
+      Follow pi.sh/cursor.sh SkillIR pattern (render_skill + wire_context +
+      JSON stdin). Tag # story: e69s01. Wave A — no targets.yaml row.
+    verify: >-
+      test -f scripts/adapters/mimo.sh &&
+      bash -c 'source scripts/adapters/mimo.sh && declare -f render_skill wire_context >/dev/null' &&
+      echo OK
+    risk: P2
+    security: low
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - "Wave A"
+        - "Integration"
+
+  - id: 2
+    description: >-
+      Smoke-test render_skill writes .mimocode/skills/<name>/SKILL.md with
+      frontmatter from IR globals in an isolated temp directory.
+    verify: >-
+      REPO="$(git rev-parse --show-toplevel)" &&
+      TMP="$(mktemp -d)" &&
+      cd "$TMP" &&
+      export IR_NAME=smoke IR_DESC_ESCAPED=Smoke IR_BODY='# Smoke' MIMO_SKILLS=.mimocode/skills &&
+      source "$REPO/scripts/adapters/mimo.sh" &&
+      render_skill &&
+      test -f .mimocode/skills/smoke/SKILL.md &&
+      grep -q smoke .mimocode/skills/smoke/SKILL.md &&
+      echo OK
+    risk: P2
+    security: low
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - "Wave A"
+        - "Integration"
+
+  - id: 3
+    description: >-
+      Smoke-test JSON stdin path renders SKILL.md (pi.sh contract).
+    verify: >-
+      REPO="$(git rev-parse --show-toplevel)" &&
+      TMP="$(mktemp -d)" &&
+      cd "$TMP" &&
+      export MIMO_SKILLS=.mimocode/skills &&
+      echo '{"name":"json-smoke","description":"JSON smoke","body":"# JSON body"}' |
+      bash "$REPO/scripts/adapters/mimo.sh" &&
+      test -f .mimocode/skills/json-smoke/SKILL.md &&
+      grep -q 'JSON body' .mimocode/skills/json-smoke/SKILL.md &&
+      echo OK
+    risk: P2
+    security: low
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - "Wave A"
+        - "Integration"
+
+  - id: 4
+    description: >-
+      Story verify: adapter exists, functions defined, render smoke passes.
+      No forbidden hub files modified.
+    verify: >-
+      test -f scripts/adapters/mimo.sh &&
+      ! git diff --name-only HEAD | grep -E '^(scripts/install\.sh|scripts/lib/install-helpers\.js|bin/setup\.js|scripts/targets\.yaml|scripts/verify-install\.sh)$' &&
+      echo OK
+    risk: P2
+    security: low
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - "Wave A"
+
+out_of_scope:
+  - "targets.yaml mimo row (Wave B)"
+  - "install.sh / setup.js / verify-install.sh hub wiring"
+  - "MiMo plugin adapter (.mimocode/plugins/)"
+  - "E2E with MiMo Code CLI"

--- a/specs/epics/e69-integration-mimo-code/e69s02-hub-wiring.md
+++ b/specs/epics/e69-integration-mimo-code/e69s02-hub-wiring.md
@@ -1,0 +1,29 @@
+# e69s02: Install hub wiring (Wave B)
+
+Wire MiMo Code into the bigpowers install hub: `install.sh`, `install-helpers.js`, `bin/setup.js`, `targets.yaml`, and `verify-install.sh`. Wave A adapter remains unchanged.
+
+## In scope
+
+- `install_mimo()` / `uninstall_mimo()` in `scripts/install.sh` — symlink rendered `.mimocode/skills/<name>/` into `~/.mimocode/skills/`, symlink `AGENTS.md` into `~/.mimocode/AGENTS.md`.
+- `mimo` cases in `scripts/lib/install-helpers.js` (global + local + uninstall).
+- Add `mimo` to `SUPPORTED_IDS` in `bin/setup.js`.
+- `mimo` row in `scripts/targets.yaml`.
+- MiMo contract assertions in `scripts/verify-install.sh`.
+- `scripts/test-mimo-hub.sh` regression harness.
+
+## Out of scope
+
+- Live MiMo Code UAT
+- MiMo plugins (`.mimocode/plugins/` — future story)
+- Hooks (MiMo has none per epic research)
+
+## Verify
+
+```bash
+bash scripts/test-mimo-hub.sh &&
+bash scripts/verify-install.sh &&
+bash -n scripts/install.sh &&
+node --check scripts/lib/install-helpers.js &&
+node --check bin/setup.js &&
+echo OK
+```

--- a/specs/epics/e69-integration-mimo-code/e69s02-tasks.yaml
+++ b/specs/epics/e69-integration-mimo-code/e69s02-tasks.yaml
@@ -1,0 +1,37 @@
+# story: e69s02
+title: "Install hub wiring (Wave B)"
+status: passing
+risk: P1
+spec: e69s02-hub-wiring.md
+tasks:
+  - id: t1
+    title: Add scripts/test-mimo-hub.sh regression harness
+    status: passing
+    verify: bash scripts/test-mimo-hub.sh
+  - id: t2
+    title: Wire install_mimo/uninstall_mimo in scripts/install.sh
+    status: passing
+    verify: bash -n scripts/install.sh && bash scripts/install.sh --dry-run 2>&1 | grep -q 'MiMo Code →'
+  - id: t3
+    title: Add mimo cases to scripts/lib/install-helpers.js
+    status: passing
+    verify: node --check scripts/lib/install-helpers.js
+  - id: t4
+    title: Add mimo to SUPPORTED_IDS in bin/setup.js
+    status: passing
+    verify: node --check bin/setup.js && grep -q "'mimo'" bin/setup.js
+  - id: t5
+    title: Add mimo row to scripts/targets.yaml
+    status: passing
+    verify: grep -q 'id: mimo' scripts/targets.yaml && grep -q 'adapter: mimo' scripts/targets.yaml
+  - id: t6
+    title: Extend scripts/verify-install.sh with mimo contract assertions
+    status: passing
+    verify: bash scripts/verify-install.sh
+  - id: t7
+    title: Story gate — hub harness + verify-install green
+    status: passing
+    verify: >-
+      bash scripts/test-mimo-hub.sh &&
+      bash scripts/verify-install.sh &&
+      echo OK

--- a/specs/epics/e69-integration-mimo-code/epic.yaml
+++ b/specs/epics/e69-integration-mimo-code/epic.yaml
@@ -27,3 +27,9 @@ stories:
     status: done
     spec: e69s01-mimo-adapter.md
     tasks: e69s01-tasks.yaml
+  - id: e69s02
+    title: "Install hub wiring (Wave B)"
+    bcps: 2
+    status: done
+    spec: e69s02-hub-wiring.md
+    tasks: e69s02-tasks.yaml

--- a/specs/epics/e69-integration-mimo-code/epic.yaml
+++ b/specs/epics/e69-integration-mimo-code/epic.yaml
@@ -20,4 +20,10 @@ integration_details:
   hooks: false
   hook_events: []
   hook_events_count: 0
-stories: []
+stories:
+  - id: e69s01
+    title: "MiMo Code adapter — Wave A skills-dir (.mimocode/skills/)"
+    bcps: 2
+    status: done
+    spec: e69s01-mimo-adapter.md
+    tasks: e69s01-tasks.yaml

--- a/specs/execution-status.yaml
+++ b/specs/execution-status.yaml
@@ -352,8 +352,9 @@ development_status:
   e66: backlog
   e67: backlog
   e68: backlog
-  e69: backlog
-  e69s01: backlog
+  e69: in_progress
+  e69s01: done
+  e69s02: done
   e70: backlog
   e71: backlog
   e72: backlog
@@ -3062,16 +3063,17 @@ stories:
     tasks_passing: 6
     tasks_failing: 0
     risk_max: P1
-  e69s01:
+  e69s02:
     status: done
-    title: 'MiMo Code adapter — Wave A skills-dir (.mimocode/skills/)'
+    title: "Install hub wiring (Wave B)"
     bcps: 2
     epic: e69
-    tasks_total: 4
-    tasks_passing: 4
+    started_at: "2026-07-24T11:25:00-03:00"
+    completed_at: "2026-07-24T11:35:00-03:00"
+    tasks_total: 7
+    tasks_passing: 7
     tasks_failing: 0
-    risk_max: P2
-    security_max: low
+    risk_max: P1
   e76s01:
     status: done
     title: ZCode adapter — Wave A greenfield skills-dir

--- a/specs/execution-status.yaml
+++ b/specs/execution-status.yaml
@@ -353,6 +353,7 @@ development_status:
   e67: backlog
   e68: backlog
   e69: backlog
+  e69s01: backlog
   e70: backlog
   e71: backlog
   e72: backlog
@@ -367,6 +368,7 @@ development_status:
   generated_at: '2026-07-07T04:00:00Z'
   heuristic_ratio: 0.8
   verdict: PASS
+
 epics:
   e01:
     status: done
@@ -374,11 +376,11 @@ epics:
     total_bcps: 4
   e02:
     status: done
-    title: Verification & Evals
+    title: 'Verification & Evals'
     total_bcps: 4
   e03:
     status: done
-    title: Discovery & Planning
+    title: 'Discovery & Planning'
     total_bcps: 2
   e04:
     status: done
@@ -390,7 +392,7 @@ epics:
     total_bcps: 3
   e06:
     status: done
-    title: Taxonomy & Provenance
+    title: 'Taxonomy & Provenance'
     total_bcps: 3
   e07:
     status: done
@@ -402,7 +404,7 @@ epics:
     total_bcps: 1
   e09:
     status: done
-    title: Self-Evolution
+    title: 'Self-Evolution'
     total_bcps: 11
   e10:
     status: done
@@ -418,15 +420,15 @@ epics:
     total_bcps: 8
   e13:
     status: done
-    title: Catalog Integrity & Index Automation
+    title: 'Catalog Integrity & Index Automation'
     total_bcps: 3
   e14:
     status: done
-    title: Release Hardening & Quality Metrics
+    title: 'Release Hardening & Quality Metrics'
     total_bcps: 3
   e15:
     status: done
-    title: CI/CD Pipeline & Package Publishing
+    title: 'CI/CD Pipeline & Package Publishing'
     total_bcps: 5
   e16:
     status: done
@@ -438,19 +440,19 @@ epics:
     total_bcps: 3
   e18:
     status: done
-    title: Quality Gates & Impact Analysis
+    title: 'Quality Gates & Impact Analysis'
     total_bcps: 5
   e19:
     status: done
-    title: Quick-Fix Fast-Path
+    title: 'Quick-Fix Fast-Path'
     total_bcps: 3
   e20:
     status: done
-    title: Build-Epic Ergonomics & Flow Polish
+    title: 'Build-Epic Ergonomics & Flow Polish'
     total_bcps: 5
   e21:
     status: done
-    title: MCP-Native Discovery & Tool Integration
+    title: 'MCP-Native Discovery & Tool Integration'
     total_bcps: 8
   e22:
     status: done
@@ -466,11 +468,11 @@ epics:
     total_bcps: 3
   e25:
     status: done
-    title: Migrate-Spec Methodology Enhancements
+    title: 'Migrate-Spec Methodology Enhancements'
     total_bcps: 10
   e26:
     status: done
-    title: Security-Review Lifecycle Integration
+    title: 'Security-Review Lifecycle Integration'
     total_bcps: 21
   e27:
     status: done
@@ -519,7 +521,7 @@ epics:
     total_bcps: 45
   e38:
     status: done
-    title: Spec-to-Code Traceability Gate
+    title: 'Spec-to-Code Traceability Gate'
     total_bcps: 13
   e39:
     status: done
@@ -527,7 +529,7 @@ epics:
     total_bcps: 20
   e40:
     status: done
-    title: Metrics Integrity — Honest, Additive, Benchmarkable
+    title: 'Metrics Integrity — Honest, Additive, Benchmarkable'
     total_bcps: 18
   e41:
     status: done
@@ -535,7 +537,7 @@ epics:
     total_bcps: 10
   e42:
     status: done
-    title: Golden Story Suite — Agent-Driven
+    title: 'Golden Story Suite — Agent-Driven'
     total_bcps: 10
   e43:
     status: done
@@ -543,20 +545,20 @@ epics:
     total_bcps: 11
   e44:
     status: done
-    title: Spec Version Migration — migrate-version Skill
+    title: 'Spec Version Migration — migrate-version Skill'
     total_bcps: 14
   e45:
     status: done
-    title: Quality Core — Skill Hardening & Verification Patterns
+    title: 'Quality Core — Skill Hardening & Verification Patterns'
     wsjf: 5.0
     total_bcps: 45
   e46:
     status: done
-    title: Risk-Based Verification — TEA-Informed Test Depth
+    title: 'Risk-Based Verification — TEA-Informed Test Depth'
     total_bcps: 16
   e47:
     status: done
-    title: Cross-Tool Skill Distribution — global install + per-project seed
+    title: 'Cross-Tool Skill Distribution — global install + per-project seed'
     total_bcps: 9
   e48:
     status: done
@@ -565,12 +567,12 @@ epics:
     total_bcps: 40
   e51:
     status: done
-    title: Always Green — Shift Left, Preflight Hard Block & Fix-or-Log Doctrine
+    title: 'Always Green — Shift Left, Preflight Hard Block & Fix-or-Log Doctrine'
     wsjf: 7.0
     total_bcps: 12
   e53:
     status: done
-    title: Establish Migration Baseline — bigpowers-to-bigspec Readiness
+    title: 'Establish Migration Baseline — bigpowers-to-bigspec Readiness'
     wsjf: 8.0
     total_bcps: 9
   e54:
@@ -595,17 +597,17 @@ epics:
     total_bcps: 0
   e58:
     status: backlog
-    title: Evals Over Compliance — Replace the 94% Gate with Outcome Proof
+    title: 'Evals Over Compliance — Replace the 94% Gate with Outcome Proof'
     wsjf: 5.3
     total_bcps: 0
   e59:
     status: backlog
-    title: Absorb Fresh References — Stay in Sync with bigspec's Ongoing Evolution
+    title: 'Absorb Fresh References — Stay in Sync with bigspec''s Ongoing Evolution'
     wsjf: 3.7
     total_bcps: 0
   e60:
     status: done
-    title: Interactive Installer — BMAD-Polished Setup for bigpowers
+    title: 'Interactive Installer — BMAD-Polished Setup for bigpowers'
     wsjf: 9.0
     total_bcps: 3
   e61:
@@ -698,10 +700,11 @@ epics:
     title: 'Integration: Cursor — Rules (No Hooks)'
     wsjf: 7.0
     total_bcps: 0
+
 stories:
   e01s01:
     status: done
-    title: slopcheck tags in `plan-work` ([OK]/[SUS]/[SLOP])
+    title: 'slopcheck tags in `plan-work` ([OK]/[SUS]/[SLOP])'
     bcps: 1
     epic: e01
     tasks_total: 0
@@ -709,7 +712,7 @@ stories:
     tasks_failing: 0
   e01s02:
     status: done
-    title: Supply-chain + OWASP in `audit-code`
+    title: 'Supply-chain + OWASP in `audit-code`'
     bcps: 1
     epic: e01
     tasks_total: 0
@@ -717,7 +720,7 @@ stories:
     tasks_failing: 0
   e01s03:
     status: done
-    title: Secret patterns documented in `guard-git`
+    title: 'Secret patterns documented in `guard-git`'
     bcps: 1
     epic: e01
     tasks_total: 0
@@ -741,7 +744,7 @@ stories:
     tasks_failing: 0
   e02s02:
     status: done
-    title: Verification Script template in `plan-work`
+    title: 'Verification Script template in `plan-work`'
     bcps: 1
     epic: e02
     tasks_total: 0
@@ -749,7 +752,7 @@ stories:
     tasks_failing: 0
   e02s03:
     status: done
-    title: UAT checkpoint in `execute-plan`
+    title: 'UAT checkpoint in `execute-plan`'
     bcps: 1
     epic: e02
     tasks_total: 0
@@ -757,7 +760,7 @@ stories:
     tasks_failing: 0
   e02s04:
     status: done
-    title: RED/GREEN/REFACTOR commits in `develop-tdd`
+    title: 'RED/GREEN/REFACTOR commits in `develop-tdd`'
     bcps: 1
     epic: e02
     tasks_total: 0
@@ -781,7 +784,7 @@ stories:
     tasks_failing: 0
   e03s03:
     status: done
-    title: Absorb 5 near-duplicate utility skills into session-state and survey-context
+    title: 'Absorb 5 near-duplicate utility skills into session-state and survey-context'
     bcps: 1
     epic: e03
     tasks_total: 0
@@ -789,7 +792,7 @@ stories:
     tasks_failing: 0
   e04s01:
     status: done
-    title: Handoff + compaction in `session-state`
+    title: 'Handoff + compaction in `session-state`'
     bcps: 1
     epic: e04
     tasks_total: 0
@@ -861,7 +864,7 @@ stories:
     tasks_failing: 0
   e07s01:
     status: done
-    title: Demeter in CONVENTIONS.md + audit-code
+    title: 'Demeter in CONVENTIONS.md + audit-code'
     bcps: 1
     epic: e07
     tasks_total: 0
@@ -869,7 +872,7 @@ stories:
     tasks_failing: 0
   e07s02:
     status: done
-    title: Module Depth score in deepen-architecture
+    title: 'Module Depth score in deepen-architecture'
     bcps: 1
     epic: e07
     tasks_total: 0
@@ -877,7 +880,7 @@ stories:
     tasks_failing: 0
   e07s03:
     status: done
-    title: Concurrency audit in model-domain
+    title: 'Concurrency audit in model-domain'
     bcps: 1
     epic: e07
     tasks_total: 0
@@ -893,7 +896,7 @@ stories:
     tasks_failing: 0
   e09s01:
     status: done
-    title: stocktake-skills, evolve-skill, search-skills, compose-workflow, simulate-agents
+    title: 'stocktake-skills, evolve-skill, search-skills, compose-workflow, simulate-agents'
     bcps: 1
     epic: e09
     tasks_total: 0
@@ -909,7 +912,7 @@ stories:
     tasks_failing: 0
   e09s03:
     status: done
-    title: craft-skill README generator
+    title: 'craft-skill README generator'
     bcps: 1
     epic: e09
     tasks_total: 0
@@ -917,7 +920,7 @@ stories:
     tasks_failing: 0
   e09s04:
     status: done
-    title: Iterative retrieval in dispatch-agents / delegate-task
+    title: 'Iterative retrieval in dispatch-agents / delegate-task'
     bcps: 1
     epic: e09
     tasks_total: 0
@@ -925,8 +928,7 @@ stories:
     tasks_failing: 0
   e09s05:
     status: done
-    title: evolve-skill benchmark path documented; run `bash scripts/score_run.sh`
-      in bigpo
+    title: 'evolve-skill benchmark path documented; run `bash scripts/score_run.sh` in bigpo'
     bcps: 1
     epic: e09
     tasks_total: 0
@@ -942,7 +944,7 @@ stories:
     tasks_failing: 0
   e10s01:
     status: done
-    title: profiles/swift.md, typescript-vue.md, node-service.md
+    title: 'profiles/swift.md, typescript-vue.md, node-service.md'
     bcps: 1
     epic: e10
     tasks_total: 0
@@ -950,7 +952,7 @@ stories:
     tasks_failing: 0
   e10s02:
     status: done
-    title: seed-conventions profile picker
+    title: 'seed-conventions profile picker'
     bcps: 1
     epic: e10
     tasks_total: 0
@@ -974,7 +976,7 @@ stories:
     tasks_failing: 0
   e11s03:
     status: done
-    title: BCP accounting + cycle-time ledger
+    title: 'BCP accounting + cycle-time ledger'
     bcps: 1
     epic: e11
     tasks_total: 0
@@ -990,7 +992,7 @@ stories:
     tasks_failing: 0
   e11s05:
     status: done
-    title: SKILL-INDEX fix + dead code removal
+    title: 'SKILL-INDEX fix + dead code removal'
     bcps: 1
     epic: e11
     tasks_total: 0
@@ -998,7 +1000,7 @@ stories:
     tasks_failing: 0
   e12s01:
     status: done
-    title: Pi skill generation — .pi/skills/<name>/SKILL.md
+    title: 'Pi skill generation — .pi/skills/<name>/SKILL.md'
     bcps: 2
     epic: e12
     tasks_total: 4
@@ -1006,7 +1008,7 @@ stories:
     tasks_failing: 0
   e12s02:
     status: done
-    title: Pi prompt templates — .pi/prompts/<name>.md
+    title: 'Pi prompt templates — .pi/prompts/<name>.md'
     bcps: 1
     epic: e12
     tasks_total: 3
@@ -1022,7 +1024,7 @@ stories:
     tasks_failing: 0
   e12s04:
     status: done
-    title: sync-skills.sh pi target
+    title: 'sync-skills.sh pi target'
     bcps: 2
     epic: e12
     tasks_total: 6
@@ -1046,7 +1048,7 @@ stories:
     tasks_failing: 0
   e13s01:
     status: done
-    title: Regenerate skills-lock.json with all 62 skills
+    title: 'Regenerate skills-lock.json with all 62 skills'
     bcps: 1
     epic: e13
     tasks_total: 0
@@ -1054,7 +1056,7 @@ stories:
     tasks_failing: 0
   e13s02:
     status: done
-    title: Autogenerate SKILL-INDEX.md from lockfile + frontmatter
+    title: 'Autogenerate SKILL-INDEX.md from lockfile + frontmatter'
     bcps: 1
     epic: e13
     tasks_total: 0
@@ -1070,7 +1072,7 @@ stories:
     tasks_failing: 0
   e14s01:
     status: done
-    title: Harden release-branch solo-local fallback
+    title: 'Harden release-branch solo-local fallback'
     bcps: 1
     epic: e14
     tasks_total: 0
@@ -1078,7 +1080,7 @@ stories:
     tasks_failing: 0
   e14s02:
     status: done
-    title: Add fix-rate KPI to session-state tracking
+    title: 'Add fix-rate KPI to session-state tracking'
     bcps: 1
     epic: e14
     tasks_total: 0
@@ -1110,7 +1112,7 @@ stories:
     tasks_failing: 0
   e15s03:
     status: done
-    title: Add CI verification step to release-branch + CI dry-run to develop-tdd
+    title: 'Add CI verification step to release-branch + CI dry-run to develop-tdd'
     bcps: 1
     epic: e15
     tasks_total: 3
@@ -1134,8 +1136,7 @@ stories:
     tasks_failing: 0
   e17s01:
     status: done
-    title: 'craft-skill: validate-contracts — assert data shape consistency across
-      system boundaries'
+    title: 'craft-skill: validate-contracts — assert data shape consistency across system boundaries'
     bcps: 1
     epic: e17
     tasks_total: 5
@@ -1143,7 +1144,7 @@ stories:
     tasks_failing: 0
   e18s01:
     status: done
-    title: audit-code as hard gate in build-epic step 6
+    title: 'audit-code as hard gate in build-epic step 6'
     bcps: 2
     epic: e18
     tasks_total: 4
@@ -1151,7 +1152,7 @@ stories:
     tasks_failing: 0
   e18s02:
     status: done
-    title: Wire enforce-first (F.I.R.S.T) into build-epic gate chain
+    title: 'Wire enforce-first (F.I.R.S.T) into build-epic gate chain'
     bcps: 1
     epic: e18
     tasks_total: 2
@@ -1159,7 +1160,7 @@ stories:
     tasks_failing: 0
   e18s03:
     status: done
-    title: Wire assess-impact into build-epic step 2 (plan-work)
+    title: 'Wire assess-impact into build-epic step 2 (plan-work)'
     bcps: 1
     epic: e18
     tasks_total: 3
@@ -1167,7 +1168,7 @@ stories:
     tasks_failing: 0
   e18s04:
     status: done
-    title: Universalize resume/checkpoint pattern to fix-bug and orchestrate-project
+    title: 'Universalize resume/checkpoint pattern to fix-bug and orchestrate-project'
     bcps: 1
     epic: e18
     tasks_total: 3
@@ -1175,7 +1176,7 @@ stories:
     tasks_failing: 0
   e18s05:
     status: done
-    title: Add auto-timing to critical-path skills for stocktake effectiveness
+    title: 'Add auto-timing to critical-path skills for stocktake effectiveness'
     bcps: 1
     epic: e18
     tasks_total: 3
@@ -1191,7 +1192,7 @@ stories:
     tasks_failing: 0
   e20s01:
     status: done
-    title: change-request conversational intake — parse natural-language requests
+    title: 'change-request conversational intake — parse natural-language requests'
     bcps: 1
     epic: e20
     tasks_total: 2
@@ -1199,8 +1200,7 @@ stories:
     tasks_failing: 0
   e20s02:
     status: done
-    title: 'Reduce state.yaml commit noise — squash state: commits or out-of-band
-      tracking'
+    title: 'Reduce state.yaml commit noise — squash state: commits or out-of-band tracking'
     bcps: 1
     epic: e20
     tasks_total: 2
@@ -1208,7 +1208,7 @@ stories:
     tasks_failing: 0
   e20s03:
     status: done
-    title: kickoff-branch pre-commit for spec artifacts — fix dirty-tree conflicts
+    title: 'kickoff-branch pre-commit for spec artifacts — fix dirty-tree conflicts'
     bcps: 1
     epic: e20
     tasks_total: 2
@@ -1216,7 +1216,7 @@ stories:
     tasks_failing: 0
   e20s04:
     status: done
-    title: verify-work verify-command validation — detect mismatches before UAT
+    title: 'verify-work verify-command validation — detect mismatches before UAT'
     bcps: 1
     epic: e20
     tasks_total: 1
@@ -1224,7 +1224,7 @@ stories:
     tasks_failing: 0
   e20s05:
     status: done
-    title: develop-tdd --config mode + build-epic --fast mode
+    title: 'develop-tdd --config mode + build-epic --fast mode'
     bcps: 1
     epic: e20
     tasks_total: 2
@@ -1232,7 +1232,7 @@ stories:
     tasks_failing: 0
   e20s06:
     status: done
-    title: verify-work --cli mode for CLI tools
+    title: 'verify-work --cli mode for CLI tools'
     bcps: 1
     epic: e20
     tasks_total: 2
@@ -1240,7 +1240,7 @@ stories:
     tasks_failing: 0
   e21s01:
     status: done
-    title: MCP-native skill discovery — register skills as MCP tools
+    title: 'MCP-native skill discovery — register skills as MCP tools'
     bcps: 3
     epic: e21
     tasks_total: 6
@@ -1248,7 +1248,7 @@ stories:
     tasks_failing: 0
   e21s02:
     status: done
-    title: Wire opensrc into research-first for learn-before-build
+    title: 'Wire opensrc into research-first for learn-before-build'
     bcps: 2
     epic: e21
     tasks_total: 2
@@ -1256,7 +1256,7 @@ stories:
     tasks_failing: 0
   e21s03:
     status: done
-    title: CI-aware skills — read preflight commands from AGENTS.md
+    title: 'CI-aware skills — read preflight commands from AGENTS.md'
     bcps: 1
     epic: e21
     tasks_total: 2
@@ -1264,7 +1264,7 @@ stories:
     tasks_failing: 0
   e21s04:
     status: done
-    title: compose-workflow → AGENTS.md agentic stack mapping
+    title: 'compose-workflow → AGENTS.md agentic stack mapping'
     bcps: 2
     epic: e21
     tasks_total: 2
@@ -1272,7 +1272,7 @@ stories:
     tasks_failing: 0
   e22s01:
     status: done
-    title: scripts/run-skill-verify.sh — machine-runnable catalog health check
+    title: 'scripts/run-skill-verify.sh — machine-runnable catalog health check'
     bcps: 1
     epic: e22
     tasks_total: 2
@@ -1280,7 +1280,7 @@ stories:
     tasks_failing: 0
   e22s02:
     status: done
-    title: Wire skill-verify to CI and stocktake-skills --verify mode
+    title: 'Wire skill-verify to CI and stocktake-skills --verify mode'
     bcps: 1
     epic: e22
     tasks_total: 2
@@ -1296,7 +1296,7 @@ stories:
     tasks_failing: 0
   e23s02:
     status: done
-    title: Create run-benchmark skill
+    title: 'Create run-benchmark skill'
     bcps: 1
     epic: e23
     tasks_total: 2
@@ -1304,7 +1304,7 @@ stories:
     tasks_failing: 0
   e23s03:
     status: done
-    title: Wire evolve-skill to use run-benchmark output
+    title: 'Wire evolve-skill to use run-benchmark output'
     bcps: 1
     epic: e23
     tasks_total: 2
@@ -1312,7 +1312,7 @@ stories:
     tasks_failing: 0
   e24s01:
     status: done
-    title: elaborate-spec writes specs/planning-context.yaml
+    title: 'elaborate-spec writes specs/planning-context.yaml'
     bcps: 1
     epic: e24
     tasks_total: 2
@@ -1320,7 +1320,7 @@ stories:
     tasks_failing: 0
   e24s02:
     status: done
-    title: scope-work and slice-tasks read planning-context.yaml
+    title: 'scope-work and slice-tasks read planning-context.yaml'
     bcps: 1
     epic: e24
     tasks_total: 2
@@ -1328,7 +1328,7 @@ stories:
     tasks_failing: 0
   e24s03:
     status: done
-    title: run-planning tracks context lifecycle in planning-status.yaml
+    title: 'run-planning tracks context lifecycle in planning-status.yaml'
     bcps: 1
     epic: e24
     tasks_total: 2
@@ -1336,7 +1336,7 @@ stories:
     tasks_failing: 0
   e25s01:
     status: done
-    title: Promote ID tracking from YAML comments to first-class fields
+    title: 'Promote ID tracking from YAML comments to first-class fields'
     bcps: 2
     epic: e25
     tasks_total: 5
@@ -1344,7 +1344,7 @@ stories:
     tasks_failing: 0
   e25s02:
     status: done
-    title: Emit FR-XX / UJ-XX REQUIREMENTS_TRACE.yaml on migration
+    title: 'Emit FR-XX / UJ-XX REQUIREMENTS_TRACE.yaml on migration'
     bcps: 2
     epic: e25
     tasks_total: 4
@@ -1368,7 +1368,7 @@ stories:
     tasks_failing: 0
   e25s05:
     status: done
-    title: Add two-pass spec writing gate (spec-kit learning)
+    title: 'Add two-pass spec writing gate (spec-kit learning)'
     bcps: 2
     epic: e25
     tasks_total: 3
@@ -1384,7 +1384,7 @@ stories:
     tasks_failing: 0
   e26s01:
     status: done
-    title: Core security-review skill + reference files
+    title: 'Core security-review skill + reference files'
     bcps: 5
     epic: e26
     tasks_total: 5
@@ -1393,7 +1393,7 @@ stories:
     security_max: none
   e26s02:
     status: done
-    title: build-epic integration — threat model step
+    title: 'build-epic integration — threat model step'
     bcps: 3
     epic: e26
     tasks_total: 2
@@ -1402,7 +1402,7 @@ stories:
     security_max: low
   e26s03:
     status: done
-    title: plan-work / plan-release integration
+    title: 'plan-work / plan-release integration'
     bcps: 3
     epic: e26
     tasks_total: 2
@@ -1411,7 +1411,7 @@ stories:
     security_max: low
   e26s04:
     status: done
-    title: audit-code / request-review integration
+    title: 'audit-code / request-review integration'
     bcps: 3
     epic: e26
     tasks_total: 2
@@ -1420,7 +1420,7 @@ stories:
     security_max: low
   e26s05:
     status: done
-    title: verify-work integration — Phase 5 security scan
+    title: 'verify-work integration — Phase 5 security scan'
     bcps: 4
     epic: e26
     tasks_total: 3
@@ -1429,7 +1429,7 @@ stories:
     security_max: medium
   e26s06:
     status: done
-    title: release-branch hard gate
+    title: 'release-branch hard gate'
     bcps: 2
     epic: e26
     tasks_total: 2
@@ -1438,7 +1438,7 @@ stories:
     security_max: medium
   e26s07:
     status: done
-    title: fix-bug / validate-fix integration
+    title: 'fix-bug / validate-fix integration'
     bcps: 1
     epic: e26
     tasks_total: 2
@@ -1447,7 +1447,7 @@ stories:
     security_max: high
   e27s01:
     status: done
-    title: Rename generated specs-root files to _LATEST.md in all source skills
+    title: 'Rename generated specs-root files to _LATEST.md in all source skills'
     bcps: 7
     epic: e27
     tasks_total: 9
@@ -1455,8 +1455,7 @@ stories:
     tasks_failing: 0
   e28s01:
     status: done
-    title: Create scripts/lib/skill-common.sh with shared functions (resolve_repo_root,
-      parse_frontmatter, iterate_skills)
+    title: 'Create scripts/lib/skill-common.sh with shared functions (resolve_repo_root, parse_frontmatter, iterate_skills)'
     bcps: 3
     epic: e28
     tasks_total: 4
@@ -1464,7 +1463,7 @@ stories:
     tasks_failing: 0
   e28s02:
     status: done
-    title: Refactor 13 scripts to source skill-common.sh instead of duplicating boilerplate
+    title: 'Refactor 13 scripts to source skill-common.sh instead of duplicating boilerplate'
     bcps: 2
     epic: e28
     tasks_total: 3
@@ -1472,7 +1471,7 @@ stories:
     tasks_failing: 0
   e28s03:
     status: done
-    title: Refactor sync-skills.sh to use render-target functions (one per target)
+    title: 'Refactor sync-skills.sh to use render-target functions (one per target)'
     bcps: 5
     epic: e28
     tasks_total: 4
@@ -1480,8 +1479,7 @@ stories:
     tasks_failing: 0
   e28s04:
     status: done
-    title: Refactor regenerate-lockfile.sh, generate-skill-index.sh, build-skill-index.sh
-      to source skill-common.sh
+    title: 'Refactor regenerate-lockfile.sh, generate-skill-index.sh, build-skill-index.sh to source skill-common.sh'
     bcps: 3
     epic: e28
     tasks_total: 4
@@ -1489,7 +1487,7 @@ stories:
     tasks_failing: 0
   e29s01:
     status: done
-    title: Location-agnostic skill discovery in all consumer scripts
+    title: 'Location-agnostic skill discovery in all consumer scripts'
     bcps: 3
     epic: e29
     tasks_total: 4
@@ -1497,7 +1495,7 @@ stories:
     tasks_failing: 0
   e29s02:
     status: done
-    title: Relocate skill sources to skills/ and re-point CI
+    title: 'Relocate skill sources to skills/ and re-point CI'
     bcps: 3
     epic: e29
     tasks_total: 5
@@ -1513,7 +1511,7 @@ stories:
     tasks_failing: 0
   e30s01:
     status: done
-    title: Add 3 missing skills to get_phase() in generate-skill-index.sh
+    title: 'Add 3 missing skills to get_phase() in generate-skill-index.sh'
     bcps: 2
     epic: e30
     tasks_total: 0
@@ -1521,7 +1519,7 @@ stories:
     tasks_failing: 0
   e30s02:
     status: done
-    title: Fix 4 broken specs/tech-architecture/ references
+    title: 'Fix 4 broken specs/tech-architecture/ references'
     bcps: 2
     epic: e30
     tasks_total: 0
@@ -1537,7 +1535,7 @@ stories:
     tasks_failing: 0
   e30s04:
     status: done
-    title: Replace tautological verify commands with behavior-relevant checks
+    title: 'Replace tautological verify commands with behavior-relevant checks'
     bcps: 3
     epic: e30
     tasks_total: 0
@@ -1545,8 +1543,7 @@ stories:
     tasks_failing: 0
   e31s01:
     status: done
-    title: 'Create scripts/golden-g04-selftest.sh — sync-pipeline self-test (G-04):
-      asserts 72 artifacts per target, skills-lock.json count, SKILL-INDEX total'
+    title: 'Create scripts/golden-g04-selftest.sh — sync-pipeline self-test (G-04): asserts 72 artifacts per target, skills-lock.json count, SKILL-INDEX total'
     bcps: 2
     epic: e31
     tasks_total: 4
@@ -1554,8 +1551,7 @@ stories:
     tasks_failing: 0
   e31s02:
     status: done
-    title: Wire npm run compliance into CI (.github/workflows/publish.yml) as a gate
-      before semantic-release
+    title: 'Wire npm run compliance into CI (.github/workflows/publish.yml) as a gate before semantic-release'
     bcps: 2
     epic: e31
     tasks_total: 3
@@ -1563,9 +1559,7 @@ stories:
     tasks_failing: 0
   e31s03:
     status: done
-    title: 'Create scripts/run-golden-suite.sh (deterministic mode): compliance ->
-      G-04 self-test -> size budget; writes specs/benchmarks/reports/GOLDEN-<date>.yaml;
-      --baseline pins'
+    title: 'Create scripts/run-golden-suite.sh (deterministic mode): compliance -> G-04 self-test -> size budget; writes specs/benchmarks/reports/GOLDEN-<date>.yaml; --baseline pins'
     bcps: 3
     epic: e31
     tasks_total: 5
@@ -1573,8 +1567,7 @@ stories:
     tasks_failing: 0
   e31s04:
     status: done
-    title: Add static size budget to run-golden-suite.sh — per-skill and total SKILL.md
-      bytes vs baseline (+20% warn, +50% fail)
+    title: 'Add static size budget to run-golden-suite.sh — per-skill and total SKILL.md bytes vs baseline (+20% warn, +50% fail)'
     bcps: 1
     epic: e31
     tasks_total: 3
@@ -1582,7 +1575,7 @@ stories:
     tasks_failing: 0
   e31s05:
     status: done
-    title: Pin baseline via run-golden-suite.sh --baseline -> specs/benchmarks/reports/BASELINE-GOLDEN.yaml
+    title: 'Pin baseline via run-golden-suite.sh --baseline -> specs/benchmarks/reports/BASELINE-GOLDEN.yaml'
     bcps: 1
     epic: e31
     tasks_total: 2
@@ -1590,7 +1583,7 @@ stories:
     tasks_failing: 0
   e31s06:
     status: done
-    title: Mandate run-golden-suite.sh as pre-merge step in CLAUDE.md and CONVENTIONS.md
+    title: 'Mandate run-golden-suite.sh as pre-merge step in CLAUDE.md and CONVENTIONS.md'
     bcps: 1
     epic: e31
     tasks_total: 2
@@ -1598,8 +1591,7 @@ stories:
     tasks_failing: 0
   e31s07:
     status: done
-    title: Point evolve-skill SKILL.md at run-golden-suite.sh for regression checks
-      (keeps per-skill run-benchmark for capability evals)
+    title: 'Point evolve-skill SKILL.md at run-golden-suite.sh for regression checks (keeps per-skill run-benchmark for capability evals)'
     bcps: 1
     epic: e31
     tasks_total: 1
@@ -1607,8 +1599,7 @@ stories:
     tasks_failing: 0
   e32s01:
     status: done
-    title: 'Spike: build bigpowers-mcp with index_skills + read_skill, validate against
-      all SKILL.md files'
+    title: 'Spike: build bigpowers-mcp with index_skills + read_skill, validate against all SKILL.md files'
     bcps: 3
     epic: e32
     tasks_total: 5
@@ -1618,8 +1609,7 @@ stories:
     security_max: low
   e32s02:
     status: done
-    title: Add build_skill_graph tool — entity-relation model from parsed SKILL.md
-      data
+    title: 'Add build_skill_graph tool — entity-relation model from parsed SKILL.md data'
     bcps: 3
     epic: e32
     tasks_total: 0
@@ -1651,7 +1641,7 @@ stories:
     tasks_failing: 0
   e32s06:
     status: done
-    title: Register bigpowers-mcp in MCP client configs (Claude Code, Cursor, OpenCode)
+    title: 'Register bigpowers-mcp in MCP client configs (Claude Code, Cursor, OpenCode)'
     bcps: 1
     epic: e32
     tasks_total: 0
@@ -1659,7 +1649,7 @@ stories:
     tasks_failing: 0
   e32s07:
     status: done
-    title: Write docs/references/bigpowers-mcp.md — architecture and operator guide
+    title: 'Write docs/references/bigpowers-mcp.md — architecture and operator guide'
     bcps: 1
     epic: e32
     tasks_total: 0
@@ -1675,7 +1665,7 @@ stories:
     tasks_failing: 0
   e33s02:
     status: done
-    title: Source-mapping prebuild — pages generated from repo sources
+    title: 'Source-mapping prebuild — pages generated from repo sources'
     bcps: 5
     epic: e33
     tasks_total: 8
@@ -1699,7 +1689,7 @@ stories:
     tasks_failing: 0
   e33s05:
     status: done
-    title: Doctrine wiring — site content is generated, never edited
+    title: 'Doctrine wiring — site content is generated, never edited'
     bcps: 1
     epic: e33
     tasks_total: 5
@@ -1707,8 +1697,7 @@ stories:
     tasks_failing: 0
   e34s01:
     status: done
-    title: Create docs/references/context-engineering.md (write/select/compress/isolate
-      framework)
+    title: 'Create docs/references/context-engineering.md (write/select/compress/isolate framework)'
     bcps: 2
     epic: e34
     tasks_total: 3
@@ -1724,7 +1713,7 @@ stories:
     tasks_failing: 0
   e34s03:
     status: done
-    title: Update CLAUDE.md Token Management to use context-engineering vocabulary
+    title: 'Update CLAUDE.md Token Management to use context-engineering vocabulary'
     bcps: 2
     epic: e34
     tasks_total: 2
@@ -1732,7 +1721,7 @@ stories:
     tasks_failing: 0
   e34s04:
     status: done
-    title: Update session-state SKILL.md to name the four context-engineering strategies
+    title: 'Update session-state SKILL.md to name the four context-engineering strategies'
     bcps: 3
     epic: e34
     tasks_total: 3
@@ -1740,7 +1729,7 @@ stories:
     tasks_failing: 0
   e35s01:
     status: done
-    title: Create docs/references/kent-beck.md (XP, TDD origins, Tidy First?)
+    title: 'Create docs/references/kent-beck.md (XP, TDD origins, Tidy First?)'
     bcps: 2
     epic: e35
     tasks_total: 4
@@ -1748,7 +1737,7 @@ stories:
     tasks_failing: 0
   e35s02:
     status: done
-    title: Create docs/references/fowler.md (refactoring catalog, code smells)
+    title: 'Create docs/references/fowler.md (refactoring catalog, code smells)'
     bcps: 2
     epic: e35
     tasks_total: 4
@@ -1756,7 +1745,7 @@ stories:
     tasks_failing: 0
   e35s03:
     status: done
-    title: Create docs/references/feathers.md (seams, characterization tests)
+    title: 'Create docs/references/feathers.md (seams, characterization tests)'
     bcps: 2
     epic: e35
     tasks_total: 4
@@ -1764,8 +1753,7 @@ stories:
     tasks_failing: 0
   e35s04:
     status: done
-    title: Create docs/references/pragmatic-programmer.md (DRY, broken windows, tracer
-      bullets)
+    title: 'Create docs/references/pragmatic-programmer.md (DRY, broken windows, tracer bullets)'
     bcps: 2
     epic: e35
     tasks_total: 2
@@ -1773,7 +1761,7 @@ stories:
     tasks_failing: 0
   e35s05:
     status: done
-    title: Create docs/references/rich-hickey.md (simple vs easy, complecting)
+    title: 'Create docs/references/rich-hickey.md (simple vs easy, complecting)'
     bcps: 2
     epic: e35
     tasks_total: 2
@@ -1781,8 +1769,7 @@ stories:
     tasks_failing: 0
   e35s06:
     status: done
-    title: Create docs/references/sandi-metz.md (SOLID in practice, message-level
-      testing)
+    title: 'Create docs/references/sandi-metz.md (SOLID in practice, message-level testing)'
     bcps: 2
     epic: e35
     tasks_total: 2
@@ -1790,7 +1777,7 @@ stories:
     tasks_failing: 0
   e35s07:
     status: done
-    title: Create docs/references/ddd.md (bounded contexts, context mapping)
+    title: 'Create docs/references/ddd.md (bounded contexts, context mapping)'
     bcps: 2
     epic: e35
     tasks_total: 2
@@ -1806,7 +1793,7 @@ stories:
     tasks_failing: 0
   e35s09:
     status: done
-    title: Update PRINCIPLES.md to credit Beck, Fowler, Feathers, Hunt & Thomas
+    title: 'Update PRINCIPLES.md to credit Beck, Fowler, Feathers, Hunt & Thomas'
     bcps: 2
     epic: e35
     tasks_total: 2
@@ -1814,7 +1801,7 @@ stories:
     tasks_failing: 0
   e35s10:
     status: done
-    title: Cross-reference new docs from SKILL.md bodies
+    title: 'Cross-reference new docs from SKILL.md bodies'
     bcps: 2
     epic: e35
     tasks_total: 3
@@ -1822,7 +1809,7 @@ stories:
     tasks_failing: 0
   e36s01:
     status: done
-    title: Slim docs/references/uncle-bob.md to provenance pointer
+    title: 'Slim docs/references/uncle-bob.md to provenance pointer'
     bcps: 3
     epic: e36
     tasks_total: 3
@@ -1831,8 +1818,7 @@ stories:
     risk_max: P2
   e36s02:
     status: done
-    title: Slim docs/references/akita.md, ousterhout.md, karpathy.md, wasowski.md
-      to provenance pointers
+    title: 'Slim docs/references/akita.md, ousterhout.md, karpathy.md, wasowski.md to provenance pointers'
     bcps: 3
     epic: e36
     tasks_total: 4
@@ -1841,8 +1827,7 @@ stories:
     risk_max: P2
   e36s03:
     status: done
-    title: Remove F.I.R.S.T rubric restatement from enforce-first and audit-code SKILL.md;
-      replace with CONVENTIONS.md pointer
+    title: 'Remove F.I.R.S.T rubric restatement from enforce-first and audit-code SKILL.md; replace with CONVENTIONS.md pointer'
     bcps: 2
     epic: e36
     tasks_total: 3
@@ -1851,8 +1836,7 @@ stories:
     risk_max: P2
   e36s04:
     status: done
-    title: Update docs/references/spec-kit.md to cover full SDD tool landscape (Kiro,
-      Tessl, BMAD, GSD)
+    title: 'Update docs/references/spec-kit.md to cover full SDD tool landscape (Kiro, Tessl, BMAD, GSD)'
     bcps: 2
     epic: e36
     tasks_total: 4
@@ -1861,8 +1845,7 @@ stories:
     risk_max: P2
   e36s05:
     status: done
-    title: Refresh docs/references/bmad.md from BMAD v6/TEA — currently covers only
-      Document Lifecycle
+    title: Refresh docs/references/bmad.md from BMAD v6/TEA — currently covers only Document Lifecycle
     bcps: 2
     epic: e36
     tasks_total: 0
@@ -1870,8 +1853,7 @@ stories:
     tasks_failing: 0
   e37s01:
     status: done
-    title: seed-conventions — unified AGENTS.md template with e51 Preflight + multi-agent
-      header
+    title: 'seed-conventions — unified AGENTS.md template with e51 Preflight + multi-agent header'
     bcps: 3
     epic: e37
     tasks_total: 5
@@ -1880,7 +1862,7 @@ stories:
     risk_max: P1
   e37s02:
     status: done
-    title: verify-install.sh + docs — Cline native AGENTS.md verification
+    title: 'verify-install.sh + docs — Cline native AGENTS.md verification'
     bcps: 2
     epic: e37
     tasks_total: 4
@@ -1890,7 +1872,7 @@ stories:
     security_max: none
   e37s03:
     status: done
-    title: seed-conventions — .aider.conf.yml read:AGENTS.md bridge for Aider users
+    title: 'seed-conventions — .aider.conf.yml read:AGENTS.md bridge for Aider users'
     bcps: 1
     epic: e37
     tasks_total: 4
@@ -1900,7 +1882,7 @@ stories:
     security_max: none
   e37s04:
     status: done
-    title: verify-install.sh — AGENTS.md spine assertions (OSS P1 + optional Codex)
+    title: 'verify-install.sh — AGENTS.md spine assertions (OSS P1 + optional Codex)'
     bcps: 2
     epic: e37
     tasks_total: 6
@@ -1919,7 +1901,7 @@ stories:
     risk_max: P1
   e37s06:
     status: done
-    title: scripts/generate-context-bundle.sh — AGENTS.md single source + all derivatives
+    title: 'scripts/generate-context-bundle.sh — AGENTS.md single source + all derivatives'
     bcps: 3
     epic: e37
     tasks_total: 4
@@ -1929,7 +1911,7 @@ stories:
     security_max: none
   e37s07:
     status: done
-    title: sync-skills.sh — adapter dispatch from targets.yaml
+    title: 'sync-skills.sh — adapter dispatch from targets.yaml'
     bcps: 5
     epic: e37
     tasks_total: 5
@@ -1938,7 +1920,7 @@ stories:
     risk_max: P0
   e37s08:
     status: done
-    title: verify-install.sh — per-target contract matrix from targets.yaml
+    title: 'verify-install.sh — per-target contract matrix from targets.yaml'
     bcps: 3
     epic: e37
     tasks_total: 4
@@ -1998,7 +1980,7 @@ stories:
     security_max: none
   e37s14:
     status: done
-    title: seed-conventions — optional Codex wiring step (AGENTS.md + .codex/config.toml)
+    title: 'seed-conventions — optional Codex wiring step (AGENTS.md + .codex/config.toml)'
     bcps: 3
     epic: e37
     tasks_total: 6
@@ -2018,7 +2000,7 @@ stories:
     security_max: low
   e37s16:
     status: done
-    title: using-bigpowers — Codex CLI onboarding section
+    title: 'using-bigpowers — Codex CLI onboarding section'
     bcps: 2
     epic: e37
     tasks_total: 4
@@ -2028,7 +2010,7 @@ stories:
     security_max: none
   e38s01:
     status: done
-    title: Create scripts/trace-stories.sh — deterministic coverage matrix builder
+    title: 'Create scripts/trace-stories.sh — deterministic coverage matrix builder'
     bcps: 3
     epic: e38
     tasks_total: 5
@@ -2036,7 +2018,7 @@ stories:
     tasks_failing: 0
   e38s02:
     status: done
-    title: Integrate trace-stories.sh into build-epic Step 8 (verify phase)
+    title: 'Integrate trace-stories.sh into build-epic Step 8 (verify phase)'
     bcps: 1
     epic: e38
     tasks_total: 2
@@ -2044,7 +2026,7 @@ stories:
     tasks_failing: 0
   e38s03:
     status: done
-    title: Add trace-stories.sh --strict to CI gate (sync-skills.yml)
+    title: 'Add trace-stories.sh --strict to CI gate (sync-skills.yml)'
     bcps: 1
     epic: e38
     tasks_total: 2
@@ -2052,7 +2034,7 @@ stories:
     tasks_failing: 0
   e38s04:
     status: done
-    title: Create scripts/check-blind-spots.sh — heuristic quality detector
+    title: 'Create scripts/check-blind-spots.sh — heuristic quality detector'
     bcps: 2
     epic: e38
     tasks_total: 3
@@ -2060,7 +2042,7 @@ stories:
     tasks_failing: 0
   e38s05:
     status: done
-    title: Integrate check-blind-spots.sh into verify-work Phase 3
+    title: 'Integrate check-blind-spots.sh into verify-work Phase 3'
     bcps: 1
     epic: e38
     tasks_total: 2
@@ -2068,7 +2050,7 @@ stories:
     tasks_failing: 0
   e38s06:
     status: done
-    title: Create gate-trace skill — deterministic quality gate before release
+    title: 'Create gate-trace skill — deterministic quality gate before release'
     bcps: 2
     epic: e38
     tasks_total: 3
@@ -2076,7 +2058,7 @@ stories:
     tasks_failing: 0
   e38s07:
     status: done
-    title: Wire gate-trace into release-branch pre-PR gate
+    title: 'Wire gate-trace into release-branch pre-PR gate'
     bcps: 1
     epic: e38
     tasks_total: 2
@@ -2092,7 +2074,7 @@ stories:
     tasks_failing: 0
   e38s09:
     status: done
-    title: Write docs/references/traceability-gate.md — architecture & operator guide
+    title: 'Write docs/references/traceability-gate.md — architecture & operator guide'
     bcps: 1
     epic: e38
     tasks_total: 2
@@ -2100,8 +2082,7 @@ stories:
     tasks_failing: 0
   e39s01:
     status: done
-    title: Consume e32 build_skill_graph MCP tool for skill graph artifact (replaces
-      standalone build-skill-graph.sh)
+    title: 'Consume e32 build_skill_graph MCP tool for skill graph artifact (replaces standalone build-skill-graph.sh)'
     bcps: 3
     epic: e39
     tasks_total: 5
@@ -2109,7 +2090,7 @@ stories:
     tasks_failing: 0
   e39s02:
     status: done
-    title: Create specs/agent-locks.yaml — multi-agent coordination protocol
+    title: 'Create specs/agent-locks.yaml — multi-agent coordination protocol'
     bcps: 2
     epic: e39
     tasks_total: 4
@@ -2117,8 +2098,7 @@ stories:
     tasks_failing: 0
   e39s03:
     status: done
-    title: Create scripts/check-spec-drift.sh — requirement change → suspect trace
-      links
+    title: 'Create scripts/check-spec-drift.sh — requirement change → suspect trace links'
     bcps: 2
     epic: e39
     tasks_total: 4
@@ -2126,8 +2106,7 @@ stories:
     tasks_failing: 0
   e39s04:
     status: done
-    title: OKF Phase 2 — sync-skills.sh generates specs/skills-wiki/ from all SKILL.md
-      files
+    title: 'OKF Phase 2 — sync-skills.sh generates specs/skills-wiki/ from all SKILL.md files'
     bcps: 3
     epic: e39
     tasks_total: 4
@@ -2135,7 +2114,7 @@ stories:
     tasks_failing: 0
   e39s05:
     status: done
-    title: OKF Phase 3a — decompose CONVENTIONS.md into specs/conventions-wiki/
+    title: 'OKF Phase 3a — decompose CONVENTIONS.md into specs/conventions-wiki/'
     bcps: 2
     epic: e39
     tasks_total: 3
@@ -2143,8 +2122,7 @@ stories:
     tasks_failing: 0
   e39s06:
     status: done
-    title: OKF Phase 3b — decompose CLAUDE.md into specs/agent-guide/ for progressive
-      disclosure
+    title: 'OKF Phase 3b — decompose CLAUDE.md into specs/agent-guide/ for progressive disclosure'
     bcps: 1
     epic: e39
     tasks_total: 3
@@ -2152,7 +2130,7 @@ stories:
     tasks_failing: 0
   e39s07:
     status: done
-    title: Create maintain-wiki skill — agent-maintained OKF ingest, lint, and query
+    title: 'Create maintain-wiki skill — agent-maintained OKF ingest, lint, and query'
     bcps: 3
     epic: e39
     tasks_total: 4
@@ -2160,7 +2138,7 @@ stories:
     tasks_failing: 0
   e39s08:
     status: done
-    title: Integrate maintain-wiki into build-epic Step 8 and verify-work Phase 3
+    title: 'Integrate maintain-wiki into build-epic Step 8 and verify-work Phase 3'
     bcps: 2
     epic: e39
     tasks_total: 2
@@ -2168,8 +2146,7 @@ stories:
     tasks_failing: 0
   e39s09:
     status: done
-    title: Write docs/references/semantic-context-bridge.md — architecture and operator
-      guide
+    title: 'Write docs/references/semantic-context-bridge.md — architecture and operator guide'
     bcps: 1
     epic: e39
     tasks_total: 2
@@ -2177,8 +2154,7 @@ stories:
     tasks_failing: 0
   e39s10:
     status: done
-    title: Extend scripts/validate-okf.sh (created by e40s06) with OKF v0.1 frontmatter
-      conformance checks
+    title: 'Extend scripts/validate-okf.sh (created by e40s06) with OKF v0.1 frontmatter conformance checks'
     bcps: 1
     epic: e39
     tasks_total: 2
@@ -2186,8 +2162,7 @@ stories:
     tasks_failing: 0
   e40s01:
     status: done
-    title: Land record-cycle-time.sh — git-derived additive effort + lead_time (report/append
-      + additivity self-check)
+    title: 'Land record-cycle-time.sh — git-derived additive effort + lead_time (report/append + additivity self-check)'
     bcps: 1
     epic: e40
     tasks_total: 3
@@ -2195,8 +2170,7 @@ stories:
     tasks_failing: 0
   e40s02:
     status: done
-    title: Wire record-cycle-time.sh append into release-branch; deprecate story_start/story_end
-      hand-arithmetic in survey-context + release-branch
+    title: 'Wire record-cycle-time.sh append into release-branch; deprecate story_start/story_end hand-arithmetic in survey-context + release-branch'
     bcps: 3
     epic: e40
     tasks_total: 3
@@ -2204,8 +2178,7 @@ stories:
     tasks_failing: 0
   e40s03:
     status: done
-    title: Adopt OKF story-metrics bundle format (specs/templates/story-metrics.okf.md);
-      emit one bundle per merged story
+    title: 'Adopt OKF story-metrics bundle format (specs/templates/story-metrics.okf.md); emit one bundle per merged story'
     bcps: 3
     epic: e40
     tasks_total: 3
@@ -2213,8 +2186,7 @@ stories:
     tasks_failing: 0
   e40s04:
     status: done
-    title: 'Agent code-gen telemetry capture where harness exposes usage (pi, Claude
-      Code): cost, tokens, cache_hit, tier, tool_calls'
+    title: 'Agent code-gen telemetry capture where harness exposes usage (pi, Claude Code): cost, tokens, cache_hit, tier, tool_calls'
     bcps: 3
     epic: e40
     tasks_total: 3
@@ -2222,8 +2194,7 @@ stories:
     tasks_failing: 0
   e40s05:
     status: done
-    title: DORA four keys per story, computed from git/deploy events (lead time, deploy
-      frequency, change failure, restore time) — median/rate aggregation only
+    title: 'DORA four keys per story, computed from git/deploy events (lead time, deploy frequency, change failure, restore time) — median/rate aggregation only'
     bcps: 3
     epic: e40
     tasks_total: 3
@@ -2231,8 +2202,7 @@ stories:
     tasks_failing: 0
   e40s06:
     status: done
-    title: 'validate-okf.sh + provenance gate (e31-style): bundle valid iff generator
-      ran and commit_range resolves; wire into compliance CI'
+    title: 'validate-okf.sh + provenance gate (e31-style): bundle valid iff generator ran and commit_range resolves; wire into compliance CI'
     bcps: 2
     epic: e40
     tasks_total: 4
@@ -2240,8 +2210,7 @@ stories:
     tasks_failing: 0
   e40s07:
     status: done
-    title: 'Quarantine fabricated cycle-times.yaml rows (tag source: backfilled) and
-      exclude from aggregates'
+    title: 'Quarantine fabricated cycle-times.yaml rows (tag source: backfilled) and exclude from aggregates'
     bcps: 2
     epic: e40
     tasks_total: 3
@@ -2249,8 +2218,7 @@ stories:
     tasks_failing: 0
   e40s08:
     status: done
-    title: Benchmark axes scaffold in specs/benchmarks using OKF bundles (delivery,
-      reliability, cost, routing, quality)
+    title: 'Benchmark axes scaffold in specs/benchmarks using OKF bundles (delivery, reliability, cost, routing, quality)'
     bcps: 1
     epic: e40
     tasks_total: 2
@@ -2258,8 +2226,7 @@ stories:
     tasks_failing: 0
   e41s01:
     status: done
-    title: Create scripts/build-receipts.sh — aggregate all quality evidence into
-      specs/receipts.json
+    title: 'Create scripts/build-receipts.sh — aggregate all quality evidence into specs/receipts.json'
     bcps: 3
     epic: e41
     tasks_total: 2
@@ -2275,7 +2242,7 @@ stories:
     tasks_failing: 0
   e41s03:
     status: done
-    title: CI wiring — regenerate receipts on every main push; provenance gate, e40-style
+    title: 'CI wiring — regenerate receipts on every main push; provenance gate, e40-style'
     bcps: 2
     epic: e41
     tasks_total: 2
@@ -2283,8 +2250,7 @@ stories:
     tasks_failing: 0
   e41s04:
     status: done
-    title: Honesty guardrails codified — validate-okf checks receipts.json source
-      tags
+    title: 'Honesty guardrails codified — validate-okf checks receipts.json source tags'
     bcps: 1
     epic: e41
     tasks_total: 2
@@ -2300,8 +2266,7 @@ stories:
     tasks_failing: 0
   e42s01:
     status: done
-    title: 'Spike: headless golden-chain harness — gh-aw + DeepSeek v4 prototype confirmed
-      viable'
+    title: 'Spike: headless golden-chain harness — gh-aw + DeepSeek v4 prototype confirmed viable'
     bcps: 3
     epic: e42
     tasks_total: 0
@@ -2309,8 +2274,7 @@ stories:
     tasks_failing: 0
   e42s02:
     status: done
-    title: Create specs/benchmarks/fixtures/minimal-api/ fixture repo (createUser
-      + failing-ready test harness)
+    title: 'Create specs/benchmarks/fixtures/minimal-api/ fixture repo (createUser + failing-ready test harness)'
     bcps: 3
     epic: e42
     tasks_total: 4
@@ -2318,8 +2282,7 @@ stories:
     tasks_failing: 0
   e42s03:
     status: done
-    title: Author 4 golden story YAMLs (g-01, g-02, g-03, g-05) with code graders
-      and pass@k 2-of-3 flake policy
+    title: 'Author 4 golden story YAMLs (g-01, g-02, g-03, g-05) with code graders and pass@k 2-of-3 flake policy'
     bcps: 3
     epic: e42
     tasks_total: 5
@@ -2327,8 +2290,7 @@ stories:
     tasks_failing: 0
   e42s04:
     status: done
-    title: 'Add --agent mode to run-golden-suite.sh: headless chain execution per
-      golden story, per-epic cadence, report merged with deterministic gates'
+    title: 'Add --agent mode to run-golden-suite.sh: headless chain execution per golden story, per-epic cadence, report merged with deterministic gates'
     bcps: 4
     epic: e42
     tasks_total: 5
@@ -2336,7 +2298,7 @@ stories:
     tasks_failing: 0
   e43s01:
     status: done
-    title: Scaffold the showcase app in a separate public repo via seed-conventions
+    title: 'Scaffold the showcase app in a separate public repo via seed-conventions'
     bcps: 3
     epic: e43
     tasks_total: 2
@@ -2344,7 +2306,7 @@ stories:
     tasks_failing: 0
   e43s02:
     status: done
-    title: Build one feature epic end-to-end via the 8-step build-epic cycle
+    title: 'Build one feature epic end-to-end via the 8-step build-epic cycle'
     bcps: 3
     epic: e43
     tasks_total: 2
@@ -2352,7 +2314,7 @@ stories:
     tasks_failing: 0
   e43s03:
     status: done
-    title: Fix one real bug via the investigate-bug → develop-tdd → validate-fix trail
+    title: 'Fix one real bug via the investigate-bug → develop-tdd → validate-fix trail'
     bcps: 2
     epic: e43
     tasks_total: 2
@@ -2360,8 +2322,7 @@ stories:
     tasks_failing: 0
   e43s04:
     status: done
-    title: Link the showcase from README + docs site; register as e37 golden-story
-      fixture candidate
+    title: 'Link the showcase from README + docs site; register as e37 golden-story fixture candidate'
     bcps: 2
     epic: e43
     tasks_total: 1
@@ -2369,8 +2330,7 @@ stories:
     tasks_failing: 0
   e43s05:
     status: done
-    title: Add offline-tolerant fallbacks for e43 verify commands that depend on gh
-      api/gh search
+    title: 'Add offline-tolerant fallbacks for e43 verify commands that depend on gh api/gh search'
     bcps: 1
     epic: e43
     tasks_total: 0
@@ -2378,8 +2338,7 @@ stories:
     tasks_failing: 0
   e44s01:
     status: done
-    title: Define OKF schema for spec-migration and migration-registry; create initial
-      registry with m1-m2
+    title: 'Define OKF schema for spec-migration and migration-registry; create initial registry with m1-m2'
     bcps: 3
     epic: e44
     tasks_total: 7
@@ -2387,8 +2346,7 @@ stories:
     tasks_failing: 0
   e44s02:
     status: done
-    title: Create scripts/check-spec-version-gap.sh — fingerprint + stamp-based version
-      detection
+    title: 'Create scripts/check-spec-version-gap.sh — fingerprint + stamp-based version detection'
     bcps: 2
     epic: e44
     tasks_total: 6
@@ -2396,8 +2354,7 @@ stories:
     tasks_failing: 0
   e44s03:
     status: done
-    title: Create scripts/migrate-version.sh — one-shot ordered migration engine with
-      triple safety net
+    title: 'Create scripts/migrate-version.sh — one-shot ordered migration engine with triple safety net'
     bcps: 4
     epic: e44
     tasks_total: 12
@@ -2405,8 +2362,7 @@ stories:
     tasks_failing: 0
   e44s04:
     status: done
-    title: Verification gates + migration report generation + CLAUDE.md/CONVENTIONS.md
-      staleness check
+    title: Verification gates + migration report generation + CLAUDE.md/CONVENTIONS.md staleness check
     bcps: 2
     epic: e44
     tasks_total: 7
@@ -2414,7 +2370,7 @@ stories:
     tasks_failing: 0
   e44s05:
     status: done
-    title: Integrate check_spec_version_gap into survey-context; wire handoff signal
+    title: 'Integrate check_spec_version_gap into survey-context; wire handoff signal'
     bcps: 1
     epic: e44
     tasks_total: 4
@@ -2422,8 +2378,7 @@ stories:
     tasks_failing: 0
   e44s06:
     status: done
-    title: Golden test fixtures (v1.x, v2.0.0, v2.20) + roundtrip validation; wire
-      as G-06 golden story
+    title: 'Golden test fixtures (v1.x, v2.0.0, v2.20) + roundtrip validation; wire as G-06 golden story'
     bcps: 2
     epic: e44
     tasks_total: 7
@@ -2503,8 +2458,7 @@ stories:
     tasks_failing: 0
   e45s10:
     status: done
-    title: 'docs/references: auto-regenerate from source-of-truth docs via scheduled
-      sync'
+    title: 'docs/references: auto-regenerate from source-of-truth docs via scheduled sync'
     bcps: 2
     epic: e45
     tasks_total: 0
@@ -2512,8 +2466,7 @@ stories:
     tasks_failing: 0
   e45s11:
     status: done
-    title: 'orchestration / dispatch-agents: typed message protocol + 3-failure circuit
-      breaker'
+    title: 'orchestration / dispatch-agents: typed message protocol + 3-failure circuit breaker'
     bcps: 2
     epic: e45
     tasks_total: 0
@@ -2777,7 +2730,7 @@ stories:
     tasks_failing: 0
   e46s03:
     status: done
-    title: NFR evidence gate — performance/reliability/operability with go/no-go output
+    title: 'NFR evidence gate — performance/reliability/operability with go/no-go output'
     bcps: 4
     epic: e46
     tasks_total: 0
@@ -2785,8 +2738,7 @@ stories:
     tasks_failing: 0
   e46s04:
     status: done
-    title: Upstream test-design artifact — plan-tests skill, registered output path,
-      scenario ID traceability
+    title: 'Upstream test-design artifact — plan-tests skill, registered output path, scenario ID traceability'
     bcps: 6
     epic: e46
     tasks_total: 0
@@ -2794,8 +2746,7 @@ stories:
     tasks_failing: 0
   e47s01:
     status: done
-    title: install.sh — global pi coverage (install_pi/uninstall_pi) + remove broken
-      OpenCode step
+    title: install.sh — global pi coverage (install_pi/uninstall_pi) + remove broken OpenCode step
     bcps: 3
     epic: e47
     tasks_total: 6
@@ -2804,7 +2755,7 @@ stories:
     risk_max: P2
   e47s02:
     status: done
-    title: seed-conventions — optional per-project local wiring for Cursor + OpenCode
+    title: 'seed-conventions — optional per-project local wiring for Cursor + OpenCode'
     bcps: 3
     epic: e47
     tasks_total: 0
@@ -2812,7 +2763,7 @@ stories:
     tasks_failing: 0
   e47s03:
     status: done
-    title: docs — skill-catalog vs instruction-only distinction in agent-config reference
+    title: 'docs — skill-catalog vs instruction-only distinction in agent-config reference'
     bcps: 1
     epic: e47
     tasks_total: 0
@@ -2820,7 +2771,7 @@ stories:
     tasks_failing: 0
   e47s04:
     status: done
-    title: verify-install.sh — manual verification harness for install + seed wiring
+    title: 'verify-install.sh — manual verification harness for install + seed wiring'
     bcps: 2
     epic: e47
     tasks_total: 0
@@ -2828,7 +2779,7 @@ stories:
     tasks_failing: 0
   e48s01:
     status: done
-    title: Generate epics-wiki and adr-wiki as OKF concept bundles from sync-skills.sh
+    title: 'Generate epics-wiki and adr-wiki as OKF concept bundles from sync-skills.sh'
     bcps: 2
     epic: e48
     tasks_total: 0
@@ -2836,7 +2787,7 @@ stories:
     tasks_failing: 0
   e48s02:
     status: done
-    title: Emit verification reports as OKF bundles from run-golden-suite.sh and audit-compliance.sh
+    title: 'Emit verification reports as OKF bundles from run-golden-suite.sh and audit-compliance.sh'
     bcps: 2
     epic: e48
     tasks_total: 0
@@ -2844,8 +2795,7 @@ stories:
     tasks_failing: 0
   e48s03:
     status: done
-    title: 'OKF-ify bug-registry: specs/bugs/registry.yaml emits concept bundles per
-      bug'
+    title: 'OKF-ify bug-registry: specs/bugs/registry.yaml emits concept bundles per bug'
     bcps: 1
     epic: e48
     tasks_total: 0
@@ -2853,7 +2803,7 @@ stories:
     tasks_failing: 0
   e48s04:
     status: done
-    title: Create viz.html — interactive force-layout graph companion for visual-dashboard
+    title: 'Create viz.html — interactive force-layout graph companion for visual-dashboard'
     bcps: 2
     epic: e48
     tasks_total: 0
@@ -2861,8 +2811,7 @@ stories:
     tasks_failing: 0
   e48s05:
     status: done
-    title: Wire OKF validation into CI (sync-skills.yml) and document in OKF authority
-      [HARD GATE]
+    title: 'Wire OKF validation into CI (sync-skills.yml) and document in OKF authority [HARD GATE]'
     bcps: 1
     epic: e48
     tasks_total: 0
@@ -2870,8 +2819,7 @@ stories:
     tasks_failing: 0
   e48s06:
     status: done
-    title: 'Add tier: field (core/extended/specialized) to OKF wiki indexes for conditional
-      agent loading'
+    title: 'Add tier: field (core/extended/specialized) to OKF wiki indexes for conditional agent loading'
     bcps: 2
     epic: e48
     tasks_total: 0
@@ -2879,7 +2827,7 @@ stories:
     tasks_failing: 0
   e48s07:
     status: done
-    title: Create publish-to-wiki kernel tool
+    title: 'Create publish-to-wiki kernel tool'
     bcps: 3
     epic: e48
     tasks_total: 0
@@ -2887,7 +2835,7 @@ stories:
     tasks_failing: 0
   e48s08:
     status: done
-    title: Add GitHub Action Template for publish-wiki.yml [HARD GATE]
+    title: 'Add GitHub Action Template for publish-wiki.yml [HARD GATE]'
     bcps: 1
     epic: e48
     tasks_total: 0
@@ -2903,7 +2851,7 @@ stories:
     tasks_failing: 0
   e48s10:
     status: done
-    title: Extend bigspec init with --with-wiki flag
+    title: 'Extend bigspec init with --with-wiki flag'
     bcps: 2
     epic: e48
     tasks_total: 0
@@ -2911,8 +2859,7 @@ stories:
     tasks_failing: 0
   e48s11:
     status: done
-    title: BCP Plus counter integration — install and smoke-test big-counter as optional
-      tool
+    title: 'BCP Plus counter integration — install and smoke-test big-counter as optional tool'
     bcps: 5
     epic: e48
     tasks_total: 4
@@ -2921,7 +2868,7 @@ stories:
     risk_max: P1
   e48s12:
     status: done
-    title: BCP Plus template — 13-dimension breakdown in story specs
+    title: 'BCP Plus template — 13-dimension breakdown in story specs'
     bcps: 5
     epic: e48
     tasks_total: 3
@@ -2930,7 +2877,7 @@ stories:
     risk_max: P2
   e48s13:
     status: done
-    title: NFR Gate integration — security-review and wire-observability sizing
+    title: 'NFR Gate integration — security-review and wire-observability sizing'
     bcps: 4
     epic: e48
     tasks_total: 4
@@ -2939,7 +2886,7 @@ stories:
     risk_max: P2
   e48s14:
     status: done
-    title: Build-epic integration — BCP Plus in story sizing workflow
+    title: 'Build-epic integration — BCP Plus in story sizing workflow'
     bcps: 4
     epic: e48
     tasks_total: 0
@@ -2956,7 +2903,7 @@ stories:
     risk_max: P0
   e51s01:
     status: done
-    title: CONVENTIONS — Always Green, Shift Left, Discovered Defects, banned phrases
+    title: 'CONVENTIONS — Always Green, Shift Left, Discovered Defects, banned phrases'
     bcps: 3
     epic: e51
     tasks_total: 5
@@ -2965,8 +2912,7 @@ stories:
     risk_max: P1
   e51s02:
     status: done
-    title: seed-conventions — Preflight default, solo-git default, embed Always Green
-      template
+    title: 'seed-conventions — Preflight default, solo-git default, embed Always Green template'
     bcps: 3
     epic: e51
     tasks_total: 5
@@ -2975,7 +2921,7 @@ stories:
     risk_max: P1
   e51s03:
     status: done
-    title: kickoff-branch + verify-work — Preflight hard block and CI green gate
+    title: 'kickoff-branch + verify-work — Preflight hard block and CI green gate'
     bcps: 2
     epic: e51
     tasks_total: 4
@@ -2984,8 +2930,7 @@ stories:
     risk_max: P0
   e51s04:
     status: done
-    title: audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log routing on gate
-      failure
+    title: 'audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log routing on gate failure'
     bcps: 2
     epic: e51
     tasks_total: 5
@@ -2994,7 +2939,7 @@ stories:
     risk_max: P1
   e51s05:
     status: done
-    title: CLAUDE.md — solo-default agent rules + bigpowers Preflight command row
+    title: 'CLAUDE.md — solo-default agent rules + bigpowers Preflight command row'
     bcps: 2
     epic: e51
     tasks_total: 4
@@ -3011,7 +2956,7 @@ stories:
     tasks_failing: 0
   e53s02:
     status: done
-    title: Build the tombstone-alias mechanism
+    title: 'Build the tombstone-alias mechanism'
     bcps: 3
     epic: e53
     tasks_total: 4
@@ -3019,7 +2964,7 @@ stories:
     tasks_failing: 0
   e53s03:
     status: done
-    title: Gate-trace the compliance-to-GOLDEN hard-gate coupling
+    title: 'Gate-trace the compliance-to-GOLDEN hard-gate coupling'
     bcps: 2
     epic: e53
     tasks_total: 3
@@ -3027,7 +2972,7 @@ stories:
     tasks_failing: 0
   e53s04:
     status: done
-    title: Adopt docs/TARGET-ARCHITECTURE.md as the migration's north-star reference
+    title: 'Adopt docs/TARGET-ARCHITECTURE.md as the migration''s north-star reference'
     bcps: 3
     epic: e53
     tasks_total: 4
@@ -3044,7 +2989,7 @@ stories:
     risk_max: P2
   e54s02:
     status: done
-    title: Add a soft drift-detection gate for the freeze window
+    title: 'Add a soft drift-detection gate for the freeze window'
     bcps: 3
     epic: e54
     tasks_total: 4
@@ -3053,7 +2998,7 @@ stories:
     risk_max: P1
   e54s03:
     status: done
-    title: Document the freeze's scope, exit criteria, and exception process
+    title: 'Document the freeze''s scope, exit criteria, and exception process'
     bcps: 1
     epic: e54
     tasks_total: 2
@@ -3062,7 +3007,7 @@ stories:
     risk_max: P3
   e55s01:
     status: done
-    title: Map every current doctrine source to a B0-B10 + Capstone block
+    title: 'Map every current doctrine source to a B0-B10 + Capstone block'
     bcps: 2
     epic: e55
     tasks_total: 4
@@ -3071,7 +3016,7 @@ stories:
     risk_max: P3
   e55s02:
     status: done
-    title: Write constitution.md from the mapping, CLAUDE.md/CONVENTIONS.md unchanged
+    title: 'Write constitution.md from the mapping, CLAUDE.md/CONVENTIONS.md unchanged'
     bcps: 3
     epic: e55
     tasks_total: 5
@@ -3080,7 +3025,7 @@ stories:
     risk_max: P2
   e55s03:
     status: done
-    title: Point CLAUDE.md/CONVENTIONS.md at constitution.md, don't delete them yet
+    title: 'Point CLAUDE.md/CONVENTIONS.md at constitution.md, don''t delete them yet'
     bcps: 2
     epic: e55
     tasks_total: 5
@@ -3089,7 +3034,7 @@ stories:
     risk_max: P2
   e60s01:
     status: done
-    title: Interactive installer with ASCII banner, global/local, tool selection
+    title: 'Interactive installer with ASCII banner, global/local, tool selection'
     bcps: 3
     epic: e60
     tasks_total: 0
@@ -3117,6 +3062,16 @@ stories:
     tasks_passing: 6
     tasks_failing: 0
     risk_max: P1
+  e69s01:
+    status: done
+    title: 'MiMo Code adapter — Wave A skills-dir (.mimocode/skills/)'
+    bcps: 2
+    epic: e69
+    tasks_total: 4
+    tasks_passing: 4
+    tasks_failing: 0
+    risk_max: P2
+    security_max: low
   e76s01:
     status: done
     title: ZCode adapter — Wave A greenfield skills-dir

--- a/specs/execution-status.yaml
+++ b/specs/execution-status.yaml
@@ -3063,6 +3063,16 @@ stories:
     tasks_passing: 6
     tasks_failing: 0
     risk_max: P1
+  e69s01:
+    status: done
+    title: 'MiMo Code adapter — Wave A skills-dir (.mimocode/skills/)'
+    bcps: 2
+    epic: e69
+    tasks_total: 4
+    tasks_passing: 4
+    tasks_failing: 0
+    risk_max: P2
+    security_max: low
   e69s02:
     status: done
     title: "Install hub wiring (Wave B)"

--- a/specs/security/epics/e69/THREAT_MODEL.md
+++ b/specs/security/epics/e69/THREAT_MODEL.md
@@ -1,0 +1,60 @@
+# Threat Model — Epic e69: Integration: MiMo Code — Skills + Plugins (No Hooks)
+
+**Date:** 2026-07-24
+**Risk Level:** LOW
+**Epic Scope:** Wave A adapter-only — `scripts/adapters/mimo.sh` renders SKILL.md files to `.mimocode/skills/`; context wiring via AGENTS.md symlink. No hooks, no targets.yaml registry (Wave B).
+
+## Surface Area
+
+| Component | Type | Exposure |
+|-----------|------|----------|
+| `scripts/adapters/mimo.sh` | Bash adapter | Writes `.mimocode/skills/<name>/SKILL.md` from SkillIR globals or JSON stdin |
+| `.mimocode/skills/` | Consumer project dir | MiMo Code skill discovery path (XiaomiMiMo/MiMo-Code) |
+| `.mimocode/mimocode.jsonc` | Config (Wave B+) | MiMo Code config — not written in Wave A |
+| `scripts/lib/context-wire.sh` | Shared library | Symlink/copy AGENTS.md derivative |
+
+## Vulnerability Assessment
+
+### 1. Path Traversal in render_skill
+
+**Category:** Path traversal / unsafe file write  
+**Severity:** LOW  
+**Risk:** Malformed `IR_NAME` could write outside `.mimocode/skills/` if unvalidated.  
+**Mitigation:** Adapter uses fixed base `${MIMO_SKILLS:-.mimocode/skills}`; skill names come from sync-skills IR pipeline, not user CLI input. No path segments from external input in Wave A.
+
+### 2. Command Injection via Adapter Shell
+
+**Category:** Command injection  
+**Severity:** LOW  
+**Risk:** JSON stdin parsed with `jq`; description escaped for YAML frontmatter.  
+**Mitigation:** No `eval`; quoted paths; follows pi.sh/cursor.sh adapter pattern audited in e37.
+
+### 3. Supply Chain — MiMo Code Documentation
+
+**Category:** Social engineering / misleading install guidance  
+**Severity:** LOW  
+**Risk:** Epic references XiaomiMiMo/MiMo-Code (12K+ stars). Stale URLs in future docs could misdirect users.  
+**Mitigation:** Registry row and install wiring deferred to Wave B; epic capsule pins canonical repo.
+
+### 4. Symlink Context Wiring
+
+**Category:** Path traversal  
+**Severity:** LOW  
+**Risk:** `wire_context` creates symlinks relative to repo root via shared `context-wire.sh`.  
+**Mitigation:** Repo-relative resolution; idempotent wire tested in adapter smoke verify.
+
+## Risk Summary
+
+| Category | Count | Highest |
+|----------|-------|---------|
+| Path traversal | 2 | LOW |
+| Command injection | 1 | LOW |
+| Supply chain | 1 | LOW |
+
+**Overall: LOW** — greenfield adapter mirroring proven pi.sh pattern; no hooks or external API calls.
+
+## Mitigation Guidance
+
+1. Keep Wave A scope adapter-only — do not touch `targets.yaml`, `install.sh`, or `verify-install.sh` until Wave B.
+2. Verify `render_skill` and `wire_context` via standalone smoke commands (no registry row required).
+3. Run `bash scripts/validate-targets-yaml.sh` in Wave B before adding mimo target row.

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -6,14 +6,14 @@ bigpowers_version: 2.82.4
 bug_cycle: null
 handoff:
   next_skill: release-branch
-  context: Wave B e69s02 hub wiring in progress
+  context: Wave B e69s02 hub wiring complete; audit PASS; open PR
   epic: e69
 epic_cycle:
-  step: '7'
+  step: '8'
   fast_mode: true
   story_bcps: 2
-  audit_result: pending
-  completed_steps: '0,1,2,3,4,5,6'
+  audit_result: pass
+  completed_steps: '0,1,2,3,4,5,6,7'
 metrics:
   story_start: "2026-07-24T11:10:00-03:00"
   story_end: "2026-07-24T11:20:00-03:00"

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -1,19 +1,19 @@
 active_flow: build_epic
-active_epic: e76
-active_story: e76s02
+active_epic: e69
+active_story: e69s02
 bug_id: null
 bigpowers_version: 2.82.4
 bug_cycle: null
 handoff:
   next_skill: release-branch
-  context: Wave B e76s02 hub wiring complete; audit PASS; open PR
-  epic: e76
+  context: Wave B e69s02 hub wiring in progress
+  epic: e69
 epic_cycle:
-  step: '8'
+  step: '7'
   fast_mode: true
   story_bcps: 2
-  audit_result: pass
-  completed_steps: '0,1+2,3,4,5,6,7'
+  audit_result: pending
+  completed_steps: '0,1,2,3,4,5,6'
 metrics:
   story_start: "2026-07-24T11:10:00-03:00"
   story_end: "2026-07-24T11:20:00-03:00"

--- a/specs/verifications/AUDIT-e69-e69s01.md
+++ b/specs/verifications/AUDIT-e69-e69s01.md
@@ -1,0 +1,91 @@
+# Audit Report — e69s01: MiMo Code Adapter (Wave A)
+
+**Date:** 2026-07-24
+**Epic:** e69 — Integration: MiMo Code — Skills + Plugins (No Hooks)
+**Story:** e69s01 — MiMo Code adapter — Wave A skills-dir (.mimocode/skills/)
+**Files:** scripts/adapters/mimo.sh (41 lines), specs/epics/e69-integration-mimo-code/*, specs/security/epics/e69/THREAT_MODEL.md
+
+---
+
+## Supply Chain & Security
+
+- [x] No new dependencies added
+- [x] No secrets in diff
+- [x] No OWASP Top 10 concerns (bash adapter, filesystem writes only)
+- [x] Security: diff clean — no HIGH findings; THREAT_MODEL.md risk LOW
+
+## Provenance & Metadata
+
+- [x] Adapter tagged `# story: e69s01`
+- [x] Follows pi.sh/cursor.sh SkillIR contract
+- [x] Epic capsule documents MiMo skills path `.mimocode/skills/`
+
+## Law of Demeter
+
+- [x] Adapter delegates context wiring to `context-wire.sh`
+- [x] No method chains through unrelated objects
+
+## CONVENTIONS.md Compliance
+
+- [x] Planning artifacts in `specs/`
+- [x] No `gh issue create` or GitHub REST API usage
+- [x] Story tag present in implementing file
+
+## Scope
+
+- [x] Wave A adapter-only — no forbidden hub files touched
+- [x] No targets.yaml, install.sh, setup.js, verify-install.sh changes
+- [x] No speculative features (plugins/hooks deferred)
+- [x] Discovered defects: None
+
+## Boy Scout Rule
+
+- [x] New file only — no pre-existing file degradation
+- [x] No dead code or commented-out blocks
+
+## Types and Safety
+
+- [x] Bash with quoted paths and no eval
+- [x] N/A TypeScript
+
+## Test Coverage
+
+- [x] Standalone smoke verifies in e69s01-tasks.yaml (render_skill + JSON stdin)
+- [x] Note: `test-adapters.sh mimo` deferred to Wave B (no targets.yaml row)
+- [x] Tests verify public adapter interface (render_skill, wire_context)
+
+## SOLID and Heuristics
+
+- [x] Single Responsibility: render vs wire_context separation
+- [x] Open/Closed: extends adapter pattern without modifying sync-skills.sh
+- [x] Matches existing adapter conventions (pi.sh, cursor.sh)
+
+## Code Style (CONVENTIONS.md)
+
+- [x] Functions under 20 lines
+- [x] File under 300 lines (41 lines)
+- [x] Specific names (MIMO_SKILLS, render_skill)
+- [x] Early returns via declare -f guard
+
+## Agent Readability
+
+- [x] Small, grep-able functions
+- [x] Unique env var MIMO_SKILLS
+
+---
+
+## Verdict: **PASS**
+
+All checklist sections pass. Wave A scope respected. Ready for commit on `feat/e69-integration-mimo`.
+
+## Verify Evidence
+
+```
+plan-consistency-check: CRITICAL=0 HIGH=0 MED=0 PASS
+TASK1 OK — render_skill + wire_context defined
+TASK2 OK — IR globals render smoke
+TASK3 OK — JSON stdin render smoke
+TASK4 OK — no forbidden hub files in diff
+run-verification-gates.sh: 11/11 PASS
+trace-stories.sh --strict: exit 0
+```

--- a/specs/verifications/AUDIT-e69-e69s02.md
+++ b/specs/verifications/AUDIT-e69-e69s02.md
@@ -1,0 +1,68 @@
+# Audit Report — e69s02: Install hub wiring (Wave B)
+
+**Date:** 2026-07-24
+**Mode:** `--gate`
+**Epic:** e69 — Integration: MiMo Code — Skills + Plugins (No Hooks)
+**Story:** e69s02 — Install hub wiring (Wave B)
+**Files:** `scripts/install.sh`, `scripts/lib/install-helpers.js`, `bin/setup.js`, `scripts/targets.yaml`, `scripts/verify-install.sh`, `scripts/test-mimo-hub.sh`, capsule specs
+
+**Verify:**
+```bash
+bash scripts/test-mimo-hub.sh
+bash scripts/verify-install.sh
+bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js && node --check bin/setup.js
+```
+**Verify result:** PASS
+
+---
+
+## Gate summary (stderr-style)
+
+```
+PASS Supply Chain & Security
+PASS Provenance & Metadata
+PASS Law of Demeter
+PASS CONVENTIONS.md Compliance
+PASS Scope
+PASS Boy Scout Rule
+PASS Types and Safety
+PASS Test Coverage
+PASS SOLID and Heuristics
+PASS Code Style
+PASS Agent Readability
+```
+
+**Overall: PASS**
+
+---
+
+## Supply Chain & Security
+
+- [x] No new external packages
+- [x] Symlink-only install; AGENTS.md symlink to repo template (no home-dir skill writes during sync)
+- [x] THREAT_MODEL Wave B mitigations honored (no hooks auto-installed)
+
+## Provenance & Metadata
+
+- [x] Story tag `# story: e69s02` on test harness + install-helpers.js
+- [x] Capsule `e69s02-tasks.yaml` + spec present; epic.yaml updated
+
+## Scope
+
+- [x] Hub wiring only — Wave A adapter behavior preserved
+- [x] targets.yaml mimo row added
+
+## Test Coverage
+
+- [x] `scripts/test-mimo-hub.sh` — 18 assertions
+- [x] `verify-install.sh` — mimo source + setup.js + install-helpers checks
+- [x] Wave A e69s01 adapter verify commands still valid
+
+## SOLID and Heuristics
+
+- [x] `linkRenderedSkills` reused for mimo install cases
+- [x] Mirrors zcode/hermes install patterns (symlink rendered output, context wiring)
+
+---
+
+**Next:** commit → push → release-branch (PR)


### PR DESCRIPTION
## Summary
- Wave A: MiMo Code skills adapter (`scripts/adapters/mimo.sh`) targeting `.mimocode/skills/`
- Wave B: Install hub wiring — `install_mimo`, setup.js SUPPORTED_IDS, install-helpers, targets.yaml, verify-install
- Regression harness: `scripts/test-mimo-hub.sh`

## Test plan
- [x] `bash scripts/test-mimo-hub.sh`
- [x] `bash scripts/verify-install.sh`
- [x] `bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js && node --check bin/setup.js`