### PR TITLE
feat(e64): Gemini CLI integration — adapter + install hub

### DIFF
--- a/.gemini/extensions/bigpowers/hooks/HOOKS.md
+++ b/.gemini/extensions/bigpowers/hooks/HOOKS.md
@@ -32,9 +32,9 @@
 
 See `settings.json.example` for wiring snippets. Machine-readable list: `hooks-manifest.json`.
 
-## Wave B (not in Wave A)
+## Wave B (install hub)
 
-Hub install (`scripts/install.sh` → `install_gemini()`) symlinks these scripts to `~/.gemini/hooks/` and merges hook entries into `~/.gemini/settings.json`. Do not edit hub files during Wave A.
+Hub install (`scripts/install.sh` → `install_gemini()`) symlinks these scripts to `~/.gemini/hooks/` and merges hook entries into `~/.gemini/settings.json`. See `scripts/test-gemini-hub.sh` for regression checks.
 
 ## Verify locally
 

--- a/.gemini/extensions/bigpowers/hooks/HOOKS.md
+++ b/.gemini/extensions/bigpowers/hooks/HOOKS.md
@@ -1,0 +1,43 @@
+# Gemini CLI Hook Events — bigpowers Extension
+
+**Config path:** `~/.gemini/settings.json` (global) or `.gemini/settings.json` (project)  
+**Hook scripts (installed):** `~/.gemini/hooks/` — symlinked from this directory in Wave B via `install_gemini()`  
+**Naming:** Gemini uses `BeforeTool`/`AfterTool` (not Claude's `PreToolUse`/`PostToolUse`).
+
+## All 11 events
+
+| Event | Fires when | bigpowers status |
+|-------|------------|------------------|
+| `BeforeTool` | Before a tool executes | **Shipped** — git guard, RTK, token-mgmt wrappers |
+| `AfterTool` | After a tool completes | Documented — no default hook |
+| `BeforeAgent` | Before agent loop iteration | Documented — no default hook |
+| `AfterAgent` | After agent loop iteration | Documented — no default hook |
+| `BeforeModel` | Before model call | Documented — no default hook |
+| `BeforeToolSelection` | Before tool selection | Documented — no default hook |
+| `AfterModel` | After model response | Documented — no default hook |
+| `SessionStart` | Session startup / clear / compact | **Shipped** — `session-start` |
+| `SessionEnd` | Session ends | Documented — no default hook |
+| `Notification` | User notification | Documented — no default hook |
+| `PreCompress` | Before context compression | Documented — no default hook |
+
+## Shipped templates (this directory)
+
+| Script | Event | Matcher | Purpose |
+|--------|-------|---------|---------|
+| `session-start` | SessionStart | `startup\|clear\|compact` | Project survey + using-bigpowers bootstrap |
+| `run-hook.cmd` | (polyglot launcher) | — | Windows + Unix hook runner |
+| `before-tool-git-guard.sh` | BeforeTool | `run_shell_command` | Delegates to `guard-git` with `GIT_GUARDRAILS_MODE=gemini` |
+| `before-tool-rtk.sh` | BeforeTool | `run_shell_command` | RTK passthrough when installed (optional) |
+| `before-tool-token-mgmt.sh` | BeforeTool | `read_file`, `glob`, `run_shell_command` | Token backstop (optional) |
+
+See `settings.json.example` for wiring snippets. Machine-readable list: `hooks-manifest.json`.
+
+## Wave B (not in Wave A)
+
+Hub install (`scripts/install.sh` → `install_gemini()`) symlinks these scripts to `~/.gemini/hooks/` and merges hook entries into `~/.gemini/settings.json`. Do not edit hub files during Wave A.
+
+## Verify locally
+
+```bash
+bash scripts/test-gemini-adapter.sh
+```

--- a/.gemini/extensions/bigpowers/hooks/before-tool-git-guard.sh
+++ b/.gemini/extensions/bigpowers/hooks/before-tool-git-guard.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# story: e64s01
+# BeforeTool wrapper — git guardrails for Gemini CLI (GIT_GUARDRAILS_MODE=gemini).
+set -euo pipefail
+
+find_repo_root() {
+  local d
+  d="$(cd "$(dirname "$0")" && pwd)"
+  while [[ "$d" != "/" && ! -d "$d/scripts" ]]; do
+    d="$(dirname "$d")"
+  done
+  if [[ ! -d "$d/scripts" ]]; then
+    echo "before-tool-git-guard: repo root not found" >&2
+    echo '{"decision":"allow"}'
+    exit 0
+  fi
+  echo "$d"
+}
+
+ROOT="$(find_repo_root)"
+GUARD="$ROOT/skills/guard-git/scripts/block-dangerous-git.sh"
+if [[ ! -x "$GUARD" && ! -f "$GUARD" ]]; then
+  echo '{"decision":"allow"}'
+  exit 0
+fi
+exec env GIT_GUARDRAILS_MODE=gemini bash "$GUARD"

--- a/.gemini/extensions/bigpowers/hooks/before-tool-rtk.sh
+++ b/.gemini/extensions/bigpowers/hooks/before-tool-rtk.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# story: e64s01
+# BeforeTool wrapper — RTK command rewrite (optional; passthrough when rtk absent).
+set -euo pipefail
+
+if command -v rtk >/dev/null 2>&1; then
+  if rtk hook gemini 2>/dev/null; then
+    exit 0
+  fi
+  if rtk hook claude 2>/dev/null; then
+    exit 0
+  fi
+fi
+exit 0

--- a/.gemini/extensions/bigpowers/hooks/before-tool-token-mgmt.sh
+++ b/.gemini/extensions/bigpowers/hooks/before-tool-token-mgmt.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# story: e64s01
+# BeforeTool wrapper — token management backstop (delegates to repo hook when present).
+set -euo pipefail
+
+find_repo_root() {
+  local d
+  d="$(cd "$(dirname "$0")" && pwd)"
+  while [[ "$d" != "/" && ! -d "$d/scripts" ]]; do
+    d="$(dirname "$d")"
+  done
+  [[ -d "$d/scripts" ]] && echo "$d" && return 0
+  return 1
+}
+
+ROOT="$(find_repo_root)" || exit 0
+HOOK="$ROOT/scripts/hooks/token-mgmt-pre-tool-use.sh"
+[[ -f "$HOOK" ]] || exit 0
+exec bash "$HOOK"

--- a/.gemini/extensions/bigpowers/hooks/hooks-manifest.json
+++ b/.gemini/extensions/bigpowers/hooks/hooks-manifest.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "target": "gemini",
+  "config_path": "~/.gemini/settings.json",
+  "events_total": 11,
+  "events": [
+    "BeforeTool",
+    "AfterTool",
+    "BeforeAgent",
+    "AfterAgent",
+    "BeforeModel",
+    "BeforeToolSelection",
+    "AfterModel",
+    "SessionStart",
+    "SessionEnd",
+    "Notification",
+    "PreCompress"
+  ],
+  "shipped_hooks": [
+    {
+      "event": "SessionStart",
+      "script": "session-start",
+      "matcher": "startup|clear|compact",
+      "wave": "a",
+      "status": "shipped"
+    },
+    {
+      "event": "BeforeTool",
+      "script": "before-tool-git-guard.sh",
+      "matcher": "run_shell_command",
+      "wave": "a",
+      "status": "template"
+    }
+  ],
+  "polyglot_launcher": "run-hook.cmd"
+}

--- a/.gemini/extensions/bigpowers/hooks/settings.json.example
+++ b/.gemini/extensions/bigpowers/hooks/settings.json.example
@@ -1,0 +1,41 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.gemini/hooks/run-hook.cmd\" session-start",
+            "async": false
+          }
+        ]
+      }
+    ],
+    "BeforeTool": [
+      {
+        "matcher": "run_shell_command",
+        "hooks": [
+          {
+            "name": "git-guardrails",
+            "type": "command",
+            "command": "GIT_GUARDRAILS_MODE=gemini \"$HOME/.gemini/hooks/before-tool-git-guard.sh\"",
+            "timeout": 5000
+          }
+        ]
+      },
+      {
+        "matcher": "run_shell_command",
+        "hooks": [
+          {
+            "name": "rtk-rewrite",
+            "type": "command",
+            "command": "\"$HOME/.gemini/hooks/before-tool-rtk.sh\"",
+            "timeout": 3000
+          }
+        ]
+      }
+    ]
+  },
+  "_comment": "Example only — Wave B install_gemini() merges into ~/.gemini/settings.json. Copy paths after install.sh symlinks hooks."
+}

--- a/scripts/adapters/gemini.sh
+++ b/scripts/adapters/gemini.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # story: e48s15
 # story: e37s05 e37s07
+# story: e64s01
 
 render_skill() {
   if declare -f render_gemini_skill >/dev/null 2>&1; then
@@ -35,6 +36,88 @@ wire_context() {
   source "$(dirname "${BASH_SOURCE[0]}")/../lib/context-wire.sh"
   wire_context_mode symlink "${1:-GEMINI.md}"
 }
+
+GEMINI_HOOK_EVENTS=(
+  BeforeTool AfterTool BeforeAgent AfterAgent BeforeModel
+  BeforeToolSelection AfterModel SessionStart SessionEnd Notification PreCompress
+)
+
+gemini_hooks_dir() {
+  echo "${GEMINI_HOOKS_DIR:-${GEMINI_EXT_DIR:-.gemini/extensions/bigpowers}/hooks}"
+}
+
+list_hook_events() {
+  printf '%s\n' "${GEMINI_HOOK_EVENTS[@]}"
+}
+
+gemini_required_hook_files() {
+  cat <<'EOF'
+session-start
+run-hook.cmd
+HOOKS.md
+hooks-manifest.json
+settings.json.example
+before-tool-git-guard.sh
+before-tool-rtk.sh
+before-tool-token-mgmt.sh
+EOF
+}
+
+validate_hook_templates() {
+  local hookdir missing=0 rel
+  hookdir="$(gemini_hooks_dir)"
+  if [[ ! -d "$hookdir" ]]; then
+    echo "FAIL: hook dir missing: $hookdir" >&2
+    return 1
+  fi
+  while IFS= read -r rel; do
+    [[ -n "$rel" ]] || continue
+    if [[ ! -f "$hookdir/$rel" ]]; then
+      echo "FAIL: missing $hookdir/$rel" >&2
+      missing=1
+    fi
+  done < <(gemini_required_hook_files)
+  local count
+  count="$(list_hook_events | wc -l | tr -d ' ')"
+  if [[ "$count" != "11" ]]; then
+    echo "FAIL: expected 11 hook events, got $count" >&2
+    missing=1
+  fi
+  return "$missing"
+}
+
+render_hooks_manifest() {
+  if declare -f render_gemini_hooks_manifest >/dev/null 2>&1; then
+    render_gemini_hooks_manifest
+    return
+  fi
+  local hookdir
+  hookdir="$(gemini_hooks_dir)"
+  mkdir -p "$hookdir"
+  cat > "$hookdir/hooks-manifest.json" <<'JSON'
+{
+  "schema_version": 1,
+  "target": "gemini",
+  "events_total": 11,
+  "events": [
+    "BeforeTool", "AfterTool", "BeforeAgent", "AfterAgent", "BeforeModel",
+    "BeforeToolSelection", "AfterModel", "SessionStart", "SessionEnd",
+    "Notification", "PreCompress"
+  ]
+}
+JSON
+}
+
+# CLI: bash scripts/adapters/gemini.sh --validate-hooks
+if [[ "${1:-}" == "--validate-hooks" ]]; then
+  validate_hook_templates && echo "PASS: gemini hook templates"
+  exit $?
+fi
+
+if [[ "${1:-}" == "--list-hook-events" ]]; then
+  list_hook_events
+  exit 0
+fi
 
 # If stdin is a pipe/redirect, read the SkillIR JSON and render
 if [[ ! -t 0 ]]; then

--- a/scripts/adapters/mimo.sh
+++ b/scripts/adapters/mimo.sh
@@ -6,8 +6,9 @@ render_skill() {
     render_mimo_skill
     return
   fi
-  mkdir -p "${MIMO_SKILLS:-.mimocode/skills}/$IR_NAME"
-  cp "${SKILL_MD_PATH:-}" "${MIMO_SKILLS}/$IR_NAME/SKILL.md" 2>/dev/null || {
+  local out="${MIMO_SKILLS:-.mimocode/skills}/$IR_NAME"
+  mkdir -p "$out"
+  cp "${SKILL_MD_PATH:-}" "$out/SKILL.md" 2>/dev/null || {
     {
       echo "---"
       echo "name: $IR_NAME"
@@ -16,7 +17,7 @@ render_skill() {
       echo "---"
       echo ""
       echo "${IR_BODY_SKILL:-$IR_BODY}"
-    } > "${MIMO_SKILLS}/$IR_NAME/SKILL.md"
+    } > "$out/SKILL.md"
   }
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # story: e45s16
+# story: e64s02
 # install.sh — global symlink install for bigpowers skills
 #
 # Supported tools:
@@ -128,11 +129,12 @@ uninstall_claude() {
   fi
 }
 
-# ── Gemini CLI ────────────────────────────────────────────────────────────────
+# ── Gemini CLI (e64s02) ───────────────────────────────────────────────────────
 
 GEMINI_CONFIG_DIR="$HOME/.gemini"
 GEMINI_EXT_SRC="$REPO_ROOT/.gemini/extensions/bigpowers"
 GEMINI_EXT_DST="$GEMINI_CONFIG_DIR/config/plugins/bigpowers"
+GEMINI_HOOKS_SRC="$GEMINI_EXT_SRC/hooks"
 GEMINI_HOOKS_DIR="$GEMINI_CONFIG_DIR/hooks"
 GEMINI_SETTINGS="$GEMINI_CONFIG_DIR/settings.json"
 
@@ -146,10 +148,14 @@ install_gemini() {
   link "$GEMINI_EXT_SRC" "$GEMINI_EXT_DST"
 
   echo "Gemini CLI Hooks → $GEMINI_HOOKS_DIR/"
-  link "$REPO_ROOT/.gemini/extensions/bigpowers/hooks/session-start" "$GEMINI_HOOKS_DIR/session-start"
-  link "$REPO_ROOT/.gemini/extensions/bigpowers/hooks/run-hook.cmd" "$GEMINI_HOOKS_DIR/run-hook.cmd"
-  link "$REPO_ROOT/guard-git/scripts/block-dangerous-git.sh" "$GEMINI_HOOKS_DIR/block-dangerous-git.sh"
-  link "$REPO_ROOT/guard-git/scripts/lib" "$GEMINI_HOOKS_DIR/lib"
+  link "$GEMINI_HOOKS_SRC/session-start" "$GEMINI_HOOKS_DIR/session-start"
+  link "$GEMINI_HOOKS_SRC/run-hook.cmd" "$GEMINI_HOOKS_DIR/run-hook.cmd"
+  link "$GEMINI_HOOKS_SRC/before-tool-git-guard.sh" "$GEMINI_HOOKS_DIR/before-tool-git-guard.sh"
+  link "$GEMINI_HOOKS_SRC/before-tool-rtk.sh" "$GEMINI_HOOKS_DIR/before-tool-rtk.sh"
+  link "$GEMINI_HOOKS_SRC/before-tool-token-mgmt.sh" "$GEMINI_HOOKS_DIR/before-tool-token-mgmt.sh"
+  chmod +x "$GEMINI_HOOKS_SRC/before-tool-git-guard.sh" \
+    "$GEMINI_HOOKS_SRC/before-tool-rtk.sh" \
+    "$GEMINI_HOOKS_SRC/before-tool-token-mgmt.sh" 2>/dev/null || true
 
   if [[ -f "$GEMINI_SETTINGS" ]]; then
     echo "  Configuring global hooks in $GEMINI_SETTINGS..."
@@ -157,14 +163,17 @@ install_gemini() {
       local tmp; tmp=$(mktemp)
       cat "$GEMINI_SETTINGS" | jq '
         .hooks.SessionStart += [{"matcher":"startup|clear|compact","hooks":[{"type":"command","command":"\"'"$GEMINI_HOOKS_DIR/run-hook.cmd"'\" session-start","async":false}]}] |
-        .hooks.BeforeTool += [{"matcher":"run_shell_command","hooks":[{"name":"git-guardrails","type":"command","command":"GIT_GUARDRAILS_MODE=gemini \"'"$GEMINI_HOOKS_DIR/block-dangerous-git.sh"'\""}]}] |
-        # deduplicate
+        .hooks.BeforeTool += [{"matcher":"run_shell_command","hooks":[{"name":"git-guardrails","type":"command","command":"GIT_GUARDRAILS_MODE=gemini \"'"$GEMINI_HOOKS_DIR/before-tool-git-guard.sh"'\"","timeout":5000}]}] |
+        .hooks.BeforeTool += [{"matcher":"run_shell_command","hooks":[{"name":"rtk-rewrite","type":"command","command":"\"'"$GEMINI_HOOKS_DIR/before-tool-rtk.sh"'\"","timeout":3000}]}] |
         .hooks.SessionStart |= unique |
         .hooks.BeforeTool |= unique
       ' > "$tmp" && run mv "$tmp" "$GEMINI_SETTINGS"
     else
       echo "  WARNING: jq not found. Manual setup required in $GEMINI_SETTINGS"
+      echo "  See $GEMINI_HOOKS_SRC/settings.json.example"
     fi
+  else
+    echo "  NOTE: $GEMINI_SETTINGS not found — copy $GEMINI_HOOKS_SRC/settings.json.example after first Gemini run"
   fi
 }
 
@@ -175,8 +184,9 @@ uninstall_gemini() {
   if [[ -d "$GEMINI_HOOKS_DIR" ]]; then
     unlink_if_managed "$GEMINI_HOOKS_DIR/session-start" "$REPO_ROOT/"
     unlink_if_managed "$GEMINI_HOOKS_DIR/run-hook.cmd" "$REPO_ROOT/"
-    unlink_if_managed "$GEMINI_HOOKS_DIR/block-dangerous-git.sh" "$REPO_ROOT/"
-    unlink_if_managed "$GEMINI_HOOKS_DIR/lib" "$REPO_ROOT/"
+    unlink_if_managed "$GEMINI_HOOKS_DIR/before-tool-git-guard.sh" "$REPO_ROOT/"
+    unlink_if_managed "$GEMINI_HOOKS_DIR/before-tool-rtk.sh" "$REPO_ROOT/"
+    unlink_if_managed "$GEMINI_HOOKS_DIR/before-tool-token-mgmt.sh" "$REPO_ROOT/"
   fi
 }
 

--- a/scripts/lib/install-helpers.js
+++ b/scripts/lib/install-helpers.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // story: e60s01
 // story: e61s02
+// story: e64s02
 // story: e76s02
 // story: e69s02
 // install-helpers.js — symlink helpers for bigpowers setup
@@ -99,6 +100,18 @@ function installGlobal(tool, repoRoot) {
       const extDst = path.join(homeDir, '.gemini', 'config', 'plugins', 'bigpowers');
       fs.mkdirSync(path.dirname(extDst), { recursive: true });
       linkDir(extSrc, extDst);
+      const hooksSrc = path.join(extSrc, 'hooks');
+      const hooksDst = path.join(homeDir, '.gemini', 'hooks');
+      fs.mkdirSync(hooksDst, { recursive: true });
+      for (const hookFile of [
+        'session-start',
+        'run-hook.cmd',
+        'before-tool-git-guard.sh',
+        'before-tool-rtk.sh',
+        'before-tool-token-mgmt.sh',
+      ]) {
+        linkHook(path.join(hooksSrc, hookFile), path.join(hooksDst, hookFile));
+      }
       break;
     }
     case 'pi': {
@@ -249,6 +262,15 @@ function uninstallTool(toolId, repoRoot) {
     }
     case 'gemini':
       removeSymlink(path.join(homeDir, '.gemini', 'config', 'plugins', 'bigpowers'));
+      for (const hookFile of [
+        'session-start',
+        'run-hook.cmd',
+        'before-tool-git-guard.sh',
+        'before-tool-rtk.sh',
+        'before-tool-token-mgmt.sh',
+      ]) {
+        removeSymlink(path.join(homeDir, '.gemini', 'hooks', hookFile));
+      }
       break;
     case 'pi': {
       const skillsDir = path.join(homeDir, '.pi', 'agent', 'skills');

--- a/scripts/lib/sync-render.sh
+++ b/scripts/lib/sync-render.sh
@@ -54,6 +54,49 @@ render_gemini_command() {
   } > "$GEMINI_COMMANDS/$IR_NAME.toml"
 }
 
+render_gemini_hooks_manifest() {
+  local hookdir="${GEMINI_HOOKS_DIR:-$GEMINI_EXT_DIR/hooks}"
+  mkdir -p "$hookdir"
+  cat > "$hookdir/hooks-manifest.json" <<'JSON'
+{
+  "schema_version": 1,
+  "target": "gemini",
+  "config_path": "~/.gemini/settings.json",
+  "events_total": 11,
+  "events": [
+    "BeforeTool",
+    "AfterTool",
+    "BeforeAgent",
+    "AfterAgent",
+    "BeforeModel",
+    "BeforeToolSelection",
+    "AfterModel",
+    "SessionStart",
+    "SessionEnd",
+    "Notification",
+    "PreCompress"
+  ],
+  "shipped_hooks": [
+    {
+      "event": "SessionStart",
+      "script": "session-start",
+      "matcher": "startup|clear|compact",
+      "wave": "a",
+      "status": "shipped"
+    },
+    {
+      "event": "BeforeTool",
+      "script": "before-tool-git-guard.sh",
+      "matcher": "run_shell_command",
+      "wave": "a",
+      "status": "template"
+    }
+  ],
+  "polyglot_launcher": "run-hook.cmd"
+}
+JSON
+}
+
 render_pi_skill() {
   mkdir -p "$PI_SKILLS/$IR_NAME"
   {

--- a/scripts/lib/target-contracts.sh
+++ b/scripts/lib/target-contracts.sh
@@ -42,6 +42,16 @@ assert_gemini_ext_exists() {
   return 1
 }
 
+assert_gemini_hooks_manifest() {
+  local id="$1"
+  if GEMINI_EXT_DIR=".gemini/extensions/bigpowers" bash scripts/adapters/gemini.sh --validate-hooks >/dev/null 2>&1; then
+    echo "PASS $id:gemini_hooks_manifest"
+    return 0
+  fi
+  echo "FAIL $id:gemini_hooks_manifest — hook templates invalid"
+  return 1
+}
+
 assert_pi_skills_nonempty() {
   local id="$1"
   if [[ -d .pi/skills ]] && [[ -n "$(ls -A .pi/skills 2>/dev/null)" ]]; then
@@ -70,6 +80,7 @@ run_contract() {
     symlink_claude_md) assert_symlink_claude_md "$id" ;;
     cursor_rules_nonempty) assert_cursor_rules_nonempty "$id" ;;
     gemini_ext_exists) assert_gemini_ext_exists "$id" ;;
+    gemini_hooks_manifest) assert_gemini_hooks_manifest "$id" ;;
     pi_skills_nonempty) assert_pi_skills_nonempty "$id" ;;
     aider_bridge) assert_aider_bridge "$id" ;;
     *) echo "SKIP $id:$contract — unknown contract"; return 0 ;;

--- a/scripts/targets.yaml
+++ b/scripts/targets.yaml
@@ -29,6 +29,7 @@ targets:
       file: GEMINI.md
     contracts:
       - gemini_ext_exists
+      - gemini_hooks_manifest
 
   - id: pi
     name: pi Agent

--- a/scripts/test-gemini-adapter.sh
+++ b/scripts/test-gemini-adapter.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# story: e64s01
+# Validates Gemini adapter hook templates and stdin render path.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+GEMINI_EXT="$REPO_ROOT/.gemini/extensions/bigpowers"
+
+echo "=== test-gemini-adapter.sh ==="
+
+# Test 1: validate hook templates via adapter CLI
+echo "Test 1: validate_hook_templates"
+GEMINI_EXT_DIR="$GEMINI_EXT" GEMINI_HOOKS_DIR="$GEMINI_EXT/hooks" \
+  bash "$REPO_ROOT/scripts/adapters/gemini.sh" --validate-hooks
+
+# Test 2: event count
+echo "Test 2: hook event count"
+COUNT="$(GEMINI_EXT_DIR="$GEMINI_EXT" bash "$REPO_ROOT/scripts/adapters/gemini.sh" --list-hook-events | wc -l | tr -d ' ')"
+if [[ "$COUNT" != "11" ]]; then
+  echo "FAIL: expected 11 events, got $COUNT"
+  exit 1
+fi
+
+# Test 3: HOOKS.md documents all events
+echo "Test 3: HOOKS.md coverage"
+for ev in BeforeTool AfterTool BeforeAgent AfterAgent BeforeModel BeforeToolSelection AfterModel SessionStart SessionEnd Notification PreCompress; do
+  grep -q "$ev" "$GEMINI_EXT/hooks/HOOKS.md" || { echo "FAIL: HOOKS.md missing $ev"; exit 1; }
+done
+
+# Test 4: stdin render smoke (fallback path without sync-render sourced)
+echo "Test 4: stdin render smoke"
+TMP_SKILL="$GEMINI_EXT/skills/_test-gemini-adapter"
+TMP_CMD="$GEMINI_EXT/commands/prompts/_test-gemini-adapter.md"
+rm -rf "$TMP_SKILL" "$TMP_CMD"
+echo '{"name":"_test-gemini-adapter","model":"","description":"adapter test","body":"test body"}' | \
+  GEMINI_SKILLS="$GEMINI_EXT/skills" GEMINI_COMMANDS="$GEMINI_EXT/commands" \
+  bash "$REPO_ROOT/scripts/adapters/gemini.sh"
+if [[ ! -f "$TMP_SKILL/SKILL.md" ]] || [[ ! -f "$TMP_CMD" ]]; then
+  echo "FAIL: gemini adapter did not render test skill"
+  exit 1
+fi
+rm -rf "$TMP_SKILL" "$TMP_CMD"
+
+# Test 5: render_gemini_hooks_manifest via sync-render
+echo "Test 5: render_gemini_hooks_manifest"
+source "$REPO_ROOT/scripts/lib/skill-common.sh" 2>/dev/null || true
+source "$REPO_ROOT/scripts/lib/sync-render.sh"
+GEMINI_EXT_DIR="$GEMINI_EXT"
+render_gemini_hooks_manifest
+grep -q '"events_total": 11' "$GEMINI_EXT/hooks/hooks-manifest.json" || {
+  echo "FAIL: hooks-manifest.json invalid after render"
+  exit 1
+}
+
+# Test 6: before-tool-git-guard gemini JSON shape
+echo "Test 6: before-tool-git-guard gemini mode"
+OUT="$(echo '{"tool_input":{"command":"git reset --hard"}}' | \
+  bash "$GEMINI_EXT/hooks/before-tool-git-guard.sh")"
+echo "$OUT" | jq -e '.decision == "deny"' >/dev/null || {
+  echo "FAIL: git guard did not deny dangerous reset --hard"
+  echo "$OUT"
+  exit 1
+}
+
+echo "PASS: test-gemini-adapter.sh"
+exit 0

--- a/scripts/test-gemini-hub.sh
+++ b/scripts/test-gemini-hub.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# story: e64s02
+# Regression tests for Gemini install hub wiring (Wave B).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+echo "=== test-gemini-hub.sh ==="
+
+INSTALL_SH="$REPO_ROOT/scripts/install.sh"
+HELPERS_JS="$REPO_ROOT/scripts/lib/install-helpers.js"
+SETUP_JS="$REPO_ROOT/bin/setup.js"
+TARGETS_YAML="$REPO_ROOT/scripts/targets.yaml"
+
+grep -q 'install_gemini()' "$INSTALL_SH" && pass 'install.sh: install_gemini()' || fail 'install.sh: missing install_gemini()'
+grep -q 'uninstall_gemini()' "$INSTALL_SH" && pass 'install.sh: uninstall_gemini()' || fail 'install.sh: missing uninstall_gemini()'
+grep -q 'GEMINI_HOOKS_SRC=' "$INSTALL_SH" && pass 'install.sh: GEMINI_HOOKS_SRC' || fail 'install.sh: missing GEMINI_HOOKS_SRC'
+grep -q 'before-tool-git-guard.sh' "$INSTALL_SH" && pass 'install.sh: Wave A git-guard hook' || fail 'install.sh: missing before-tool-git-guard.sh'
+grep -q 'before-tool-rtk.sh' "$INSTALL_SH" && pass 'install.sh: Wave A rtk hook' || fail 'install.sh: missing before-tool-rtk.sh'
+grep -q 'install_gemini' "$INSTALL_SH" && grep -q 'uninstall_gemini' "$INSTALL_SH" && pass 'install.sh: dispatch wired' || fail 'install.sh: dispatch missing gemini'
+
+DRY_OUT="$(bash "$INSTALL_SH" --dry-run 2>&1)"
+echo "$DRY_OUT" | grep -q 'Gemini CLI →' && pass 'dry-run: Gemini CLI section' || fail 'dry-run: missing Gemini CLI section'
+echo "$DRY_OUT" | grep -q 'before-tool-git-guard.sh' && pass 'dry-run: git-guard hook symlink' || fail 'dry-run: missing git-guard hook'
+DRY_UNINSTALL="$(bash "$INSTALL_SH" --dry-run --uninstall 2>&1)"
+echo "$DRY_UNINSTALL" | grep -q 'Gemini CLI →' && pass 'dry-run uninstall: Gemini CLI section' || fail 'dry-run uninstall: missing Gemini CLI section'
+
+grep -q "case 'gemini'" "$HELPERS_JS" && pass 'install-helpers: gemini global case' || fail 'install-helpers: missing gemini global case'
+grep -q 'before-tool-git-guard.sh' "$HELPERS_JS" && pass 'install-helpers: gemini hook wiring' || fail 'install-helpers: missing gemini hook wiring'
+
+SETUP_SRC="$(cat "$SETUP_JS")"
+echo "$SETUP_SRC" | grep -q "SUPPORTED_IDS = new Set" && pass 'setup.js: SUPPORTED_IDS set' || fail 'setup.js: missing SUPPORTED_IDS'
+echo "$SETUP_SRC" | grep -q "'gemini'" "$SETUP_JS" && pass 'setup.js: gemini in TOOLS' || fail 'setup.js: gemini missing from TOOLS'
+echo "$SETUP_SRC" | grep -q "'gemini'" && echo "$SETUP_SRC" | grep -q "SUPPORTED_IDS" \
+  && grep -q "'gemini'" <<< "$(sed -n "/SUPPORTED_IDS = new Set/,/);/p" "$SETUP_JS")" \
+  && pass 'setup.js: gemini in SUPPORTED_IDS' || fail 'setup.js: gemini not in SUPPORTED_IDS'
+
+grep -q 'id: gemini' "$TARGETS_YAML" && pass 'targets.yaml: gemini row' || fail 'targets.yaml: missing gemini row'
+grep -q 'adapter: gemini' "$TARGETS_YAML" && pass 'targets.yaml: gemini adapter' || fail 'targets.yaml: missing gemini adapter'
+grep -q 'gemini_hooks_manifest' "$TARGETS_YAML" && pass 'targets.yaml: gemini_hooks_manifest contract' || fail 'targets.yaml: missing gemini_hooks_manifest'
+
+grep -q 'install_gemini()' "$REPO_ROOT/scripts/verify-install.sh" && pass 'verify-install: install_gemini assertion' || fail 'verify-install: missing install_gemini assertion'
+grep -q 'gemini_hooks_manifest' "$REPO_ROOT/scripts/verify-install.sh" && pass 'verify-install: gemini hook contract' || fail 'verify-install: missing gemini hook contract'
+
+bash -n "$INSTALL_SH" && pass 'bash -n install.sh' || fail 'bash -n install.sh'
+node --check "$HELPERS_JS" && pass 'node --check install-helpers.js' || fail 'node --check install-helpers.js'
+node --check "$SETUP_JS" && pass 'node --check setup.js' || fail 'node --check setup.js'
+
+echo "test-gemini-hub: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -144,6 +144,12 @@ grep -q 'uninstall_mimo()' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: u
 grep -q 'MIMO_SKILLS_DIR=' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: targets ~/.mimocode/skills/" || ta_fail "source: wrong mimo target"
 grep -q "'mimo'" "$REPO_ROOT/bin/setup.js" && grep -q 'SUPPORTED_IDS' "$REPO_ROOT/bin/setup.js" && ta_pass "setup.js: mimo supported" || ta_fail "setup.js: mimo not in SUPPORTED_IDS"
 grep -q "case 'mimo'" "$REPO_ROOT/scripts/lib/install-helpers.js" && ta_pass "install-helpers: mimo case" || ta_fail "install-helpers: missing mimo case"
+grep -q 'install_gemini()' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: install_gemini()" || ta_fail "source: missing install_gemini()"
+grep -q 'uninstall_gemini()' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: uninstall_gemini()" || ta_fail "source: missing uninstall_gemini()"
+grep -q 'before-tool-git-guard.sh' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: gemini Wave A hook templates" || ta_fail "source: missing gemini hook templates"
+grep -q "'gemini'" "$REPO_ROOT/bin/setup.js" && grep -q 'SUPPORTED_IDS' "$REPO_ROOT/bin/setup.js" && ta_pass "setup.js: gemini supported" || ta_fail "setup.js: gemini not in SUPPORTED_IDS"
+grep -q "case 'gemini'" "$REPO_ROOT/scripts/lib/install-helpers.js" && ta_pass "install-helpers: gemini case" || ta_fail "install-helpers: missing gemini case"
+grep -q 'gemini_hooks_manifest' "$REPO_ROOT/scripts/targets.yaml" && ta_pass "targets.yaml: gemini_hooks_manifest" || ta_fail "targets.yaml: missing gemini_hooks_manifest"
 ! grep -q 'install_opencode\|print_opencode_instructions' "$REPO_ROOT/scripts/install.sh" && ta_pass "source: no opencode functions" || ta_fail "source: opencode functions remain"
 
 echo ""

--- a/specs/epics/e64-integration-gemini/e64s01-gemini-hooks-adapter.md
+++ b/specs/epics/e64-integration-gemini/e64s01-gemini-hooks-adapter.md
@@ -1,0 +1,54 @@
+# story: e64s01
+# Gemini hooks adapter — event docs, templates, adapter completeness (Wave A)
+
+**type:** feat  
+**risk:** P2  
+**context:** infra  
+**bcps:** 3
+
+## Context
+
+Gemini CLI uses `BeforeTool`/`AfterTool` naming (not Claude's `PreToolUse`/`PostToolUse`) and supports 11 hook events. Core skill sync via `gemini.sh` exists; hooks are partially shipped (`session-start`, `run-hook.cmd`) but lack event documentation, a machine-readable manifest, BeforeTool wrapper templates, and adapter validation helpers. Wave A completes the **adapter layer** only — hub install wiring stays in Wave B (`install_gemini`, `install-helpers.js`, `targets.yaml` contracts).
+
+## Requirements
+
+#### ADDED: Gemini hook event catalog
+
+Full documentation of all 11 Gemini CLI hook events with bigpowers shipped/planned hook mapping, config path (`~/.gemini/settings.json`), and example `settings.json` snippet.
+
+#### ADDED: Hook template bundle under extension hooks dir
+
+Source templates: `HOOKS.md`, `hooks-manifest.json`, `settings.json.example`, BeforeTool wrappers for git guardrails / RTK / token-mgmt (passthrough or delegate to repo scripts).
+
+#### ADDED: Adapter completeness in gemini.sh
+
+Functions to list events, validate template presence, and render hooks manifest; callable from `scripts/test-gemini-adapter.sh`.
+
+#### ADDED: sync-render Gemini hook manifest helper
+
+`render_gemini_hooks_manifest()` in `scripts/lib/sync-render.sh` (Gemini-only).
+
+## Acceptance Criteria
+
+```bash
+bash scripts/test-gemini-adapter.sh && echo OK
+```
+
+## Out of scope
+
+- `scripts/install.sh` / `install-helpers.js` / `bin/setup.js` hub wiring (Wave B)
+- `scripts/targets.yaml` hook contracts (Wave B)
+- `scripts/verify-install.sh` matrix rows (Wave B)
+- Antigravity `.gemini/antigravity` paths
+- Editing generated `.gemini/extensions/bigpowers/skills/` or `commands/` (sync-skills.sh owns those)
+
+## Risks
+
+- Gemini CLI hook JSON shape may drift — wrappers use `.command // .tool_input.command` dual-path (proven in guard-git).
+- RTK may lack native Gemini hook mode — template documents optional wiring with passthrough fallback.
+
+## Verification Script
+
+1. Run `bash scripts/test-gemini-adapter.sh` — expect PASS.
+2. Open `.gemini/extensions/bigpowers/hooks/HOOKS.md` — confirm 11 events listed.
+3. Run `bash scripts/adapters/gemini.sh` with `--validate-hooks` (via test script) — all required templates present.

--- a/specs/epics/e64-integration-gemini/e64s01-tasks.yaml
+++ b/specs/epics/e64-integration-gemini/e64s01-tasks.yaml
@@ -1,0 +1,90 @@
+story_id: e64s01
+title: "Gemini hooks adapter — event docs, templates, adapter completeness (Wave A)"
+spec: e64s01-gemini-hooks-adapter.md
+status: passing
+bcps: 3
+risk: P2
+depends_on: []
+tasks:
+  - id: 1
+    description: >-
+      Write specs/security/epics/e64/THREAT_MODEL.md for Wave A adapter scope
+      (hooks templates, gemini.sh helpers; no hub install).
+    verify: test -f specs/security/epics/e64/THREAT_MODEL.md && grep -q 'LOW' specs/security/epics/e64/THREAT_MODEL.md && echo OK
+    risk: P2
+    security: low
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - Security Review
+        - Wave A
+
+  - id: 2
+    description: >-
+      Add hook event docs and templates under .gemini/extensions/bigpowers/hooks/:
+      HOOKS.md, hooks-manifest.json, settings.json.example, before-tool-git-guard.sh,
+      before-tool-rtk.sh, before-tool-token-mgmt.sh.
+    verify: >-
+      test -f .gemini/extensions/bigpowers/hooks/HOOKS.md &&
+      test -f .gemini/extensions/bigpowers/hooks/hooks-manifest.json &&
+      test -f .gemini/extensions/bigpowers/hooks/settings.json.example &&
+      test -f .gemini/extensions/bigpowers/hooks/before-tool-git-guard.sh && echo OK
+    risk: P2
+    security: low
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - Wave A
+
+  - id: 3
+    description: >-
+      Extend scripts/adapters/gemini.sh with list_hook_events, validate_hook_templates,
+      render_hooks_manifest; add render_gemini_hooks_manifest to sync-render.sh.
+    verify: >-
+      bash -n scripts/adapters/gemini.sh &&
+      bash -n scripts/lib/sync-render.sh &&
+      grep -q 'list_hook_events' scripts/adapters/gemini.sh &&
+      grep -q 'render_gemini_hooks_manifest' scripts/lib/sync-render.sh && echo OK
+    risk: P1
+    security: none
+    status: passing
+    allure:
+      severity: high
+      categories:
+        - Wave A
+
+  - id: 4
+    description: >-
+      Add scripts/test-gemini-adapter.sh — validates hook templates, event count (11),
+      and gemini adapter stdin render smoke test.
+    verify: bash scripts/test-gemini-adapter.sh
+    risk: P2
+    security: none
+    status: passing
+    allure:
+      severity: normal
+      categories:
+        - Wave A
+
+  - id: 5
+    description: >-
+      Update epic.yaml with e64s01 story entry; run plan-consistency-check on capsule.
+    verify: >-
+      grep -q 'e64s01' specs/epics/e64-integration-gemini/epic.yaml &&
+      bash scripts/lib/plan-consistency-check.sh specs/epics/e64-integration-gemini/ 2>&1 | grep -qv CRITICAL && echo OK
+    risk: P3
+    security: none
+    status: passing
+    allure:
+      severity: minor
+      categories:
+        - Wave A
+
+out_of_scope:
+  - scripts/install.sh install_gemini wiring
+  - scripts/lib/install-helpers.js gemini cases
+  - bin/setup.js SUPPORTED_IDS
+  - scripts/targets.yaml hook contracts
+  - scripts/verify-install.sh gemini hook matrix

--- a/specs/epics/e64-integration-gemini/e64s02-hub-wiring.md
+++ b/specs/epics/e64-integration-gemini/e64s02-hub-wiring.md
@@ -1,0 +1,29 @@
+# e64s02: Install hub wiring (Wave B)
+
+Wire Gemini CLI into the bigpowers install hub: `install.sh`, `install-helpers.js`, `bin/setup.js`, `targets.yaml`, and `verify-install.sh`. Wave A hook templates remain unchanged.
+
+## In scope
+
+- `install_gemini()` / `uninstall_gemini()` in `scripts/install.sh` — symlink extension to `~/.gemini/config/plugins/bigpowers/`, symlink Wave A hook templates to `~/.gemini/hooks/`, merge `BeforeTool` + `SessionStart` entries into `~/.gemini/settings.json` when present.
+- `gemini` hook cases in `scripts/lib/install-helpers.js` (global + uninstall).
+- Verify `gemini` in `SUPPORTED_IDS` in `bin/setup.js`.
+- `gemini_hooks_manifest` contract in `scripts/targets.yaml` + `target-contracts.sh`.
+- Gemini contract assertions in `scripts/verify-install.sh`.
+- `scripts/test-gemini-hub.sh` regression harness.
+
+## Out of scope
+
+- Live Gemini CLI UAT against `~/.gemini/settings.json`
+- Auto-enabling `before-tool-token-mgmt.sh` in settings (optional hook; symlink only)
+
+## Verify
+
+```bash
+bash scripts/test-gemini-hub.sh &&
+bash scripts/test-gemini-adapter.sh &&
+bash scripts/verify-install.sh &&
+bash -n scripts/install.sh &&
+node --check scripts/lib/install-helpers.js &&
+node --check bin/setup.js &&
+echo OK
+```

--- a/specs/epics/e64-integration-gemini/e64s02-tasks.yaml
+++ b/specs/epics/e64-integration-gemini/e64s02-tasks.yaml
@@ -1,0 +1,35 @@
+# story: e64s02
+title: "Install hub wiring (Wave B)"
+status: passing
+risk: P1
+spec: e64s02-hub-wiring.md
+depends_on: [e64s01]
+tasks:
+  - id: t1
+    title: Add scripts/test-gemini-hub.sh regression harness
+    status: passing
+    verify: bash scripts/test-gemini-hub.sh
+  - id: t2
+    title: Wire install_gemini/uninstall_gemini with Wave A hook templates in scripts/install.sh
+    status: passing
+    verify: bash -n scripts/install.sh && bash scripts/install.sh --dry-run 2>&1 | grep -q 'before-tool-git-guard.sh'
+  - id: t3
+    title: Add gemini hook cases to scripts/lib/install-helpers.js
+    status: passing
+    verify: node --check scripts/lib/install-helpers.js && grep -q 'before-tool-git-guard.sh' scripts/lib/install-helpers.js
+  - id: t4
+    title: Verify gemini in SUPPORTED_IDS in bin/setup.js
+    status: passing
+    verify: node --check bin/setup.js && grep -q "'gemini'" bin/setup.js
+  - id: t5
+    title: Add gemini_hooks_manifest contract to targets.yaml and verify-install.sh
+    status: passing
+    verify: grep -q gemini_hooks_manifest scripts/targets.yaml && bash scripts/verify-install.sh
+  - id: t6
+    title: Story gate — hub harness + adapter + verify-install green
+    status: passing
+    verify: >-
+      bash scripts/test-gemini-hub.sh &&
+      bash scripts/test-gemini-adapter.sh &&
+      bash scripts/verify-install.sh &&
+      echo OK

--- a/specs/epics/e64-integration-gemini/epic.yaml
+++ b/specs/epics/e64-integration-gemini/epic.yaml
@@ -29,3 +29,9 @@ stories:
     bcps: 3
     status: done
     wave: A
+  - id: e64s02
+    title: Install hub wiring (Wave B)
+    bcps: 2
+    status: in_progress
+    wave: B
+    depends_on: [e64s01]

--- a/specs/epics/e64-integration-gemini/epic.yaml
+++ b/specs/epics/e64-integration-gemini/epic.yaml
@@ -23,4 +23,9 @@ integration_details:
   hook_format: JSON (settings.json)
   hook_events_count: 11
   naming_convention: BeforeTool/AfterTool (not PreToolUse/PostToolUse)
-stories: []
+stories:
+  - id: e64s01
+    title: Gemini hooks adapter — event docs, templates, adapter completeness (Wave A)
+    bcps: 3
+    status: done
+    wave: A

--- a/specs/security/epics/e64/THREAT_MODEL.md
+++ b/specs/security/epics/e64/THREAT_MODEL.md
@@ -1,0 +1,58 @@
+# e64 Threat Model — Gemini CLI Extensions + Hooks (Wave A)
+
+**Date:** 2026-07-24 | **Assessor:** build-epic Step 0 | **Risk Level:** LOW
+
+## Scope (Wave A — adapter-only)
+
+| Surface | Description |
+|---------|-------------|
+| `scripts/adapters/gemini.sh` | Hook manifest helpers, template validation (no install wiring) |
+| `scripts/lib/sync-render.sh` | `render_gemini_hooks_manifest()` only |
+| `.gemini/extensions/bigpowers/hooks/` | Source hook templates + `settings.json.example` (not live settings) |
+| `specs/epics/e64-integration-gemini/` | Story spec, tasks, verification artifacts |
+
+**Out of scope (Wave B):** `scripts/install.sh`, `scripts/lib/install-helpers.js`, `bin/setup.js`, `scripts/targets.yaml`, `scripts/verify-install.sh`, live `~/.gemini/settings.json` mutation.
+
+## Threat Assessment
+
+### T1: Hook command injection via settings.json — LOW (Confidence: 9/10)
+
+**Surface:** Wave A ships `settings.json.example` only. Live settings mutation is deferred to Wave B (`install_gemini()` jq merge).
+
+**Exploit scenario:** An attacker with write access to the consumer's `~/.gemini/settings.json` could point hooks at arbitrary commands — but that implies the same privilege as the Gemini CLI user.
+
+**Recommendation:** Wave B must keep hook commands as quoted paths to repo-managed scripts under `unlink_if_managed()` symlinks. Document in `HOOKS.md`; no dynamic user input in hook command strings.
+
+### T2: Symlink targets in hook wrappers — LOW (Confidence: 9/10)
+
+**Surface:** Hook wrappers (`before-tool-git-guard.sh`) resolve `skills/guard-git/scripts/block-dangerous-git.sh` by walking up to repo root (same pattern as `session-start`).
+
+**Existing guard:** `unlink_if_managed()` in Wave B install prevents deleting user-owned hook targets.
+
+**Recommendation:** No Wave A changes needed. Wrappers must never accept hook payload as shell arguments.
+
+### T3: Session-start context injection — LOW (Confidence: 8/10)
+
+**Surface:** `session-start` embeds `project-survey.sh` output into JSON `additionalContext`.
+
+**Exploit scenario:** Malicious repo content could inflate context; not a privilege escalation — bounded by survey script output size.
+
+**Recommendation:** Accept for Wave A. Token-mgmt hook (Wave B wiring) provides mechanical backstop for oversized reads.
+
+### T4: Path traversal in adapter render — NONE (Confidence: 10/10)
+
+**Surface:** `render_skill()` writes to `GEMINI_SKILLS/$IR_NAME/` where `IR_NAME` comes from parsed SKILL.md frontmatter (sync pipeline), not user CLI input at install time.
+
+**Recommendation:** No action.
+
+## Decision
+
+| Category | Risk | Confidence |
+|----------|------|------------|
+| Command injection | LOW | 9/10 |
+| Symlink attacks | LOW | 9/10 |
+| Path traversal | NONE | 10/10 |
+| Secrets exposure | N/A | — |
+| **Overall** | **LOW** | **9/10** |
+
+**Verdict:** CLEAR to proceed. No HIGH findings. Wave B must preserve `unlink_if_managed()` and static hook command paths.

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -5,18 +5,18 @@ bug_id: null
 bigpowers_version: 2.82.4
 bug_cycle: null
 handoff:
-  next_skill: develop-tdd
-  context: Wave A complete — executing Wave B hub wiring (install.sh, install-helpers, verify-install)
+  next_skill: release-branch
+  context: Wave B e64s02 hub wiring complete; audit PASS; open PR
   epic: e64
 epic_cycle:
-  step: '1'
+  step: '7'
   fast_mode: true
   story_bcps: 2
-  audit_result: null
-  completed_steps: ''
+  audit_result: pass
+  completed_steps: '0,1,2,3,4,5,6'
 metrics:
   story_start: '2026-07-24T11:13:00-03:00'
-  story_end: null
+  story_end: '2026-07-24T11:25:00-03:00'
   skill_timings: {}
 release:
   ci_verified: true

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -1,24 +1,24 @@
 active_flow: build_epic
-active_epic: e69
-active_story: e69s02
+active_epic: e64
+active_story: e64s02
 bug_id: null
 bigpowers_version: 2.82.4
 bug_cycle: null
 handoff:
-  next_skill: release-branch
-  context: Wave B e69s02 hub wiring complete; audit PASS; open PR
-  epic: e69
+  next_skill: develop-tdd
+  context: Wave A complete — executing Wave B hub wiring (install.sh, install-helpers, verify-install)
+  epic: e64
 epic_cycle:
-  step: '8'
+  step: '1'
   fast_mode: true
   story_bcps: 2
-  audit_result: pass
-  completed_steps: '0,1,2,3,4,5,6,7'
+  audit_result: null
+  completed_steps: ''
 metrics:
-  story_start: "2026-07-24T11:10:00-03:00"
-  story_end: "2026-07-24T11:20:00-03:00"
+  story_start: '2026-07-24T11:13:00-03:00'
+  story_end: null
   skill_timings: {}
 release:
   ci_verified: true
-  last_commit: c9d194e3
-  last_epic: wave0
+  last_commit: ff351d29
+  last_epic: e64

--- a/specs/verifications/AUDIT-e64-e64s01.md
+++ b/specs/verifications/AUDIT-e64-e64s01.md
@@ -1,0 +1,97 @@
+# Audit Report — e64s01: Gemini Hooks Adapter (Wave A)
+
+**Date:** 2026-07-24  
+**Epic:** e64 — Integration: Gemini CLI — Extensions + Hooks  
+**Story:** e64s01 — Gemini hooks adapter — event docs, templates, adapter completeness  
+**Branch:** feat/e64-integration-gemini  
+**Mode:** build-epic --fast (steps 0–6, stop before release-branch)
+
+**Files:** `scripts/adapters/gemini.sh`, `scripts/lib/sync-render.sh`, `scripts/test-gemini-adapter.sh`, `.gemini/extensions/bigpowers/hooks/*`, `specs/epics/e64-integration-gemini/*`, `specs/security/epics/e64/THREAT_MODEL.md`
+
+---
+
+## Supply Chain & Security
+
+- [x] No new npm/cargo dependencies
+- [x] No secrets in diff
+- [x] Threat model written — LOW risk, CLEAR verdict
+- [x] Hook wrappers delegate to existing guard-git / token-mgmt scripts (no new attack surface)
+- [x] Wave A scope excludes live `~/.gemini/settings.json` mutation
+
+## Provenance & Metadata
+
+- [x] `# story: e64s01` tags on new hook scripts and adapter changes
+- [x] Capsule story spec + tasks.yaml with verify commands
+
+## Law of Demeter
+
+- [x] Hook wrappers walk to repo root then exec one script — no deep chains
+
+## CONVENTIONS.md Compliance
+
+- [x] Spec output under `specs/`
+- [x] No forbidden hub files edited
+- [x] Hook templates in gemini-only paths (allowed Wave A scope)
+
+## Scope
+
+- [x] Adapter-only — no install hub wiring (deferred Wave B)
+- [x] No speculative features beyond hook docs/templates/validation
+- [x] Discovered defects: none
+
+## Boy Scout Rule
+
+- [x] Files touched are focused and clean
+- [x] No dead code
+
+## Types and Safety
+
+- [x] Bash with `set -euo pipefail` on new scripts
+- [x] JSON test uses `jq -e` for assertions
+
+## Test Coverage
+
+- [x] `scripts/test-gemini-adapter.sh` covers template validation, event count, HOOKS.md coverage, stdin render, manifest render, git-guard gemini deny path
+- [x] All task verify commands exit 0
+
+## SOLID and Heuristics
+
+- [x] Single responsibility: gemini.sh = adapter + hook validation; sync-render = render helpers only
+- [x] Open/Closed: new hooks added via manifest + templates without hub changes
+
+## Code Style
+
+- [x] Functions 4–20 lines where applicable
+- [x] Unique names (`validate_hook_templates`, `render_gemini_hooks_manifest`)
+- [x] Comments explain WHY (Wave A vs B boundary)
+
+## Agent Readability
+
+- [x] HOOKS.md table maps events → shipped status
+- [x] `hooks-manifest.json` machine-readable for Wave B install
+
+---
+
+## Summary
+
+| Section | Status |
+|---------|--------|
+| Supply Chain & Security | PASS |
+| Provenance & Metadata | PASS |
+| Law of Demeter | PASS |
+| CONVENTIONS.md Compliance | PASS |
+| Scope | PASS |
+| Boy Scout Rule | PASS |
+| Types and Safety | PASS |
+| Test Coverage | PASS |
+| SOLID and Heuristics | PASS |
+| Code Style | PASS |
+| Agent Readability | PASS |
+
+**Overall: PASS**
+
+**Next skill:** commit-message (Wave A stops before release-branch)
+
+---
+
+**epic_cycle.audit_result:** pass

--- a/specs/verifications/AUDIT-e64-e64s02.md
+++ b/specs/verifications/AUDIT-e64-e64s02.md
@@ -1,0 +1,96 @@
+# Audit Report — e64s02: Install Hub Wiring (Wave B)
+
+**Date:** 2026-07-24  
+**Epic:** e64 — Integration: Gemini CLI — Extensions + Hooks  
+**Story:** e64s02 — Install hub wiring (Wave B)  
+**Branch:** feat/e64-integration-gemini  
+**Mode:** build-epic --fast (Wave B hub wiring)
+
+**Files:** `scripts/install.sh`, `scripts/lib/install-helpers.js`, `scripts/targets.yaml`, `scripts/lib/target-contracts.sh`, `scripts/verify-install.sh`, `scripts/test-gemini-hub.sh`, `specs/epics/e64-integration-gemini/e64s02-*`
+
+---
+
+## Supply Chain & Security
+
+- [x] No new npm/cargo dependencies
+- [x] No secrets in diff
+- [x] Hook install uses Wave A wrappers (delegates to guard-git/rtk) — no new attack surface
+- [x] settings.json merge only when file exists; example path documented when absent
+
+## Provenance & Metadata
+
+- [x] `# story: e64s02` tags on install-helpers.js and test-gemini-hub.sh
+- [x] Capsule story spec + tasks.yaml with verify commands
+
+## Law of Demeter
+
+- [x] install_gemini links templates; wrappers find repo root independently
+
+## CONVENTIONS.md Compliance
+
+- [x] Spec output under `specs/`
+- [x] Hub wiring in allowed install paths only
+- [x] Wave A templates unchanged (symlink-only)
+
+## Scope
+
+- [x] Hub wiring only — no adapter rewrites
+- [x] token-mgmt hook symlinked but not auto-enabled (per spec)
+- [x] Discovered defects: none
+
+## Boy Scout Rule
+
+- [x] Replaced legacy block-dangerous-git direct symlink with Wave A wrapper pattern
+- [x] No dead code
+
+## Types and Safety
+
+- [x] Bash with `set -euo pipefail` preserved
+- [x] node --check passes on install-helpers.js
+
+## Test Coverage
+
+- [x] `scripts/test-gemini-hub.sh` — 22 assertions on install path
+- [x] `scripts/test-gemini-adapter.sh` — Wave A regression still green
+- [x] `scripts/verify-install.sh` — gemini contract assertions added
+
+## SOLID and Heuristics
+
+- [x] install_gemini mirrors Claude/hermes hub patterns
+- [x] Contract `gemini_hooks_manifest` reuses adapter validation
+
+## Code Style
+
+- [x] Focused diff — no unrelated refactors
+- [x] HOOKS.md Wave B section updated
+
+## Agent Readability
+
+- [x] settings.json.example remains source of truth for hook wiring shape
+- [x] Dry-run output shows Wave A hook symlinks
+
+---
+
+## Summary
+
+| Section | Status |
+|---------|--------|
+| Supply Chain & Security | PASS |
+| Provenance & Metadata | PASS |
+| Law of Demeter | PASS |
+| CONVENTIONS.md Compliance | PASS |
+| Scope | PASS |
+| Boy Scout Rule | PASS |
+| Types and Safety | PASS |
+| Test Coverage | PASS |
+| SOLID and Heuristics | PASS |
+| Code Style | PASS |
+| Agent Readability | PASS |
+
+**Overall: PASS**
+
+**Next skill:** release-branch (PR only — do not merge)
+
+---
+
+**epic_cycle.audit_result:** pass

--- a/specs/verifications/VERIFY-e64-e64s01.md
+++ b/specs/verifications/VERIFY-e64-e64s01.md
@@ -1,0 +1,27 @@
+# Verify Report — e64s01: Gemini Hooks Adapter (Wave A)
+
+**Date:** 2026-07-24  
+**Story:** e64s01 — Gemini hooks adapter — event docs, templates, adapter completeness  
+**Worktree:** `/Users/danielvm/Developer/bp-e64`  
+**Branch:** `feat/e64-integration-gemini`
+
+## Mechanical gates
+
+| Gate | Command | Result |
+|------|---------|--------|
+| Hook adapter test | `bash scripts/test-gemini-adapter.sh` | PASS |
+| Plan consistency | `bash scripts/lib/plan-consistency-check.sh specs/epics/e64-integration-gemini/` | PASS (CRITICAL=0 HIGH=0) |
+| Adapter syntax | `bash -n scripts/adapters/gemini.sh` | PASS |
+| sync-render syntax | `bash -n scripts/lib/sync-render.sh` | PASS |
+| Threat model | `test -f specs/security/epics/e64/THREAT_MODEL.md` | PASS |
+
+## Scope compliance
+
+- No edits to forbidden hub files (`install.sh`, `install-helpers.js`, `setup.js`, `targets.yaml`, `verify-install.sh`).
+- No Antigravity `.gemini/antigravity` paths touched.
+
+## Task ledger
+
+All 5 tasks in `e64s01-tasks.yaml` verified passing.
+
+**Verdict:** PASS

--- a/specs/verifications/VERIFY-e64-e64s02.md
+++ b/specs/verifications/VERIFY-e64-e64s02.md
@@ -1,0 +1,30 @@
+# Verify Report — e64s02: Install Hub Wiring (Wave B)
+
+**Date:** 2026-07-24  
+**Story:** e64s02 — Install hub wiring (Wave B)  
+**Worktree:** `/Users/danielvm/Developer/bp-e64`  
+**Branch:** `feat/e64-integration-gemini`
+
+## Mechanical gates
+
+| Gate | Command | Result |
+|------|---------|--------|
+| Hub regression | `bash scripts/test-gemini-hub.sh` | PASS (22/22) |
+| Adapter regression | `bash scripts/test-gemini-adapter.sh` | PASS |
+| Install harness | `bash scripts/verify-install.sh` | PASS (47/47) |
+| install.sh syntax | `bash -n scripts/install.sh` | PASS |
+| install-helpers | `node --check scripts/lib/install-helpers.js` | PASS |
+| setup.js | `node --check bin/setup.js` | PASS |
+| Plan consistency | `bash scripts/lib/plan-consistency-check.sh specs/epics/e64-integration-gemini/` | PASS |
+
+## Scope compliance
+
+- Wave A hook templates wired via `install_gemini()` — no template rewrites.
+- `before-tool-token-mgmt.sh` symlinked but not auto-merged into settings (optional hook).
+- No Antigravity `.gemini/antigravity` paths touched.
+
+## Task ledger
+
+All 6 tasks in `e64s02-tasks.yaml` verified passing.
+
+**Verdict:** PASS


### PR DESCRIPTION
## Summary

- **Wave A (e64s01):** Gemini hook adapter — 11-event docs, hook templates (`before-tool-git-guard`, RTK, token-mgmt), adapter validation, and `test-gemini-adapter.sh`.
- **Wave B (e64s02):** Install hub wiring — `install_gemini()` symlinks Wave A templates to `~/.gemini/hooks/`, merges `SessionStart` + `BeforeTool` into `settings.json`, extends `install-helpers.js`, adds `gemini_hooks_manifest` contract, and ships `test-gemini-hub.sh`.

Rebased onto `origin/main` (includes e61, e76 merges).

## Test plan

- [x] `bash scripts/test-gemini-adapter.sh` — PASS
- [x] `bash scripts/test-gemini-hub.sh` — PASS (22/22)
- [x] `bash scripts/verify-install.sh` — PASS (47/47)
- [x] Audit: `specs/verifications/AUDIT-e64-e64s02.md` — **PASS**

## Audit

| Story | Path | Verdict |
|-------|------|---------|
| e64s01 | `specs/verifications/AUDIT-e64-e64s01.md` | PASS |
| e64s02 | `specs/verifications/AUDIT-e64-e64s02.md` | PASS |

**Do not merge** — awaiting review.

Made with [Cursor](https://cursor.com)