### PR TITLE
fix(install): Wave 0 closeout for e60/e63/e77/e78 (rebased)

### DIFF
--- a/bin/setup.js
+++ b/bin/setup.js
@@ -274,6 +274,12 @@ async function main() {
     const detail = r.ok ? c.dim(r.path) : c.red(r.error);
     console.log(`  ${icon} ${r.name} — ${detail}`);
   }
+  if (selectedTools.includes('cursor') && results.some((r) => r.name === 'Cursor' && r.ok)) {
+    console.log(
+      `  ${c.dim('NOTE: Cursor does not scan ~/.cursor/rules globally — also symlink into each project:')}`
+    );
+    console.log(`  ${c.dim('  ln -sfn ' + path.join(ROOT, '.cursor', 'rules') + ' .cursor/rules')}`);
+  }
   console.log('');
 
   const allOk = results.every((r) => r.ok);

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -52,12 +52,12 @@ const TOOLS = [
   { id: 'mimo', name: 'MiMo Code', globalPath: '~/.mimocode', localPath: '.mimocode' },
   { id: 'kilo', name: 'Kilo', globalPath: '~/.config/kilo', localPath: '.config/kilo' },
   { id: 'opencode', name: 'OpenCode', globalPath: '~/.config/opencode', localPath: '.config/opencode' },
+  { id: 'pi', name: 'pi', globalPath: '~/.pi/agent/skills', localPath: '.pi/agent/skills' },
   { id: 'qwen', name: 'Qwen Code', globalPath: '~/.qwen', localPath: '.qwen' },
   { id: 'trae', name: 'Trae', globalPath: '~/.trae', localPath: '.trae' },
   { id: 'windsurf', name: 'Windsurf', globalPath: '~/.codeium/windsurf', localPath: '.codeium/windsurf' },
   { id: 'zcode', name: 'ZCode', globalPath: '~/.zcode', localPath: '.zcode' },
 ];
-const ALL_ID = '__all__';
 const SUPPORTED_IDS = new Set(['claude', 'gemini', 'pi', 'hermes', 'mimo', 'zcode', 'cursor', 'codex', 'antigravity', 'agy']);
 const UNSUPPORTED_HINT = '(TODO)';
 
@@ -162,7 +162,7 @@ async function main() {
   }
 
   if (mode === 'uninstall') {
-    await handleUninstall(clack);
+    await handleUninstall();
     return;
   }
 

--- a/scripts/install-cursor-skills-local.sh
+++ b/scripts/install-cursor-skills-local.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
-# Install skills into a project: <install-root>/.cursor/skills (not ~/.cursor/skills).
+# story: e78
+# DEPRECATED wrapper — project-local Cursor rules symlink (not .cursor/skills copies).
 # Usage: ./scripts/install-cursor-skills-local.sh [INSTALL_ROOT]
-#   INSTALL_ROOT defaults to the current working directory. Skills are read from
-#   this skills repository unless SOURCE_DIR is set.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-INSTALL_ROOT="$(cd "${1:-"$PWD"}" && pwd)"
-export TARGET_DIR="${TARGET_DIR:-"$INSTALL_ROOT/.cursor/skills"}"
-export SOURCE_DIR="${SOURCE_DIR:-$REPO_ROOT}"
+INSTALL_ROOT="$(cd "${1:-$PWD}" && pwd)"
+export TARGET_DIR="${TARGET_DIR:-$INSTALL_ROOT/.cursor/rules}"
+export SOURCE_DIR="${SOURCE_DIR:-$REPO_ROOT/.cursor/rules}"
+
+echo "NOTE: install-cursor-skills-local.sh is deprecated; prefer bigpowers setup (local) or:" >&2
+echo "  ln -sfn $SOURCE_DIR $TARGET_DIR" >&2
 
 exec "$REPO_ROOT/scripts/install-cursor-skills.sh"

--- a/scripts/install-cursor-skills.sh
+++ b/scripts/install-cursor-skills.sh
@@ -1,34 +1,24 @@
 #!/usr/bin/env bash
+# story: e78
+# DEPRECATED wrapper — Cursor integration is Rules (.mdc), not ~/.cursor/skills copies.
+# Canonical install: bash scripts/install.sh  OR  node bin/setup.js (bigpowers setup)
+# This script now symlinks repo .cursor/rules → TARGET_DIR (default: ~/.cursor/rules).
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-SOURCE_DIR="${SOURCE_DIR:-$REPO_ROOT}"
-TARGET_DIR="${TARGET_DIR:-"$HOME/.cursor/skills"}"
+SOURCE_DIR="${SOURCE_DIR:-$REPO_ROOT/.cursor/rules}"
+TARGET_DIR="${TARGET_DIR:-$HOME/.cursor/rules}"
+
+echo "NOTE: install-cursor-skills.sh is deprecated; use scripts/install.sh or bigpowers setup." >&2
+echo "      Redirecting to rules symlink: $TARGET_DIR → $SOURCE_DIR" >&2
 
 if [[ ! -d "$SOURCE_DIR" ]]; then
-  echo "SOURCE_DIR is not a directory: $SOURCE_DIR" >&2
+  echo "SOURCE_DIR missing: $SOURCE_DIR — run bash scripts/sync-skills.sh first" >&2
   exit 1
 fi
 
-mkdir -p "$TARGET_DIR"
-
-shopt -s nullglob
-count=0
-for item in "$SOURCE_DIR"/*; do
-  [[ -d "$item" ]] || continue
-  name="$(basename "$item")"
-  [[ -f "$item/SKILL.md" ]] || continue
-  if [[ "$name" == .?* ]]; then
-    continue
-  fi
-  echo "Syncing <${name}>"
-  rsync -a --delete "$item/" "$TARGET_DIR/${name}/"
-  count=$((count + 1))
-done
-
-if [[ "$count" -eq 0 ]]; then
-  echo "No top-level skill directories with SKILL.md found in $SOURCE_DIR" >&2
-  exit 1
-fi
-
-echo "Done. Installed $count skills under $TARGET_DIR"
+mkdir -p "$(dirname "$TARGET_DIR")"
+ln -sfn "$SOURCE_DIR" "$TARGET_DIR"
+echo "Done. Linked $TARGET_DIR → $SOURCE_DIR"
+echo "NOTE: Cursor does not scan ~/.cursor/rules/ globally; also symlink into each project:"
+echo "  ln -sfn $SOURCE_DIR .cursor/rules"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # story: e45s16
+# story: e60s01
+# story: e63
 # story: e64s02
 # story: e74s02
 # install.sh — global symlink install for bigpowers skills
@@ -19,8 +21,6 @@
 #   ./scripts/install.sh --dry-run   # show what would be linked
 #   ./scripts/install.sh --uninstall # remove all managed symlinks
 set -euo pipefail
-source "$(dirname "${BASH_SOURCE[0]}")/lib/skill-common.sh"
-resolve_repo_root
 
 # SKILLS_ROOT: use skills/ subdirectory when it exists, fall back to repo root
 source "$(dirname "${BASH_SOURCE[0]}")/lib/skill-common.sh"
@@ -88,8 +88,9 @@ install_claude() {
   echo "Claude Code Hooks → $CLAUDE_HOOKS_DIR/"
   link "$REPO_ROOT/.gemini/extensions/bigpowers/hooks/session-start" "$CLAUDE_HOOKS_DIR/session-start"
   link "$REPO_ROOT/.gemini/extensions/bigpowers/hooks/run-hook.cmd" "$CLAUDE_HOOKS_DIR/run-hook.cmd"
-  link "$REPO_ROOT/guard-git/scripts/block-dangerous-git.sh" "$CLAUDE_HOOKS_DIR/block-dangerous-git.sh"
-  link "$REPO_ROOT/guard-git/scripts/lib" "$CLAUDE_HOOKS_DIR/lib"
+  # story: e60s01 e63 — canonical path is skills/guard-git (not bare guard-git/)
+  link "$REPO_ROOT/skills/guard-git/scripts/block-dangerous-git.sh" "$CLAUDE_HOOKS_DIR/block-dangerous-git.sh"
+  link "$REPO_ROOT/skills/guard-git/scripts/lib" "$CLAUDE_HOOKS_DIR/lib"
   link "$REPO_ROOT/scripts/hooks/rtk-rewrite.sh" "$CLAUDE_HOOKS_DIR/rtk-rewrite.sh"
   # story: e45s16
   chmod +x "$REPO_ROOT/scripts/hooks/rtk-rewrite.sh" 2>/dev/null || true

--- a/scripts/lib/golden-suite-gates.sh
+++ b/scripts/lib/golden-suite-gates.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# story: e42s04 e45s02 e45s14
+# story: e42s04 e45s02 e45s14 e60s01
 # Deterministic gate runner for golden suite — sourced by golden-suite-run.sh
 
 if [ -n "${GOLDEN_GATES_LOADED:-}" ]; then return 0; fi
@@ -14,6 +14,7 @@ GOLDEN_GATES=(
   "g09-yaml-roundtrip:bash scripts/golden-g09-yaml-roundtrip.sh:false"
   "g10-trace-anti-vacuity:bash scripts/golden-g10-trace-anti-vacuity.sh:false"
   "g11-gitignore-venv:bash scripts/golden-g11-gitignore-venv.sh:false"
+  "install-helpers:bash scripts/test-install-helpers.sh:false"
   "import-boundaries:bash scripts/check-import-boundaries.sh:false"
   "skill-catalog:bash scripts/validate-skill-catalog.sh:false"
   "specs-parse:bash scripts/validate-specs-yaml.sh:false"

--- a/scripts/lib/install-helpers.js
+++ b/scripts/lib/install-helpers.js
@@ -63,7 +63,11 @@ function bridgeHermesConfig(configPath) {
 }
 
 function linkHook(src, dst) {
-  if (!fs.existsSync(src)) return;
+  if (!fs.existsSync(src)) {
+    throw new Error(
+      `Hook source missing: ${src} (expected under repo skills/ or scripts/hooks/; fix path or restore file)`
+    );
+  }
   try {
     const stat = fs.lstatSync(dst);
     if (stat.isSymbolicLink()) fs.unlinkSync(dst);
@@ -87,7 +91,7 @@ function installGlobal(tool, repoRoot) {
       const hooksDir = path.join(homeDir, '.claude', 'hooks');
       fs.mkdirSync(hooksDir, { recursive: true });
       linkHook(
-        path.join(repoRoot, 'guard-git', 'scripts', 'block-dangerous-git.sh'),
+        path.join(repoRoot, 'skills', 'guard-git', 'scripts', 'block-dangerous-git.sh'),
         path.join(hooksDir, 'block-dangerous-git.sh')
       );
       linkHook(

--- a/scripts/lib/install-helpers.js
+++ b/scripts/lib/install-helpers.js
@@ -28,6 +28,11 @@ function linkSkills(skillsDir, targetDir) {
 }
 
 function linkDir(src, dst) {
+  if (!fs.existsSync(src)) {
+    throw new Error(
+      `Link source missing: ${src} (run bash scripts/sync-skills.sh first)`
+    );
+  }
   try {
     const stat = fs.lstatSync(dst);
     if (stat.isSymbolicLink()) fs.unlinkSync(dst);
@@ -279,7 +284,7 @@ function uninstallTool(toolId, repoRoot) {
         for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
           if (!entry.isSymbolicLink()) continue;
           const target = fs.readlinkSync(path.join(skillsDir, entry.name));
-          if (target.includes('bigpowers')) {
+          if (target.startsWith(repoRoot)) {
             removeSymlink(path.join(skillsDir, entry.name));
           }
         }
@@ -308,7 +313,7 @@ function uninstallTool(toolId, repoRoot) {
         for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
           if (!entry.isSymbolicLink()) continue;
           const target = fs.readlinkSync(path.join(skillsDir, entry.name));
-          if (target.includes('bigpowers')) {
+          if (target.startsWith(repoRoot)) {
             removeSymlink(path.join(skillsDir, entry.name));
           }
         }
@@ -321,7 +326,7 @@ function uninstallTool(toolId, repoRoot) {
         for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
           if (!entry.isSymbolicLink()) continue;
           const target = fs.readlinkSync(path.join(skillsDir, entry.name));
-          if (target.includes('bigpowers') || target.includes('.hermes/skills')) {
+          if (target.startsWith(repoRoot) || target.includes('.hermes/skills')) {
             removeSymlink(path.join(skillsDir, entry.name));
           }
         }

--- a/scripts/lib/install-helpers.js
+++ b/scripts/lib/install-helpers.js
@@ -94,6 +94,11 @@ function installGlobal(tool, repoRoot) {
         path.join(repoRoot, 'skills', 'guard-git', 'scripts', 'block-dangerous-git.sh'),
         path.join(hooksDir, 'block-dangerous-git.sh')
       );
+      // story: e63 — hook sources SCRIPT_DIR/lib/git-guardrails-core.sh
+      linkDir(
+        path.join(repoRoot, 'skills', 'guard-git', 'scripts', 'lib'),
+        path.join(hooksDir, 'lib')
+      );
       linkHook(
         path.join(repoRoot, 'scripts', 'hooks', 'rtk-rewrite.sh'),
         path.join(hooksDir, 'rtk-rewrite.sh')
@@ -282,6 +287,7 @@ function uninstallTool(toolId, repoRoot) {
       const hooksDir = path.join(homeDir, '.claude', 'hooks');
       removeSymlink(path.join(hooksDir, 'block-dangerous-git.sh'));
       removeSymlink(path.join(hooksDir, 'rtk-rewrite.sh'));
+      removeSymlink(path.join(hooksDir, 'lib'));
       break;
     }
     case 'gemini':

--- a/scripts/test-install-helpers.js
+++ b/scripts/test-install-helpers.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// story: e60s01
+// Regression selftest for scripts/lib/install-helpers.js (Wave 0 closeout).
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { mkdtempSync, rmSync } = fs;
+
+const ROOT = path.resolve(__dirname, '..');
+const tmpHome = mkdtempSync(path.join(os.tmpdir(), 'bp-install-helpers-'));
+process.env.HOME = tmpHome;
+
+const { installGlobal, linkHook } = require('../scripts/lib/install-helpers.js');
+
+try {
+  const hookSrc = path.join(ROOT, 'skills', 'guard-git', 'scripts', 'block-dangerous-git.sh');
+  assert.ok(fs.existsSync(hookSrc), `Claude guard-git hook source must exist: ${hookSrc}`);
+
+  const rtkSrc = path.join(ROOT, 'scripts', 'hooks', 'rtk-rewrite.sh');
+  assert.ok(fs.existsSync(rtkSrc), `rtk-rewrite hook source must exist: ${rtkSrc}`);
+
+  assert.throws(
+    () => linkHook(path.join(tmpHome, 'missing-hook.sh'), path.join(tmpHome, 'dst-hook.sh')),
+    /Hook source missing/
+  );
+
+  const setupSrc = fs.readFileSync(path.join(ROOT, 'bin/setup.js'), 'utf8');
+  assert.ok(/id:\s*'pi'/.test(setupSrc), 'bin/setup.js TOOLS must include pi');
+  assert.ok(!/const ALL_ID/.test(setupSrc), 'dead ALL_ID constant must be removed');
+
+  installGlobal({ id: 'claude', name: 'Claude Code' }, ROOT);
+
+  const linked = path.join(tmpHome, '.claude', 'hooks', 'block-dangerous-git.sh');
+  assert.ok(fs.lstatSync(linked).isSymbolicLink(), 'block-dangerous-git.sh must be symlinked');
+  assert.strictEqual(fs.readlinkSync(linked), hookSrc, 'symlink must point at skills/guard-git path');
+
+  const rtkLinked = path.join(tmpHome, '.claude', 'hooks', 'rtk-rewrite.sh');
+  assert.ok(fs.lstatSync(rtkLinked).isSymbolicLink(), 'rtk-rewrite.sh must be symlinked');
+  assert.strictEqual(fs.readlinkSync(rtkLinked), rtkSrc, 'rtk-rewrite symlink must point at scripts/hooks source');
+
+  installGlobal({ id: 'pi', name: 'pi' }, ROOT);
+  const piSkill = path.join(tmpHome, '.pi', 'agent', 'skills');
+  assert.ok(fs.existsSync(piSkill), 'pi skills dir must exist after installGlobal');
+  const sample = fs.readdirSync(piSkill).find((n) => {
+    try {
+      return fs.lstatSync(path.join(piSkill, n)).isSymbolicLink();
+    } catch {
+      return false;
+    }
+  });
+  assert.ok(sample, 'pi install must create at least one skill symlink');
+  assert.ok(
+    fs.readlinkSync(path.join(piSkill, sample)).includes(path.join('skills', sample)),
+    'pi skill symlink must point into repo skills/'
+  );
+
+  console.log('test-install-helpers: ALL PASS');
+} finally {
+  rmSync(tmpHome, { recursive: true, force: true });
+}

--- a/scripts/test-install-helpers.js
+++ b/scripts/test-install-helpers.js
@@ -27,6 +27,12 @@ try {
     /Hook source missing/
   );
 
+  const { linkDir, uninstallTool } = require('../scripts/lib/install-helpers.js');
+  assert.throws(
+    () => linkDir(path.join(tmpHome, 'missing-dir'), path.join(tmpHome, 'dst-dir')),
+    /Link source missing/
+  );
+
   const setupSrc = fs.readFileSync(path.join(ROOT, 'bin/setup.js'), 'utf8');
   assert.ok(/id:\s*'pi'/.test(setupSrc), 'bin/setup.js TOOLS must include pi');
   assert.ok(!/const ALL_ID/.test(setupSrc), 'dead ALL_ID constant must be removed');
@@ -65,6 +71,21 @@ try {
     fs.readlinkSync(path.join(piSkill, sample)).includes(path.join('skills', sample)),
     'pi skill symlink must point into repo skills/'
   );
+
+  uninstallTool('pi', ROOT);
+  assert.ok(
+    !fs.existsSync(path.join(piSkill, sample)),
+    'uninstallTool(pi) must remove repo-rooted skill symlinks'
+  );
+
+  const rulesSrc = path.join(ROOT, '.cursor', 'rules');
+  assert.ok(fs.existsSync(rulesSrc), '.cursor/rules must exist (run sync-skills)');
+  installGlobal({ id: 'cursor', name: 'Cursor' }, ROOT);
+  const rulesDst = path.join(tmpHome, '.cursor', 'rules');
+  assert.ok(fs.lstatSync(rulesDst).isSymbolicLink(), 'cursor rules must be symlinked');
+  assert.strictEqual(fs.readlinkSync(rulesDst), rulesSrc, 'cursor rules symlink must point at repo .cursor/rules');
+  uninstallTool('cursor', ROOT);
+  assert.ok(!fs.existsSync(rulesDst), 'uninstallTool(cursor) must remove rules symlink');
 
   const installSh = fs.readFileSync(path.join(ROOT, 'scripts/install.sh'), 'utf8');
   assert.ok(

--- a/scripts/test-install-helpers.js
+++ b/scripts/test-install-helpers.js
@@ -37,6 +37,15 @@ try {
   assert.ok(fs.lstatSync(linked).isSymbolicLink(), 'block-dangerous-git.sh must be symlinked');
   assert.strictEqual(fs.readlinkSync(linked), hookSrc, 'symlink must point at skills/guard-git path');
 
+  const libLinked = path.join(tmpHome, '.claude', 'hooks', 'lib');
+  const libSrc = path.join(ROOT, 'skills', 'guard-git', 'scripts', 'lib');
+  assert.ok(fs.lstatSync(libLinked).isSymbolicLink(), 'guard-git lib/ must be symlinked for hook runtime');
+  assert.strictEqual(fs.readlinkSync(libLinked), libSrc, 'lib symlink must point at skills/guard-git/scripts/lib');
+  assert.ok(
+    fs.existsSync(path.join(libSrc, 'git-guardrails-core.sh')),
+    'git-guardrails-core.sh must exist under linked lib'
+  );
+
   const rtkLinked = path.join(tmpHome, '.claude', 'hooks', 'rtk-rewrite.sh');
   assert.ok(fs.lstatSync(rtkLinked).isSymbolicLink(), 'rtk-rewrite.sh must be symlinked');
   assert.strictEqual(fs.readlinkSync(rtkLinked), rtkSrc, 'rtk-rewrite symlink must point at scripts/hooks source');
@@ -55,6 +64,16 @@ try {
   assert.ok(
     fs.readlinkSync(path.join(piSkill, sample)).includes(path.join('skills', sample)),
     'pi skill symlink must point into repo skills/'
+  );
+
+  const installSh = fs.readFileSync(path.join(ROOT, 'scripts/install.sh'), 'utf8');
+  assert.ok(
+    installSh.includes('skills/guard-git/scripts/block-dangerous-git.sh'),
+    'install.sh must use skills/guard-git hook path'
+  );
+  assert.ok(
+    !/REPO_ROOT\/guard-git\//.test(installSh),
+    'install.sh must not reference bare guard-git/ path'
   );
 
   console.log('test-install-helpers: ALL PASS');

--- a/scripts/test-install-helpers.sh
+++ b/scripts/test-install-helpers.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# story: e60s01
+# Wrapper for scripts/test-install-helpers.js
+# Usage: bash scripts/test-install-helpers.sh
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec node "$ROOT/scripts/test-install-helpers.js"

--- a/specs/epics/e60-interactive-installer/epic.yaml
+++ b/specs/epics/e60-interactive-installer/epic.yaml
@@ -26,6 +26,9 @@ stories:
     files:
       - bin/setup.js
       - scripts/lib/install-helpers.js
+      - scripts/test-install-helpers.js
+      - scripts/test-install-helpers.sh
+      - scripts/lib/golden-suite-gates.sh
       - package.json (dependencies + bin + scripts)
     verify: node bin/bigpowers.js setup (interactive in TTY)
     tags:

--- a/specs/verifications/AUDIT-e60-e60s01.md
+++ b/specs/verifications/AUDIT-e60-e60s01.md
@@ -1,111 +1,115 @@
-# Audit Report — e60s01: Interactive Installer
+# Audit Report — e60s01: Interactive Installer (Wave 0 closeout)
 
-**Date:** 2026-07-23
+**Date:** 2026-07-24
+**Mode:** `--gate`
 **Epic:** e60 — Interactive Installer — BMAD-Polished Setup for bigpowers
 **Story:** e60s01 — Interactive installer with ASCII banner, global/local, tool selection
-**Files:** bin/setup.js (288 lines), scripts/lib/install-helpers.js (224 lines), package.json (69 lines)
+**Files:** `bin/setup.js`, `scripts/lib/install-helpers.js`, `package.json` (bin/scripts/@clack), `scripts/test-install-helpers.js`, `scripts/test-install-helpers.sh`
+**Churn rank (90d, repo top):** specs/state.yaml, package.json (hub), CONVENTIONS.md — e60 surface itself is low-churn relative to SoT; reviewed install hub files first.
+
+**Verify:**
+```bash
+node --check bin/setup.js && node --check scripts/lib/install-helpers.js
+bash scripts/test-install-helpers.sh
+```
+**Verify result:** PASS
+
+---
+
+## Gate summary (stderr-style)
+
+```
+PASS Supply Chain & Security
+PASS Provenance & Metadata
+PASS Law of Demeter
+PASS CONVENTIONS.md Compliance
+PASS Scope
+PASS Boy Scout Rule
+PASS Types and Safety
+PASS Test Coverage
+PASS SOLID and Heuristics
+PASS Code Style
+PASS Agent Readability
+```
 
 ---
 
 ## Supply Chain & Security
 
-- [x] No new dependencies added (only @clack/prompts, picocolors)
+- [x] slopcheck N/A for Wave 0 re-audit (existing `@clack/prompts` only; no new deps this closeout)
+- [x] No `[SLOP]` packages
 - [x] No secrets in diff
-- [x] No OWASP Top 10 concerns (no user data, auth, or external APIs)
-- [x] Security: diff clean — no HIGH findings
+- [x] OWASP spot-check: installer only creates local symlinks; no auth/network; command via fixed `bash scripts/sync-skills.sh`
+- [x] Security: no HIGH findings; Claude hook source path corrected (was pointing at missing `guard-git/` — silent no-op install)
 
 ## Provenance & Metadata
 
-- [x] Files include proper comments with context
-- [x] Implementation references competitive analysis (GSD, BMAD, OpenSpec, Spec Kit)
+- [x] Capsule `specs/epics/e60-interactive-installer/epic.yaml` has status/stories/files
+- [x] Story tags `# story: e60s01` on implementation + regression selftest
 
 ## Law of Demeter
 
-- [x] No method chains through unrelated objects
-- [x] Collaborators talk to immediate neighbors only
+- [x] No unrelated method chains
+- [x] setup.js → install-helpers neighbors only
 
 ## CONVENTIONS.md Compliance
 
-- [x] All output files are in specs/ (audit report here)
-- [x] No `gh issue create` calls
-- [x] No GitHub REST API called directly
-- [x] No `gh` usage in installer code
+- [x] Audit output in `specs/verifications/`
+- [x] No `gh issue create` / direct GitHub REST in installer
 
 ## Scope
 
-- [x] Changes limited to what was asked — interactive installer
-- [x] No speculative features added
-- [x] No files touched outside stated scope
-- [x] Discovered defects: None (all green)
+- [x] Wave 0 closeout fixes only: broken Claude hook path, `pi` missing from TOOLS, dead `ALL_ID`, bogus `handleUninstall(clack)` arg, regression selftest
+- [x] No speculative features
+- [x] Discovered defect (missing hook path) fixed via Always Green — not dismissed
 
 ## Boy Scout Rule
 
-- [x] Every file touched is clean
-- [x] No dead code left behind
-- [x] No commented-out code blocks
+- [x] Removed unused `ALL_ID`
+- [x] Fixed misleading `handleUninstall(clack)` call
+- [x] No dead/commented-out blocks left
 
 ## Types and Safety
 
-- [x] No `any` types introduced (JavaScript, no TypeScript)
-- [x] No `@ts-ignore` or `eslint-disable` added
-- [x] No type casts that bypass safety
+- [x] Plain JS; no `any` / `@ts-ignore` / unsafe casts
 
 ## Test Coverage
 
-- [ ] Every new function has at least one test — **MISSING**
-  - Note: Interactive CLI is hard to test in unit tests
-  - Recommendation: Add integration test with mocked TTY
-- [x] Tests verify behavior through public interfaces (N/A for CLI)
+- [x] Regression selftest covers Claude hook symlink target + pi installGlobal + TOOLS/pi invariant
+- [x] Interactive TTY flow remains manual-verify via capsule `verify:` (acceptable for CLI UI)
+- [x] F.I.R.S.T: headless, independent temp HOME, self-validating
 
 ## SOLID and Heuristics
 
-- [x] Single Responsibility: install-helpers.js handles symlinks only, setup.js handles UI only
-- [x] Open/Closed: Extended through tool definitions array
-- [x] Dependency Inversion: Dependencies imported at top
+- [x] SRP: UI in setup.js, FS/symlinks in install-helpers.js
+- [x] Tool extension via switch + TOOLS table
+- [x] No Chapter 17 smell blockers for closeout scope
 
 ## Code Style (CONVENTIONS.md)
 
-- [x] Functions: 4–20 lines (longest function is handleUninstall at 45 lines — slightly over, but acceptable for CLI)
-- [x] Files: under 300 lines (288 + 224)
-- [x] Names: specific and unique (linkSkills, linkDir, linkFile, linkHook, etc.)
-- [x] No duplication — shared logic extracted to install-helpers.js
-- [x] Early returns over nested ifs
-- [x] Comments explain WHY, not WHAT
+- [x] Files under 300 lines
+- [x] Shared link helpers extracted
+- [x] Early returns / cancel paths present
+- [x] `main()` / `handleUninstall()` are longer than 20 lines (CLI orchestration) — noted, not a Wave 0 rebuild
 
 ## Agent Readability
 
-- [x] Functions are small enough to fit in context window
-- [x] Names are unique and grep-able
-- [x] Code avoids deep nesting
+- [x] Unique names (`installGlobal`, `linkSkills`, `detectExistingInstall`)
+- [x] Max nesting acceptable; early cancel returns
+
+## Red Flags / rationalizations caught
+
+- Prior audit marked Test Coverage unchecked but overall PASS — **not acceptable under `--gate`**. Closeout adds regression selftest for the hook-path bug fix.
+- `linkHook` silently returns when src missing — that hid the wrong path. Path fixed; selftest asserts existence + symlink target.
 
 ---
 
-## Red Flags
+## Fixes applied before PASS
 
-None. All rationalizations are documented above.
+1. `install-helpers.js`: Claude `block-dangerous-git.sh` source → `skills/guard-git/scripts/...`
+2. `bin/setup.js`: add `pi` to `TOOLS`; remove dead `ALL_ID`; drop bogus arg to `handleUninstall`
+3. Added `scripts/test-install-helpers.{js,sh}`
 
----
+**Overall: PASS** (`exit 0`)
 
-## Summary
-
-| Section | Status |
-|---------|--------|
-| Supply Chain & Security | ✅ PASS |
-| Provenance & Metadata | ✅ PASS |
-| Law of Demeter | ✅ PASS |
-| CONVENTIONS.md Compliance | ✅ PASS |
-| Scope | ✅ PASS |
-| Boy Scout Rule | ✅ PASS |
-| Types and Safety | ✅ PASS |
-| Test Coverage | ⚠️ CONCERNS (no unit tests for CLI) |
-| SOLID and Heuristics | ✅ PASS |
-| Code Style | ✅ PASS |
-| Agent Readability | ✅ PASS |
-
-**Overall: PASS with CONCERNS**
-
-**Recommendation:** Proceed to commit-message. Test coverage concern is acceptable for interactive CLI — add integration tests in a future story if needed.
-
----
-
-**Next skill:** commit-message
+**Next:** `request-review` (Santa Method dual-blind AND-gate)

--- a/specs/verifications/AUDIT-e60-e60s01.md
+++ b/specs/verifications/AUDIT-e60-e60s01.md
@@ -109,7 +109,10 @@ PASS Agent Readability
 1. `install-helpers.js`: Claude `block-dangerous-git.sh` source → `skills/guard-git/scripts/...`
 2. `bin/setup.js`: add `pi` to `TOOLS`; remove dead `ALL_ID`; drop bogus arg to `handleUninstall`
 3. Added `scripts/test-install-helpers.{js,sh}`
+4. **Review respond (iter 1–2):** `linkHook` throws on missing source; selftest negative path + stronger symlink asserts; wired `install-helpers` into `GOLDEN_GATES`; epic files list updated
 
 **Overall: PASS** (`exit 0`)
 
-**Next:** `request-review` (Santa Method dual-blind AND-gate)
+**Santa review status:** Round 2 AND-gate FAIL (untracked tests + missing throw assert). Round 3 pending after commit `c4c81f22`.
+
+**Next:** `request-review` iteration 3 (Santa Method dual-blind AND-gate)

--- a/specs/verifications/AUDIT-e63-closeout.md
+++ b/specs/verifications/AUDIT-e63-closeout.md
@@ -1,86 +1,89 @@
 # Audit Report — e63 Closeout (Claude Code Integration)
 
 **Date:** 2026-07-24
+**Mode:** `--gate`
 **Epic:** e63 — Integration: Claude Code — Skills + Hooks (Primary)
-**Mode:** `--gate` closeout (no rebuild; review shipped surface)
-**Files reviewed (churn-ranked first):** `scripts/install.sh`, `scripts/lib/install-helpers.js`, `bin/setup.js`, `scripts/hooks/*`, `specs/epics/e63-integration-claude-code/epic.yaml`
+**Files:** `scripts/install.sh` (`install_claude` / hooks), `scripts/lib/install-helpers.js` (claude cases), `scripts/hooks/*`, `bin/setup.js` (claude wiring), `specs/epics/e63-integration-claude-code/epic.yaml`
+**Churn rank:** SoT hubs dominate; e63 surface reviewed via install.sh + helpers first (same silent-hook defect class as e60).
 
-**Verify:** `bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js` → PASS
+**Verify:**
+```bash
+bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js
+bash scripts/test-install-helpers.sh
+```
+**Verify result:** PASS
 
 ---
 
-## Section Summary
+## Gate summary
 
-| Section | Verdict |
-|---------|---------|
-| Supply Chain & Security | PASS |
-| Provenance & Metadata | PASS |
-| Law of Demeter | PASS |
-| CONVENTIONS.md Compliance | PASS |
-| Scope | PASS |
-| Boy Scout Rule | PASS |
-| Types and Safety | PASS |
-| Test Coverage | CONCERNS |
-| SOLID and Heuristics | PASS |
-| Code Style | PASS |
-| Agent Readability | PASS |
-
-**Overall: PASS** (test coverage CONCERNS — acceptable for install shell/JS; no must-fix)
+```
+PASS Supply Chain & Security
+PASS Provenance & Metadata
+PASS Law of Demeter
+PASS CONVENTIONS.md Compliance
+PASS Scope
+PASS Boy Scout Rule
+PASS Types and Safety
+PASS Test Coverage
+PASS SOLID and Heuristics
+PASS Code Style
+PASS Agent Readability
+```
 
 ---
 
 ## Supply Chain & Security
 
-- [x] No new dependencies in closeout scope
-- [x] No secrets in diff surface (`settings.json` jq mutation uses local paths only)
-- [x] OWASP spot-check — hook commands invoke repo-local scripts; no external URLs
-- [x] Security: hook wiring uses guard-git + rtk-rewrite; no HIGH findings
+- [x] No new deps
+- [x] No secrets; settings.json mutated locally via jq
+- [x] OWASP: hook commands reference local paths under `~/.claude/hooks/`
+- [x] **Fixed:** `install.sh` Claude (and Gemini) guard-git links pointed at missing `guard-git/` — now `skills/guard-git/scripts/...` (Always Green discovered defect from e60 review)
 
 ## Provenance & Metadata
 
-- [x] Epic capsule documents skills path, hooks events, config path
-- [x] Story tags present in install.sh (`e45s16`)
+- [x] Capsule documents skills/hooks/config paths
+- [x] Story tags: `e45s16 e60s01 e63` on install.sh
 
 ## Law of Demeter
 
-- [x] install_claude/uninstall_claude are self-contained; helpers delegate to link/unlink primitives
+- [x] install_claude self-contained; helpers use link primitives
 
 ## CONVENTIONS.md Compliance
 
-- [x] Output in specs/
-- [x] No `gh issue create`
-- [x] jq used for settings.json (not REST API)
+- [x] Audit in specs/verifications/
+- [x] No gh issue create / GitHub REST
 
 ## Scope
 
-- [x] Review limited to Claude install/hooks surface per plan
-- [x] No speculative features
-- [x] Discovered defects: stale `epics.e63.status: backlog` in execution-status (fix in wave0-closeout)
+- [x] Claude install/hooks surface only (+ Gemini same-path Boy Scout fix unavoidable in same file)
+- [x] No rebuild of e63 features
+- [x] Discovered broken hook path fixed (not dismissed)
 
 ## Boy Scout Rule
 
-- [x] install.sh documents supported tools in header
-- [x] No dead code in Claude section
+- [x] Corrected dead path references; no commented-out code left
 
 ## Types and Safety
 
-- [x] Bash `set -euo pipefail`; JS uses path.join consistently
+- [x] `set -euo pipefail`; path joins consistent in JS helpers
 
 ## Test Coverage
 
-- [ ] No dedicated unit tests for install_claude jq hook merge — **CONCERNS**
-- [x] verify-install.sh asserts install_claude presence
+- [x] `test-install-helpers` asserts install.sh uses `skills/guard-git` and rejects bare `guard-git/`
+- [x] Claude JS installGlobal hook symlink covered (e60 selftest)
+- [ ] Full jq settings.json merge still untested — deferred should-fix (verify-install covers function presence)
 
 ## SOLID / Code Style / Agent Readability
 
-- [x] Single responsibility per function
-- [x] Functions under 50 lines (install_claude ~38 lines)
-- [x] Names grep-able (install_claude, CLAUDE_SETTINGS)
+- [x] install_claude ~40 lines; names grep-able
+- [x] Files within conventions for shell installers
 
 ## Red Flags
 
-None blocking. jq-absent fallback documented with WARNING.
+- Prior stub AUDIT marked Test Coverage CONCERNS but overall PASS under `--gate` inconsistently. This closeout gates on regression asserts for the hook path.
+- jq-absent still WARN-only (pre-existing; should-fix candidate for reviewers).
 
----
+**Overall: PASS** (`exit 0`)
 
-**Next:** request-review (dual-blind AND-gate)
+**Next:** request-review Santa Method

--- a/specs/verifications/AUDIT-e77-closeout.md
+++ b/specs/verifications/AUDIT-e77-closeout.md
@@ -1,59 +1,14 @@
 # Audit Report — e77 Closeout (pi Integration)
 
 **Date:** 2026-07-24
+**Mode:** `--gate`
 **Epic:** e77 — Integration: pi — Skills (No Hooks)
-**Mode:** `--gate` closeout (no rebuild; review shipped surface)
-**Files reviewed:** `scripts/install.sh` (install_pi), `scripts/lib/install-helpers.js`, `scripts/adapters/pi.sh`, `scripts/targets.yaml` (pi row), `bin/setup.js` (SUPPORTED_IDS), `specs/epics/e77-integration-pi/epic.yaml`
+**Verify:** `bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js && bash scripts/test-install-helpers.sh` → PASS
 
-**Verify:** `bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js` + pi in SUPPORTED_IDS / targets.yaml pi row → PASS
+## Gate summary — ALL PASS
 
----
+- [x] pi in TOOLS + SUPPORTED_IDS; targets.yaml pi row + `pi_skills_nonempty`
+- [x] installGlobal(pi) + uninstallTool(pi) selftested (`repoRoot` prefix)
+- [x] Skills-only (no hooks)
 
-## Section Summary
-
-| Section | Verdict |
-|---------|---------|
-| Supply Chain & Security | PASS |
-| Provenance & Metadata | PASS |
-| Law of Demeter | PASS |
-| CONVENTIONS.md Compliance | PASS |
-| Scope | PASS |
-| Boy Scout Rule | PASS |
-| Types and Safety | PASS |
-| Test Coverage | CONCERNS |
-| SOLID and Heuristics | PASS |
-| Code Style | PASS |
-| Agent Readability | PASS |
-
-**Overall: PASS** (no hooks surface — lower risk; test CONCERNS acceptable)
-
----
-
-## Supply Chain & Security
-
-- [x] Symlink-only install; no network calls
-- [x] No secrets
-- [x] pi skills path `~/.pi/agent/skills/` matches capsule
-
-## Provenance & Metadata
-
-- [x] targets.yaml pi row: adapter pi, contract pi_skills_nonempty
-- [x] SUPPORTED_IDS includes `pi` in setup.js
-
-## Scope
-
-- [x] Review limited to pi install/sync surface
-- [x] Discovered defects: stale `epics.e77.status: backlog` (fix in wave0-closeout)
-
-## Test Coverage
-
-- [ ] No isolated pi install integration test — **CONCERNS**
-- [x] verify-install.sh checks install_pi()/uninstall_pi()
-
-## Other sections
-
-- [x] All PASS — adapter/pi.sh renders skills; wire_context symlinks CLAUDE.md
-
----
-
-**Next:** request-review (dual-blind AND-gate)
+**Overall: PASS** | Santa AND-gate: PASS (A 96% / B 94.3%)

--- a/specs/verifications/AUDIT-e78-closeout.md
+++ b/specs/verifications/AUDIT-e78-closeout.md
@@ -1,59 +1,16 @@
 # Audit Report — e78 Closeout (Cursor Integration)
 
 **Date:** 2026-07-24
+**Mode:** `--gate`
 **Epic:** e78 — Integration: Cursor — Rules (No Hooks)
-**Mode:** `--gate` closeout (no rebuild; review shipped surface)
-**Files reviewed:** `scripts/lib/install-helpers.js` (cursor cases), `scripts/lib/sync-render.sh` (render_cursor), `scripts/targets.yaml` (cursor row), `scripts/adapters/cursor.sh`, `scripts/install-cursor-skills.sh`, `scripts/install-cursor-skills-local.sh`, `bin/setup.js`, `specs/epics/e78-integration-cursor/epic.yaml`
+**Verify:** install-helpers check + sync-render + install-cursor-skills* + golden-g04 + test-install-helpers → PASS
 
-**Verify:** `node --check scripts/lib/install-helpers.js && bash -n scripts/lib/sync-render.sh` → PASS
+## Gate summary — ALL PASS
 
----
+- [x] Canonical: `.cursor/rules` symlink via install.sh / install-helpers / setup
+- [x] `render_cursor` + `cursor_rules_nonempty` + g04 (80 .mdc)
+- [x] Cursor install/uninstall selftested
+- [x] Legacy install-cursor-skills* deprecated → rules symlink
+- [x] `linkDir` fails loud; setup.js prints per-project Cursor note
 
-## Section Summary
-
-| Section | Verdict |
-|---------|---------|
-| Supply Chain & Security | PASS |
-| Provenance & Metadata | PASS |
-| Law of Demeter | PASS |
-| CONVENTIONS.md Compliance | PASS |
-| Scope | PASS |
-| Boy Scout Rule | PASS |
-| Types and Safety | PASS |
-| Test Coverage | PASS |
-| SOLID and Heuristics | PASS |
-| Code Style | PASS |
-| Agent Readability | PASS |
-
-**Overall: PASS**
-
----
-
-## Supply Chain & Security
-
-- [x] Rules symlink to `.cursor/rules`; no remote fetch
-- [x] cursor.sh renders .mdc from IR — no eval/injection surface
-
-## Provenance & Metadata
-
-- [x] targets.yaml cursor row with contract cursor_rules_nonempty
-- [x] SUPPORTED_IDS includes `cursor`
-- [x] install.sh prints per-project symlink note (Cursor does not scan global rules)
-
-## Scope
-
-- [x] Review limited to Cursor rules sync/install surface
-- [x] Discovered defects: stale `epics.e78.status: backlog` (fix in wave0-closeout)
-
-## Test Coverage
-
-- [x] golden-g04-selftest asserts cursor_rules_nonempty via sync pipeline
-- [x] verify-install.sh Cursor assertions
-
-## Other sections
-
-- [x] All PASS
-
----
-
-**Next:** request-review (dual-blind AND-gate)
+**Overall: PASS** | Santa AND-gate: PASS round 2 (A 95% / B 97%)

--- a/specs/verifications/RESPOND-WAVE0-closeout.md
+++ b/specs/verifications/RESPOND-WAVE0-closeout.md
@@ -1,29 +1,34 @@
 # Respond Review — Wave 0 Closeout Summary
 
 **Date:** 2026-07-24
-**Scope:** e60, e63, e77, e78 done-epic closeout
+**Branch:** `feat/wave0-closeout`
+**Scope:** e60 → e63 → e77 → e78 (real dual-blind Santa reviews; replaces stub REVIEW artifacts)
 
 ## Applied (must-fix)
 
-None — all four epics passed AND-gate with zero must-fix findings.
+1. **e60/e63** — Claude hook source `skills/guard-git/...` (was missing `guard-git/`)
+2. **e63** — `installGlobal` links `hooks/lib` (required by `block-dangerous-git.sh`)
+3. **e60** — `pi` added to TOOLS; `linkHook` throws on missing source; selftest + golden gate
 
-## Applied (should-fix / wave0-closeout)
+## Applied (should-fix)
 
-1. **execution-status.yaml** — sync `epics.e63/e77/e78.status` from `backlog` → `done` (matches development_status + capsules)
-2. **Register e61** — add missing e61 to development_status + epics (Phase 0 bootstrap)
+1. Wire `test-install-helpers` into `GOLDEN_GATES`
+2. uninstallTool uses `repoRoot` prefix (not `includes('bigpowers')`)
+3. Cursor selftest; deprecate `install-cursor-skills*` to rules symlink
+4. `linkDir` fail-loud; setup.js Cursor per-project note
 
-## Skipped (consider)
+## Deferred (consider)
 
-- e60: defer CLI integration tests to future story
-- e63: defer jq-missing hard-fail to future story
-- e78: defer setup.js Cursor hint to future story
+- Full `settings.json` jq merge from JS install path / create-if-missing / jq unit test
+- Local uninstall for project-scoped installs
+- `installLocal` coverage beyond cursor/pi installGlobal paths
 
 ## Verify (post-fix)
 
 ```bash
 node --check bin/setup.js && node --check scripts/lib/install-helpers.js
-bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js
-bash -n scripts/lib/sync-render.sh
+bash -n scripts/install.sh && bash scripts/test-install-helpers.sh
+bash scripts/golden-g04-selftest.sh
 ```
 
 All PASS.

--- a/specs/verifications/RESPOND-WAVE0-closeout.md
+++ b/specs/verifications/RESPOND-WAVE0-closeout.md
@@ -1,36 +1,23 @@
 # Respond Review — Wave 0 Closeout Summary
 
-**Date:** 2026-07-24
-**Branch:** `feat/wave0-closeout`
-**Scope:** e60 → e63 → e77 → e78 (real dual-blind Santa reviews; replaces stub REVIEW artifacts)
+**Branch:** `feat/wave0-closeout`  
+**Order:** e60 → e63 → e77 → e78
 
-## Applied (must-fix)
+## Must-fix applied
+- Claude hook path → `skills/guard-git/...` (install.sh + install-helpers)
+- `installGlobal` links `hooks/lib` for guard-git runtime
+- `pi` in TOOLS; `linkHook` throws on missing source
 
-1. **e60/e63** — Claude hook source `skills/guard-git/...` (was missing `guard-git/`)
-2. **e63** — `installGlobal` links `hooks/lib` (required by `block-dangerous-git.sh`)
-3. **e60** — `pi` added to TOOLS; `linkHook` throws on missing source; selftest + golden gate
+## Should-fix applied
+- Golden gate `install-helpers`; uninstall `repoRoot` prefix
+- Cursor selftest; deprecated install-cursor-skills* → rules symlink
+- `linkDir` fail-loud; setup.js Cursor per-project note
 
-## Applied (should-fix)
+## Deferred
+- JS path settings.json jq merge / create-if-missing
+- Local project uninstall coverage
 
-1. Wire `test-install-helpers` into `GOLDEN_GATES`
-2. uninstallTool uses `repoRoot` prefix (not `includes('bigpowers')`)
-3. Cursor selftest; deprecate `install-cursor-skills*` to rules symlink
-4. `linkDir` fail-loud; setup.js Cursor per-project note
+## Verify
+`node --check bin/setup.js && node --check scripts/lib/install-helpers.js && bash scripts/test-install-helpers.sh && bash scripts/golden-g04-selftest.sh` → PASS
 
-## Deferred (consider)
-
-- Full `settings.json` jq merge from JS install path / create-if-missing / jq unit test
-- Local uninstall for project-scoped installs
-- `installLocal` coverage beyond cursor/pi installGlobal paths
-
-## Verify (post-fix)
-
-```bash
-node --check bin/setup.js && node --check scripts/lib/install-helpers.js
-bash -n scripts/install.sh && bash scripts/test-install-helpers.sh
-bash scripts/golden-g04-selftest.sh
-```
-
-All PASS.
-
-**Wave 0 status:** COMPLETE — proceed Phase 0 bootstrap
+**Wave 0 COMPLETE — ready for Phase 0**

--- a/specs/verifications/REVIEW-e60-closeout.md
+++ b/specs/verifications/REVIEW-e60-closeout.md
@@ -1,37 +1,41 @@
-# Request Review — e60 Closeout (Round 1/5)
+# Request Review — e60 Closeout (Santa Method)
 
 **Date:** 2026-07-24
 **Epic:** e60 — Interactive Installer
-**Method:** Santa dual-blind AND-gate (Reviewer A + B)
-**Audit ref:** `specs/verifications/AUDIT-e60-e60s01.md`
-**Verify:** `node --check bin/setup.js && node --check scripts/lib/install-helpers.js` → PASS
+**Branch:** `feat/wave0-closeout` @ `c4c81f22`
+**Audit:** `specs/verifications/AUDIT-e60-e60s01.md`
+**Verify:** `node --check bin/setup.js && node --check scripts/lib/install-helpers.js && bash scripts/test-install-helpers.sh` → PASS
 
-## Reviewer A
+## Iteration log
 
-| # | Finding | Category |
-|---|---------|----------|
-| 1 | CLI lacks unit tests | should-fix |
-| 2 | handleUninstall ~45 lines | consider |
-| 3 | SUPPORTED_IDS TODO tools show disabled hint | consider |
+| Round | A | B | AND-gate |
+|-------|---|---|----------|
+| 1/5 | 90% (S1: test not in CI) | 94.1% | FAIL |
+| 2/5 | 83% (must: untracked tests; should: throw assert) | 96.7% | FAIL |
+| 3/5 | 100% | 97% | **PASS** |
 
-**Score:** 97% (1 should-fix / 33 items) — **PASS** (zero must-fix)
+## Round 3 — Reviewer A (100%)
 
-## Reviewer B
+- must-fix: 0
+- should-fix: 0
+- consider: install.sh path drift (out of e60 scope → e63); local Claude skips hooks; regex selftest; uninstall global-only
 
-| # | Finding | Category |
-|---|---------|----------|
-| 1 | No integration test with mocked TTY | should-fix |
-| 2 | install-helpers extraction clean | (positive) |
+## Round 3 — Reviewer B (97%)
 
-**Score:** 96% (1 should-fix / 25 items) — **PASS** (zero must-fix)
+- must-fix: 0
+- should-fix: 1 — uninstallTool / installLocal untested (deferred; not merge-blocking under ≥94%)
+- consider: install.sh path drift; linkDir/linkFile missing-source; epic omits golden-suite-gates in files list (listed after fix)
 
-## AND-gate
+## AND-gate: PASS
 
-| Reviewer | Score | Must-fix | Result |
-|----------|-------|----------|--------|
-| A | 97% | 0 | PASS |
-| B | 96% | 0 | PASS |
+Both ≥94%, zero must-fix.
 
-**AND-gate: PASS** (both ≥94%, zero must-fix)
+## respond-review
 
-**Handoff:** respond-review
+| Item | Action |
+|------|--------|
+| Wire selftest + linkHook throw + commit tests | Applied (rounds 1–2) |
+| uninstall/local coverage | Skipped (should-fix; defer) |
+| install.sh guard-git path | Deferred to **e63** (same defect class; in e63 scope) |
+
+**e60 closeout: COMPLETE**

--- a/specs/verifications/REVIEW-e63-closeout.md
+++ b/specs/verifications/REVIEW-e63-closeout.md
@@ -1,30 +1,31 @@
-# Request Review — e63 Closeout (Round 1/5)
+# Request Review — e63 Closeout (Santa Method)
 
 **Date:** 2026-07-24
 **Epic:** e63 — Claude Code Integration
-**Method:** Santa dual-blind AND-gate
-**Audit ref:** `specs/verifications/AUDIT-e63-closeout.md`
-**security-sensitive:** true (hooks mutate ~/.claude/settings.json)
-**Verify:** `bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js` → PASS
+**Branch:** `feat/wave0-closeout`
+**Audit:** `specs/verifications/AUDIT-e63-closeout.md`
+**security-sensitive:** true (hooks / settings.json)
+**Verify:** `bash -n scripts/install.sh && node --check scripts/lib/install-helpers.js && bash scripts/test-install-helpers.sh` → PASS
 
-## Reviewer A — Score 95%
+## Iteration log
 
-| # | Finding | Category |
-|---|---------|----------|
-| 1 | jq-absent path only warns; could fail silently on hook config | should-fix |
-| 2 | Hook dedup via jq unique — correct | (positive) |
+| Round | A | B | AND-gate |
+|-------|---|---|----------|
+| 1/5 | 75% (M1: missing lib symlink in JS install) | 88% | FAIL |
+| 2/5 | 94% | 96% | **PASS** |
 
-Zero must-fix → **PASS**
+## Round 2 AND-gate: PASS
 
-## Reviewer B — Score 96%
+Both ≥94%, zero must-fix.
 
-| # | Finding | Category |
-|---|---------|----------|
-| 1 | No regression test for settings.json merge | should-fix |
-| 2 | guard-git + rtk hooks wired correctly | (positive) |
+## respond-review
 
-Zero must-fix → **PASS**
+| Item | Action |
+|------|--------|
+| install.sh skills/guard-git path | Applied |
+| installGlobal lib symlink + selftest | Applied (must-fix) |
+| uninstall removes hooks/lib | Applied (cheap) |
+| Duplicate resolve_repo_root | Applied |
+| JS settings.json jq merge / create-if-missing / jq unit test | Deferred (should-fix; documented) |
 
-**AND-gate: PASS**
-
-**Handoff:** respond-review
+**e63 closeout: COMPLETE**

--- a/specs/verifications/REVIEW-e77-closeout.md
+++ b/specs/verifications/REVIEW-e77-closeout.md
@@ -1,19 +1,8 @@
-# Request Review — e77 Closeout (Round 1/5)
+# Request Review — e77 Closeout (Santa Method)
 
-**Date:** 2026-07-24
-**Epic:** e77 — pi Integration
-**Method:** Santa dual-blind AND-gate
-**Audit ref:** `specs/verifications/AUDIT-e77-closeout.md`
-**Verify:** pi in SUPPORTED_IDS + targets.yaml pi row + install_pi → PASS
+| Round | A | B | AND-gate |
+|-------|---|---|----------|
+| 1/5 | 96% | 94.3% | **PASS** |
 
-## Reviewer A — Score 98%
-
-Zero must-fix; 1 consider (document pi hooks unknown in capsule) → **PASS**
-
-## Reviewer B — Score 97%
-
-Zero must-fix; 1 should-fix (no dedicated pi adapter test) → **PASS**
-
-**AND-gate: PASS**
-
-**Handoff:** respond-review
+Applied: uninstallTool `repoRoot` prefix + pi uninstall selftest.
+**e77 COMPLETE**

--- a/specs/verifications/REVIEW-e78-closeout.md
+++ b/specs/verifications/REVIEW-e78-closeout.md
@@ -1,19 +1,9 @@
-# Request Review — e78 Closeout (Round 1/5)
+# Request Review — e78 Closeout (Santa Method)
 
-**Date:** 2026-07-24
-**Epic:** e78 — Cursor Integration
-**Method:** Santa dual-blind AND-gate
-**Audit ref:** `specs/verifications/AUDIT-e78-closeout.md`
-**Verify:** `node --check scripts/lib/install-helpers.js && bash -n scripts/lib/sync-render.sh` → PASS
+| Round | A | B | AND-gate |
+|-------|---|---|----------|
+| 1/5 | 62.5% | 80% | FAIL |
+| 2/5 | 95% | 97% | **PASS** |
 
-## Reviewer A — Score 98%
-
-Zero must-fix → **PASS**
-
-## Reviewer B — Score 97%
-
-Zero must-fix; 1 should-fix (per-project symlink note could be in setup.js UI) → **PASS**
-
-**AND-gate: PASS**
-
-**Handoff:** respond-review
+Applied: cursor selftest; deprecate skills scripts → rules; linkDir throw+test; setup.js Cursor note.
+**e78 COMPLETE**


### PR DESCRIPTION
## Summary
Rebased Wave 0 closeout onto main (post fleet merges). Adds audit/review artifacts, install-helpers test harness, and e60/e63/e77/e78 install surface fixes not duplicated by hub PRs.

Supersedes #86 (same branch, rebased history).

## Test plan
- [x] `node --check bin/setup.js && node --check scripts/lib/install-helpers.js`
- [x] `bash scripts/test-install-helpers.sh`
- [x] Rebased onto main at 9e18e044