### PR TITLE
fix(land-branch): fallback to PR when default branch push is protected

### DIFF
--- a/scripts/land-branch.sh
+++ b/scripts/land-branch.sh
@@ -5,6 +5,9 @@
 # Run from the primary repository root (not a linked worktree).
 set -euo pipefail
 
+# shellcheck source=lib/land-branch-push.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/land-branch-push.sh"
+
 CONVENTIONAL_REGEX='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+'
 
 usage_land() {
@@ -150,7 +153,9 @@ echo "==> Land commit: $LAND_SHA"
 
 if git remote get-url origin >/dev/null 2>&1; then
   echo "==> Pushing $DEFAULT_BRANCH to origin"
-  git push origin "$DEFAULT_BRANCH"
+  if ! land_push_default_branch "$DEFAULT_BRANCH" "$LAND_SHA" "$FEATURE_BRANCH" "$COMMIT_MSG"; then
+    land_branch_deny "git push origin $DEFAULT_BRANCH failed"
+  fi
 fi
 
 # Epic capsule archival (evolved bigpowers v4.0.0+)
@@ -198,11 +203,19 @@ fi
 git checkout "$DEFAULT_BRANCH"
 
 echo ""
-echo "Land complete."
-echo "  Branch:   $FEATURE_BRANCH (removed)"
-echo "  Commit:   $LAND_SHA on $DEFAULT_BRANCH"
-echo "  Message:  $COMMIT_MSG"
-echo "  cwd:      $(pwd)"
-echo "  current:  $(git branch --show-current)"
-echo ""
-echo "semantic-release will pick up the push to $DEFAULT_BRANCH when configured."
+if [ "${LAND_PR_FALLBACK:-0}" = "1" ]; then
+  echo "Land complete (protected-branch fallback — PR opened)."
+  echo "  Branch:   $FEATURE_BRANCH (local cleanup below)"
+  echo "  Recovery: $(land_recovery_branch_name "$FEATURE_BRANCH") @ $LAND_SHA"
+  echo "  Message:  $COMMIT_MSG"
+  echo "  Note:     local $DEFAULT_BRANCH reset to origin; merge via PR"
+else
+  echo "Land complete."
+  echo "  Branch:   $FEATURE_BRANCH (removed)"
+  echo "  Commit:   $LAND_SHA on $DEFAULT_BRANCH"
+  echo "  Message:  $COMMIT_MSG"
+  echo "  cwd:      $(pwd)"
+  echo "  current:  $(git branch --show-current)"
+  echo ""
+  echo "semantic-release will pick up the push to $DEFAULT_BRANCH when configured."
+fi

--- a/scripts/lib/land-branch-push.sh
+++ b/scripts/lib/land-branch-push.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# land-branch-push.sh — push + protected-branch fallback helpers for land-branch.sh
+# story: BUG-2026-07-25-land-branch-protected
+set -euo pipefail
+
+if [[ -n "${LAND_BRANCH_PUSH_LOADED:-}" ]]; then return 0; fi
+LAND_BRANCH_PUSH_LOADED=1
+
+LAND_PR_FALLBACK=0
+
+is_protected_branch_rejection() {
+  local output="$1"
+  echo "$output" | grep -qE '(^|[[:space:]])GH006|Changes must be made through a pull request'
+}
+
+land_recovery_branch_name() {
+  local feature_branch="$1"
+  echo "land-recovery/${feature_branch}"
+}
+
+land_print_recovery_commands() {
+  local recovery_branch="$1"
+  local land_sha="$2"
+  local default_branch="$3"
+  local commit_msg="$4"
+
+  {
+    echo "ERROR: Protected-branch fallback failed. Run these commands to recover manually:"
+    echo ""
+    echo "  git branch $recovery_branch $land_sha"
+    echo "  git checkout $default_branch"
+    echo "  git fetch origin $default_branch"
+    echo "  git reset --hard origin/$default_branch"
+    echo "  git push -u origin $recovery_branch"
+    echo "  gh pr create --base $default_branch --head $recovery_branch --title \"$commit_msg\""
+  } >&2
+}
+
+land_fallback_to_pr() {
+  local default_branch="$1"
+  local land_sha="$2"
+  local feature_branch="$3"
+  local commit_msg="$4"
+  local recovery_branch
+  recovery_branch="$(land_recovery_branch_name "$feature_branch")"
+  local full_sha
+  full_sha="$(git rev-parse "$land_sha")"
+
+  echo "==> Protected branch push rejected; falling back to PR workflow"
+  echo "    Recovery branch: $recovery_branch @ $land_sha"
+
+  if git show-ref --verify --quiet "refs/heads/$recovery_branch"; then
+    git branch -D "$recovery_branch"
+  fi
+  git branch "$recovery_branch" "$full_sha"
+
+  git fetch origin "$default_branch"
+  git reset --hard "origin/$default_branch"
+
+  if ! git push -u origin "$recovery_branch"; then
+    land_print_recovery_commands "$recovery_branch" "$full_sha" "$default_branch" "$commit_msg"
+    return 1
+  fi
+
+  local pr_body
+  pr_body="Automated recovery from \`land-branch.sh\` after protected-branch push rejection on \`$default_branch\`.
+
+Squash commit: \`$land_sha\`
+Source feature branch: \`$feature_branch\`"
+
+  if ! gh pr create \
+    --base "$default_branch" \
+    --head "$recovery_branch" \
+    --title "$commit_msg" \
+    --body "$pr_body"; then
+    land_print_recovery_commands "$recovery_branch" "$full_sha" "$default_branch" "$commit_msg"
+    return 1
+  fi
+
+  LAND_PR_FALLBACK=1
+  echo "==> PR created via protected-branch fallback (local $default_branch reset to origin)"
+  return 0
+}
+
+land_push_default_branch() {
+  local default_branch="$1"
+  local land_sha="$2"
+  local feature_branch="$3"
+  local commit_msg="$4"
+  local push_output=""
+  local push_status=0
+
+  if push_output=$(git push origin "$default_branch" 2>&1); then
+    return 0
+  fi
+  push_status=$?
+
+  if is_protected_branch_rejection "$push_output"; then
+    echo "$push_output" >&2
+    land_fallback_to_pr "$default_branch" "$land_sha" "$feature_branch" "$commit_msg"
+    return $?
+  fi
+
+  echo "$push_output" >&2
+  return "$push_status"
+}

--- a/specs/bugs/BUG-2026-07-25-land-branch-protected.md
+++ b/specs/bugs/BUG-2026-07-25-land-branch-protected.md
@@ -1,6 +1,6 @@
 ---
 bug_id: BUG-2026-07-25-land-branch-protected
-status: open
+status: fixed
 severity: high
 scope: scripts
 title: "solo-git land-branch.sh fails ungracefully against protected-branch repos, leaving a stranded local commit"
@@ -47,8 +47,8 @@ No pre-flight `gh api .../protection` check in v1 (out of scope).
 
 ## Acceptance Criteria
 
-- [ ] Protected-branch push rejection triggers Option A fallback automatically
-- [ ] Fallback failure prints exact recovery commands
-- [ ] `tests/test-land-branch-protected.sh` green with `# story:` tag
+- [x] Protected-branch push rejection triggers Option A fallback automatically
+- [x] Fallback failure prints exact recovery commands
+- [x] `tests/test-land-branch-protected.sh` green with `# story:` tag
 - [ ] Preflight green in fix worktree
 - [ ] Closes GH #92

--- a/specs/bugs/BUG-2026-07-25-land-branch-protected.md
+++ b/specs/bugs/BUG-2026-07-25-land-branch-protected.md
@@ -50,5 +50,5 @@ No pre-flight `gh api .../protection` check in v1 (out of scope).
 - [x] Protected-branch push rejection triggers Option A fallback automatically
 - [x] Fallback failure prints exact recovery commands
 - [x] `tests/test-land-branch-protected.sh` green with `# story:` tag
-- [ ] Preflight green in fix worktree
-- [ ] Closes GH #92
+- [x] Preflight green in fix worktree
+- [x] Closes GH #92 (PR #93)

--- a/specs/bugs/registry.yaml
+++ b/specs/bugs/registry.yaml
@@ -407,7 +407,7 @@ bugs:
     title: "bigpowers setup spinner freezes during sync-skills.sh instead of animating"
     file: bugs/BUG-2026-07-24-installer-spinner-freezes-during-sync.md
   - id: BUG-2026-07-25-land-branch-protected
-    status: open
+    status: fixed
     severity: high
     scope: scripts
     title: "solo-git land-branch.sh fails ungracefully against protected-branch repos, leaving a stranded local commit"

--- a/tests/test-land-branch-protected.sh
+++ b/tests/test-land-branch-protected.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# story: BUG-2026-07-25-land-branch-protected
+# Regression: land-branch protected-branch push rejection + PR fallback.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../scripts/lib/land-branch-push.sh
+source "$REPO_ROOT/scripts/lib/land-branch-push.sh"
+
+pass_count=0
+fail_count=0
+
+assert_true() {
+  local label="$1"
+  shift
+  if "$@"; then
+    echo "  PASS $label"
+    pass_count=$((pass_count + 1))
+  else
+    echo "  FAIL $label"
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+assert_false() {
+  local label="$1"
+  shift
+  if ! "$@"; then
+    echo "  PASS $label"
+    pass_count=$((pass_count + 1))
+  else
+    echo "  FAIL $label"
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1"
+  local haystack="$2"
+  local needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS $label"
+    pass_count=$((pass_count + 1))
+  else
+    echo "  FAIL $label (missing: $needle)"
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+echo "=== is_protected_branch_rejection fixtures ==="
+
+GH006_FIXTURE=$'remote: error: GH006: Protected branch update failed for refs/heads/main.\nremote: - Changes must be made through a pull request.\nerror: failed to push some refs'
+PR_ONLY_FIXTURE=$'remote: - Changes must be made through a pull request.\nerror: failed to push some refs'
+UNRELATED_FIXTURE=$'error: failed to push some refs\nremote: Permission denied'
+
+assert_true "detects GH006 rejection" is_protected_branch_rejection "$GH006_FIXTURE"
+assert_true "detects PR-required message without GH006 code" is_protected_branch_rejection "$PR_ONLY_FIXTURE"
+assert_false "ignores unrelated push failure" is_protected_branch_rejection "$UNRELATED_FIXTURE"
+
+echo "=== temp bare remote with rejecting pre-receive hook ==="
+
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+BARE="$TMPDIR_ROOT/remote.git"
+WORK="$TMPDIR_ROOT/work"
+MOCK_BIN="$TMPDIR_ROOT/bin"
+mkdir -p "$MOCK_BIN"
+
+git init --bare "$BARE" >/dev/null
+mkdir -p "$BARE/hooks"
+cat >"$BARE/hooks/pre-receive" <<'HOOK'
+#!/bin/sh
+while read -r oldrev newrev refname; do
+  case "$refname" in
+    refs/heads/main)
+      if [ "$oldrev" = "0000000000000000000000000000000000000000" ]; then
+        continue
+      fi
+      echo "remote: error: GH006: Protected branch update failed for refs/heads/main."
+      echo "remote: - Changes must be made through a pull request."
+      exit 1
+      ;;
+  esac
+done
+exit 0
+HOOK
+chmod +x "$BARE/hooks/pre-receive"
+
+git clone "$BARE" "$WORK" >/dev/null
+git -C "$WORK" config user.email "test@example.com"
+git -C "$WORK" config user.name "test"
+echo "base" >"$WORK/README.md"
+git -C "$WORK" add README.md
+git -C "$WORK" commit -qm "chore: init"
+git -C "$WORK" push origin main >/dev/null
+
+git -C "$WORK" checkout -b feat/test >/dev/null
+echo "feature" >>"$WORK/README.md"
+git -C "$WORK" add README.md
+git -C "$WORK" commit -qm "feat: add feature"
+git -C "$WORK" checkout main >/dev/null
+git -C "$WORK" merge --squash feat/test >/dev/null
+git -C "$WORK" commit -qm "feat(test): squash land"
+LAND_SHA="$(git -C "$WORK" rev-parse --short HEAD)"
+LAND_FULL_SHA="$(git -C "$WORK" rev-parse HEAD)"
+RECOVERY_BRANCH="land-recovery/feat/test"
+
+cat >"$MOCK_BIN/gh" <<'MOCK'
+#!/usr/bin/env bash
+echo "https://github.com/example/repo/pull/1"
+exit 0
+MOCK
+chmod +x "$MOCK_BIN/gh"
+
+cd "$WORK"
+export PATH="$MOCK_BIN:$PATH"
+LAND_PR_FALLBACK=0
+if ! land_push_default_branch main "$LAND_SHA" "feat/test" "feat(test): squash land"; then
+  echo "  FAIL land_push_default_branch should succeed via PR fallback"
+  fail_count=$((fail_count + 1))
+else
+  echo "  PASS land_push_default_branch succeeds on protected rejection"
+  pass_count=$((pass_count + 1))
+fi
+
+if [ "$LAND_PR_FALLBACK" = "1" ]; then
+  echo "  PASS LAND_PR_FALLBACK flag set"
+  pass_count=$((pass_count + 1))
+else
+  echo "  FAIL LAND_PR_FALLBACK flag not set"
+  fail_count=$((fail_count + 1))
+fi
+
+if git show-ref --verify --quiet "refs/heads/$RECOVERY_BRANCH"; then
+  echo "  PASS recovery branch exists locally"
+  pass_count=$((pass_count + 1))
+else
+  echo "  FAIL recovery branch missing locally"
+  fail_count=$((fail_count + 1))
+fi
+
+if git rev-parse main >/dev/null 2>&1 && [ "$(git rev-parse main)" != "$LAND_FULL_SHA" ]; then
+  echo "  PASS local main reset away from stranded squash commit"
+  pass_count=$((pass_count + 1))
+else
+  echo "  FAIL local main still points at squash commit"
+  fail_count=$((fail_count + 1))
+fi
+
+if git ls-remote --heads origin "$RECOVERY_BRANCH" | grep -q "$RECOVERY_BRANCH"; then
+  echo "  PASS recovery branch pushed to origin"
+  pass_count=$((pass_count + 1))
+else
+  echo "  FAIL recovery branch not on origin"
+  fail_count=$((fail_count + 1))
+fi
+cd "$REPO_ROOT"
+
+echo "=== gh failure prints recovery commands ==="
+
+BARE2="$TMPDIR_ROOT/remote2.git"
+WORK2="$TMPDIR_ROOT/work2"
+git init --bare "$BARE2" >/dev/null
+mkdir -p "$BARE2/hooks"
+cp "$BARE/hooks/pre-receive" "$BARE2/hooks/pre-receive"
+chmod +x "$BARE2/hooks/pre-receive"
+
+cat >"$MOCK_BIN/gh" <<'MOCK'
+#!/usr/bin/env bash
+echo "gh: authentication required" >&2
+exit 1
+MOCK
+chmod +x "$MOCK_BIN/gh"
+
+git clone "$BARE2" "$WORK2" >/dev/null
+git -C "$WORK2" config user.email "test@example.com"
+git -C "$WORK2" config user.name "test"
+echo "base" >"$WORK2/README.md"
+git -C "$WORK2" add README.md
+git -C "$WORK2" commit -qm "chore: init"
+git -C "$WORK2" push origin main >/dev/null
+git -C "$WORK2" checkout -b feat/broken >/dev/null
+echo "feature" >>"$WORK2/README.md"
+git -C "$WORK2" add README.md
+git -C "$WORK2" commit -qm "feat: broken land"
+git -C "$WORK2" checkout main >/dev/null
+git -C "$WORK2" merge --squash feat/broken >/dev/null
+git -C "$WORK2" commit -qm "feat(broken): squash land"
+BROKEN_SHA="$(git -C "$WORK2" rev-parse --short HEAD)"
+BROKEN_FULL_SHA="$(git -C "$WORK2" rev-parse HEAD)"
+BROKEN_RECOVERY="land-recovery/feat/broken"
+
+cd "$WORK2"
+export PATH="$MOCK_BIN:$PATH"
+set +e
+stderr_file="$(mktemp)"
+land_push_default_branch main "$BROKEN_SHA" "feat/broken" "feat(broken): squash land" 2>"$stderr_file"
+status=$?
+set -e
+stderr="$(cat "$stderr_file")"
+rm -f "$stderr_file"
+
+if [ "$status" -ne 0 ]; then
+  echo "  PASS land_push_default_branch exits non-zero when gh fails"
+  pass_count=$((pass_count + 1))
+else
+  echo "  FAIL expected non-zero exit when gh fails"
+  fail_count=$((fail_count + 1))
+fi
+
+assert_contains "recovery commands mention git branch" "$stderr" "git branch $BROKEN_RECOVERY $BROKEN_FULL_SHA"
+assert_contains "recovery commands mention gh pr create" "$stderr" "gh pr create --base main --head $BROKEN_RECOVERY"
+cd "$REPO_ROOT"
+
+echo ""
+echo "Results: $pass_count passed, $fail_count failed"
+if [ "$fail_count" -gt 0 ]; then
+  exit 1
+fi
+echo "All land-branch protected-branch tests passed."


### PR DESCRIPTION
## Summary

- Extract push helpers into `scripts/lib/land-branch-push.sh` (`is_protected_branch_rejection`, `land_push_default_branch`, `land_fallback_to_pr`).
- On GH006 / "Changes must be made through a pull request", `land-branch.sh` now creates a `land-recovery/<feature>` branch at the squash commit, resets local default to `origin`, pushes the recovery branch, and runs `gh pr create`.
- When `gh` fails, the script prints exact manual recovery commands and exits non-zero.
- Add `tests/test-land-branch-protected.sh` with detector fixtures and a temp bare remote using a rejecting `pre-receive` hook.

## Test plan

- [x] `bash tests/test-land-branch-protected.sh` — 11/11 passed
- [x] `npm run compliance && bash scripts/run-verification-gates.sh` — Golden 12/12 PASS

Closes #92

Made with [Cursor](https://cursor.com)