### PR TITLE
feat(skills): adopt Agentic STE controlled English (#91)

### DIFF
--- a/.codebuddy/skills/craft-skill/SKILL.md
+++ b/.codebuddy/skills/craft-skill/SKILL.md
@@ -6,7 +6,7 @@ description: "Create new bigpowers skills with proper structure, progressive dis
 
 # Craft Skill
 
-> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh` — the generated `.cursor/rules/` and `.gemini/` artifacts must match the source SKILL.md.
+> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh`. Generated `.cursor/rules/` and `.gemini/` artifacts MUST match the source SKILL.md.
 
 ## CSO Description Discipline (e45s02)
 
@@ -21,11 +21,25 @@ The YAML `description` is the **Catalog Selection Object** — the only field ag
 
 Move process detail into the SKILL.md body or REFERENCE.md — never into `description`.
 
+## Agentic STE body discipline (e79s02)
+
+Skill-body instructional prose MUST follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md).
+
+| Rule | Limit |
+|------|-------|
+| Sentence length | ≤20 words per instruction sentence |
+| Voice | Imperative, active |
+| Directive terms | MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT |
+| Banned modals | should, might, could, may, consider, try, generally, typically |
+| Scope | SKILL.md body only — not YAML `description`, not `terse-mode` output |
+
+> **HARD GATE** — Do NOT merge a new or edited skill until `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` exits 0. Fix violations before `sync-skills.sh`.
+
 ## Process
 
 1. **Gather requirements** — ask user about:
    - What task/domain does the skill cover?
-   - What specific use cases should it handle?
+   - Which use cases must the skill handle?
    - Does it need executable scripts or just instructions?
    - Any reference materials to include?
    - What specs/ output does it produce (if any)?
@@ -41,7 +55,8 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
    - Additional reference files if content exceeds 100 lines
    - Utility scripts if deterministic operations needed
 
-   **Auto-skill from library README:** When user provides a library README or API docs URL, extract: triggers, HARD GATEs, verify commands, specs/ output — draft SKILL.md without inventing APIs not in the source.
+   **Auto-skill from library README:** When user provides a library README or API docs URL, extract triggers and HARD GATEs.
+   Draft verify commands and specs/ output into SKILL.md. Do NOT invent APIs not in the source.
 
 4. Add `model:` frontmatter (`haiku` | `sonnet` | `opus`) per [model-profiles.md](https://github.com/danielvm-git/bigpowers/blob/main/docs/references/model-profiles.md).
 
@@ -50,10 +65,11 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
 5. **Review with user** — present draft and ask:
    - Does this cover your use cases?
    - Anything missing or unclear?
-   - Should any section be more/less detailed?
+   - Does any section need more or less detail?
 
 6. **Completion-honesty gate (HARD GATE — e45s02)** — Before declaring done:
    - Run `bash scripts/validate-skill-description.sh skills/<name>/SKILL.md` — must exit 0
+   - Run `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` — must exit 0 (e79s02)
    - Run `bash scripts/sync-skills.sh` — must complete without error
    - Run `bash scripts/run-skill-verify.sh <name>` if the skill defines a verify command
    - Show terminal output for each — narration without evidence is rejected
@@ -78,6 +94,7 @@ After drafting, verify:
 - [ ] Consistent terminology with CONVENTIONS.md
 - [ ] specs/ output documented if applicable
 - [ ] `validate-skill-description.sh` exits 0
+- [ ] `validate-agentic-ste.sh --strict` exits 0 (e79s02)
 - [ ] `sync-skills.sh` run to propagate to Cursor/Gemini
 - [ ] `bash scripts/validate-skill-catalog.sh` passes for the new skill (HARD GATE — completion honesty)
 

--- a/.codebuddy/skills/seed-conventions/SKILL.md
+++ b/.codebuddy/skills/seed-conventions/SKILL.md
@@ -9,6 +9,7 @@ description: "Generate CLAUDE.md and CONVENTIONS.md for a brand-new project thro
 # story: e10s02
 # story: e51s02
 # story: e45s21
+# story: e79s03
 
 
 # Seed Conventions
@@ -32,12 +33,24 @@ Ask the user these questions (one at a time, wait for each answer):
 2. **Stack** — "What language, framework, and runtime? (e.g. TypeScript / Next.js / Node 22)"
 2b. **Stack profile (optional)** — Offer: `swift`, `typescript-vue`, `node-service`, or none. If chosen, merge the matching fragment from `profiles/<name>.md` into generated `CONVENTIONS.md`.
 3. **Commands** — "What commands do you use for: run, test, build, lint?"
-3b. **Preflight (optional)** — "What single command runs your full local green stack (test + lint + build)? If you don't have one, we'll chain your Test + Lint + Build answers into a **Preflight** row in the Commands table."
+3b. **Preflight (optional)** — "What command runs test, lint, and build together? If none, chain Test + Lint + Build into one **Preflight** row."
 4. **Architecture** — "Key modules and relationships in 1–2 sentences."
 5. **Conventions** — "Any naming, file organization, or patterns all agents must follow?"
 6. **Never-do list** — "What are the hard stops? Things an agent must never touch?"
 7. **Defensive code categories** — "Which apply? (Rate limit / Retry / Circuit breaker / Timeout / Graceful degradation)"
 8. **Local tool wiring (optional)** — "Wire bigpowers for project-local tools? (Cursor, OpenCode, Cline, Aider, Codex CLI)" If yes, generate AGENTS.md spine artifacts per [REFERENCE.md](REFERENCE.md) §Local tool wiring and §AGENTS.md spine. If no, skip — standard seed output unchanged (no AGENTS.md spine unless opted in).
+
+## Agentic STE for generated prose (e79s03)
+
+When writing instructional lines in `CLAUDE.md`, `AGENTS.md`, or `CONVENTIONS.md`, follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md):
+
+- Use directive vocabulary: MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT
+- Do NOT use hedge modals listed in AGENTIC-STE.md Rule 3
+- Cap each instruction sentence at 20 words
+- Write imperative, active-voice lines — one instruction per line
+- Do NOT apply Agentic STE to `terse-mode` (output compression is out of scope)
+
+After generation, run `bash scripts/validate-agentic-ste.sh --strict CLAUDE.md CONVENTIONS.md` when those files exist in the target project.
 
 ## Generate files
 
@@ -65,9 +78,11 @@ echo "# Specs\n\nAll planning documents for this project." > specs/README.md
 
 **Note:** `specs/state.yaml.lock` is NOT pre-created — acquired/released dynamically.
 
-`specs/state.yaml` carries a top-level `workflow_mode` key (`team-pr` | `solo-git`, default `solo-git`). This is the **canonical integrate-mode signal** for all skills — set it once here and skills such as `release-branch` read it from this file instead of sniffing profile files.
+`specs/state.yaml` carries top-level `workflow_mode` (`team-pr` | `solo-git`, default `solo-git`).
+This is the **canonical integrate-mode signal** for all skills.
+Set it once here. Skills such as `release-branch` read this file instead of sniffing profiles.
 
-When generating `CLAUDE.md`, if the user did not name a Preflight command, chain the Test + Lint + Build interview answers into one **Preflight** row (e.g. `npm test && npm run lint && npm run build`).
+When generating `CLAUDE.md`, chain Test + Lint + Build into one **Preflight** row if the user named no Preflight command.
 
 ### Self-installing fenced markers (e45s21)
 
@@ -79,7 +94,9 @@ Skills that write into `CLAUDE.md` or `AGENTS.md` MUST use **fenced HTML comment
 <!-- END bigpowers:section-id -->
 ```
 
-**Merge rule:** On update, replace only the content *between* matching `BEGIN`/`END` pairs. If a marker pair is missing, append a new fenced block at the end of the file — never rewrite the whole file.
+**Merge rule:** On update, replace only content between matching `BEGIN`/`END` pairs.
+If a marker pair is missing, append a new fenced block at file end.
+Never rewrite the whole file.
 
 **Standard marker IDs** for seeded projects (see [REFERENCE.md](REFERENCE.md) § Fenced markers):
 

--- a/.codebuddy/skills/stocktake-skills/SKILL.md
+++ b/.codebuddy/skills/stocktake-skills/SKILL.md
@@ -6,6 +6,7 @@ description: "Sequential subagent batch audit of the bigpowers skill catalog —
 
 # story: e09s01
 <!-- story: e45s12 -->
+<!-- story: e79s04 -->
 
 
 # Stocktake Skills
@@ -25,6 +26,7 @@ Audit SKILL.md catalog for drift, stale triggers, missing HARD GATEs, and INDEX 
 ## Process
 
 0. **Catalog validator (code-enforced)** — run `bash scripts/validate-skill-catalog.sh`. Any FAIL is a critical finding before manual review. Add `--archive` to list zero-usage skills from `metrics.skill_timings` for auto-archiving candidates (move to `specs/epics/archive/` or delete after user confirms).
+0b. **Agentic STE audit (e79s04)** — run `bash scripts/validate-agentic-ste.sh --audit skills/`. Flag hedge words and sentences over 20 words per [AGENTIC-STE.md](../../docs/AGENTIC-STE.md). Record WARN lines in the stocktake report as **STE debt** — do NOT rewrite the full catalog in one pass. Route critical repeat offenders to `evolve-skill`.
 1. Run `bash scripts/audit-catalog.sh` to verify pi/skills ↔ source SKILL.md sync. Mismatch is a critical finding.
 2. Run mode; for each skill check: exists, verb-noun, &lt;300 lines total, HARD GATE present, INDEX row matches.
 3. Write `specs/STOCKTAKE-<date>.md` with findings table (skill, issue, severity).

--- a/.codex/skills/craft-skill/SKILL.md
+++ b/.codex/skills/craft-skill/SKILL.md
@@ -6,7 +6,7 @@ description: "Create new bigpowers skills with proper structure, progressive dis
 
 # Craft Skill
 
-> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh` — the generated `.cursor/rules/` and `.gemini/` artifacts must match the source SKILL.md.
+> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh`. Generated `.cursor/rules/` and `.gemini/` artifacts MUST match the source SKILL.md.
 
 ## CSO Description Discipline (e45s02)
 
@@ -21,11 +21,25 @@ The YAML `description` is the **Catalog Selection Object** — the only field ag
 
 Move process detail into the SKILL.md body or REFERENCE.md — never into `description`.
 
+## Agentic STE body discipline (e79s02)
+
+Skill-body instructional prose MUST follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md).
+
+| Rule | Limit |
+|------|-------|
+| Sentence length | ≤20 words per instruction sentence |
+| Voice | Imperative, active |
+| Directive terms | MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT |
+| Banned modals | should, might, could, may, consider, try, generally, typically |
+| Scope | SKILL.md body only — not YAML `description`, not `terse-mode` output |
+
+> **HARD GATE** — Do NOT merge a new or edited skill until `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` exits 0. Fix violations before `sync-skills.sh`.
+
 ## Process
 
 1. **Gather requirements** — ask user about:
    - What task/domain does the skill cover?
-   - What specific use cases should it handle?
+   - Which use cases must the skill handle?
    - Does it need executable scripts or just instructions?
    - Any reference materials to include?
    - What specs/ output does it produce (if any)?
@@ -41,7 +55,8 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
    - Additional reference files if content exceeds 100 lines
    - Utility scripts if deterministic operations needed
 
-   **Auto-skill from library README:** When user provides a library README or API docs URL, extract: triggers, HARD GATEs, verify commands, specs/ output — draft SKILL.md without inventing APIs not in the source.
+   **Auto-skill from library README:** When user provides a library README or API docs URL, extract triggers and HARD GATEs.
+   Draft verify commands and specs/ output into SKILL.md. Do NOT invent APIs not in the source.
 
 4. Add `model:` frontmatter (`haiku` | `sonnet` | `opus`) per [model-profiles.md](https://github.com/danielvm-git/bigpowers/blob/main/docs/references/model-profiles.md).
 
@@ -50,10 +65,11 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
 5. **Review with user** — present draft and ask:
    - Does this cover your use cases?
    - Anything missing or unclear?
-   - Should any section be more/less detailed?
+   - Does any section need more or less detail?
 
 6. **Completion-honesty gate (HARD GATE — e45s02)** — Before declaring done:
    - Run `bash scripts/validate-skill-description.sh skills/<name>/SKILL.md` — must exit 0
+   - Run `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` — must exit 0 (e79s02)
    - Run `bash scripts/sync-skills.sh` — must complete without error
    - Run `bash scripts/run-skill-verify.sh <name>` if the skill defines a verify command
    - Show terminal output for each — narration without evidence is rejected
@@ -78,6 +94,7 @@ After drafting, verify:
 - [ ] Consistent terminology with CONVENTIONS.md
 - [ ] specs/ output documented if applicable
 - [ ] `validate-skill-description.sh` exits 0
+- [ ] `validate-agentic-ste.sh --strict` exits 0 (e79s02)
 - [ ] `sync-skills.sh` run to propagate to Cursor/Gemini
 - [ ] `bash scripts/validate-skill-catalog.sh` passes for the new skill (HARD GATE — completion honesty)
 

--- a/.codex/skills/seed-conventions/SKILL.md
+++ b/.codex/skills/seed-conventions/SKILL.md
@@ -9,6 +9,7 @@ description: "Generate CLAUDE.md and CONVENTIONS.md for a brand-new project thro
 # story: e10s02
 # story: e51s02
 # story: e45s21
+# story: e79s03
 
 
 # Seed Conventions
@@ -32,12 +33,24 @@ Ask the user these questions (one at a time, wait for each answer):
 2. **Stack** — "What language, framework, and runtime? (e.g. TypeScript / Next.js / Node 22)"
 2b. **Stack profile (optional)** — Offer: `swift`, `typescript-vue`, `node-service`, or none. If chosen, merge the matching fragment from `profiles/<name>.md` into generated `CONVENTIONS.md`.
 3. **Commands** — "What commands do you use for: run, test, build, lint?"
-3b. **Preflight (optional)** — "What single command runs your full local green stack (test + lint + build)? If you don't have one, we'll chain your Test + Lint + Build answers into a **Preflight** row in the Commands table."
+3b. **Preflight (optional)** — "What command runs test, lint, and build together? If none, chain Test + Lint + Build into one **Preflight** row."
 4. **Architecture** — "Key modules and relationships in 1–2 sentences."
 5. **Conventions** — "Any naming, file organization, or patterns all agents must follow?"
 6. **Never-do list** — "What are the hard stops? Things an agent must never touch?"
 7. **Defensive code categories** — "Which apply? (Rate limit / Retry / Circuit breaker / Timeout / Graceful degradation)"
 8. **Local tool wiring (optional)** — "Wire bigpowers for project-local tools? (Cursor, OpenCode, Cline, Aider, Codex CLI)" If yes, generate AGENTS.md spine artifacts per [REFERENCE.md](REFERENCE.md) §Local tool wiring and §AGENTS.md spine. If no, skip — standard seed output unchanged (no AGENTS.md spine unless opted in).
+
+## Agentic STE for generated prose (e79s03)
+
+When writing instructional lines in `CLAUDE.md`, `AGENTS.md`, or `CONVENTIONS.md`, follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md):
+
+- Use directive vocabulary: MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT
+- Do NOT use hedge modals listed in AGENTIC-STE.md Rule 3
+- Cap each instruction sentence at 20 words
+- Write imperative, active-voice lines — one instruction per line
+- Do NOT apply Agentic STE to `terse-mode` (output compression is out of scope)
+
+After generation, run `bash scripts/validate-agentic-ste.sh --strict CLAUDE.md CONVENTIONS.md` when those files exist in the target project.
 
 ## Generate files
 
@@ -65,9 +78,11 @@ echo "# Specs\n\nAll planning documents for this project." > specs/README.md
 
 **Note:** `specs/state.yaml.lock` is NOT pre-created — acquired/released dynamically.
 
-`specs/state.yaml` carries a top-level `workflow_mode` key (`team-pr` | `solo-git`, default `solo-git`). This is the **canonical integrate-mode signal** for all skills — set it once here and skills such as `release-branch` read it from this file instead of sniffing profile files.
+`specs/state.yaml` carries top-level `workflow_mode` (`team-pr` | `solo-git`, default `solo-git`).
+This is the **canonical integrate-mode signal** for all skills.
+Set it once here. Skills such as `release-branch` read this file instead of sniffing profiles.
 
-When generating `CLAUDE.md`, if the user did not name a Preflight command, chain the Test + Lint + Build interview answers into one **Preflight** row (e.g. `npm test && npm run lint && npm run build`).
+When generating `CLAUDE.md`, chain Test + Lint + Build into one **Preflight** row if the user named no Preflight command.
 
 ### Self-installing fenced markers (e45s21)
 
@@ -79,7 +94,9 @@ Skills that write into `CLAUDE.md` or `AGENTS.md` MUST use **fenced HTML comment
 <!-- END bigpowers:section-id -->
 ```
 
-**Merge rule:** On update, replace only the content *between* matching `BEGIN`/`END` pairs. If a marker pair is missing, append a new fenced block at the end of the file — never rewrite the whole file.
+**Merge rule:** On update, replace only content between matching `BEGIN`/`END` pairs.
+If a marker pair is missing, append a new fenced block at file end.
+Never rewrite the whole file.
 
 **Standard marker IDs** for seeded projects (see [REFERENCE.md](REFERENCE.md) § Fenced markers):
 

--- a/.codex/skills/stocktake-skills/SKILL.md
+++ b/.codex/skills/stocktake-skills/SKILL.md
@@ -6,6 +6,7 @@ description: "Sequential subagent batch audit of the bigpowers skill catalog —
 
 # story: e09s01
 <!-- story: e45s12 -->
+<!-- story: e79s04 -->
 
 
 # Stocktake Skills
@@ -25,6 +26,7 @@ Audit SKILL.md catalog for drift, stale triggers, missing HARD GATEs, and INDEX 
 ## Process
 
 0. **Catalog validator (code-enforced)** — run `bash scripts/validate-skill-catalog.sh`. Any FAIL is a critical finding before manual review. Add `--archive` to list zero-usage skills from `metrics.skill_timings` for auto-archiving candidates (move to `specs/epics/archive/` or delete after user confirms).
+0b. **Agentic STE audit (e79s04)** — run `bash scripts/validate-agentic-ste.sh --audit skills/`. Flag hedge words and sentences over 20 words per [AGENTIC-STE.md](../../docs/AGENTIC-STE.md). Record WARN lines in the stocktake report as **STE debt** — do NOT rewrite the full catalog in one pass. Route critical repeat offenders to `evolve-skill`.
 1. Run `bash scripts/audit-catalog.sh` to verify pi/skills ↔ source SKILL.md sync. Mismatch is a critical finding.
 2. Run mode; for each skill check: exists, verb-noun, &lt;300 lines total, HARD GATE present, INDEX row matches.
 3. Write `specs/STOCKTAKE-<date>.md` with findings table (skill, issue, severity).

--- a/.cursor/rules/craft-skill.mdc
+++ b/.cursor/rules/craft-skill.mdc
@@ -5,7 +5,7 @@ alwaysApply: false
 
 # Craft Skill
 
-> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh` — the generated `.cursor/rules/` and `.gemini/` artifacts must match the source SKILL.md.
+> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh`. Generated `.cursor/rules/` and `.gemini/` artifacts MUST match the source SKILL.md.
 
 ## CSO Description Discipline (e45s02)
 
@@ -20,11 +20,25 @@ The YAML `description` is the **Catalog Selection Object** — the only field ag
 
 Move process detail into the SKILL.md body or REFERENCE.md — never into `description`.
 
+## Agentic STE body discipline (e79s02)
+
+Skill-body instructional prose MUST follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md).
+
+| Rule | Limit |
+|------|-------|
+| Sentence length | ≤20 words per instruction sentence |
+| Voice | Imperative, active |
+| Directive terms | MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT |
+| Banned modals | should, might, could, may, consider, try, generally, typically |
+| Scope | SKILL.md body only — not YAML `description`, not `terse-mode` output |
+
+> **HARD GATE** — Do NOT merge a new or edited skill until `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` exits 0. Fix violations before `sync-skills.sh`.
+
 ## Process
 
 1. **Gather requirements** — ask user about:
    - What task/domain does the skill cover?
-   - What specific use cases should it handle?
+   - Which use cases must the skill handle?
    - Does it need executable scripts or just instructions?
    - Any reference materials to include?
    - What specs/ output does it produce (if any)?
@@ -40,7 +54,8 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
    - Additional reference files if content exceeds 100 lines
    - Utility scripts if deterministic operations needed
 
-   **Auto-skill from library README:** When user provides a library README or API docs URL, extract: triggers, HARD GATEs, verify commands, specs/ output — draft SKILL.md without inventing APIs not in the source.
+   **Auto-skill from library README:** When user provides a library README or API docs URL, extract triggers and HARD GATEs.
+   Draft verify commands and specs/ output into SKILL.md. Do NOT invent APIs not in the source.
 
 4. Add `model:` frontmatter (`haiku` | `sonnet` | `opus`) per [model-profiles.md](https://github.com/danielvm-git/bigpowers/blob/main/docs/references/model-profiles.md).
 
@@ -49,10 +64,11 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
 5. **Review with user** — present draft and ask:
    - Does this cover your use cases?
    - Anything missing or unclear?
-   - Should any section be more/less detailed?
+   - Does any section need more or less detail?
 
 6. **Completion-honesty gate (HARD GATE — e45s02)** — Before declaring done:
    - Run `bash scripts/validate-skill-description.sh skills/<name>/SKILL.md` — must exit 0
+   - Run `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` — must exit 0 (e79s02)
    - Run `bash scripts/sync-skills.sh` — must complete without error
    - Run `bash scripts/run-skill-verify.sh <name>` if the skill defines a verify command
    - Show terminal output for each — narration without evidence is rejected
@@ -77,6 +93,7 @@ After drafting, verify:
 - [ ] Consistent terminology with CONVENTIONS.md
 - [ ] specs/ output documented if applicable
 - [ ] `validate-skill-description.sh` exits 0
+- [ ] `validate-agentic-ste.sh --strict` exits 0 (e79s02)
 - [ ] `sync-skills.sh` run to propagate to Cursor/Gemini
 - [ ] `bash scripts/validate-skill-catalog.sh` passes for the new skill (HARD GATE — completion honesty)
 

--- a/.cursor/rules/seed-conventions.mdc
+++ b/.cursor/rules/seed-conventions.mdc
@@ -8,6 +8,7 @@ alwaysApply: false
 # story: e10s02
 # story: e51s02
 # story: e45s21
+# story: e79s03
 
 
 # Seed Conventions
@@ -31,12 +32,24 @@ Ask the user these questions (one at a time, wait for each answer):
 2. **Stack** — "What language, framework, and runtime? (e.g. TypeScript / Next.js / Node 22)"
 2b. **Stack profile (optional)** — Offer: `swift`, `typescript-vue`, `node-service`, or none. If chosen, merge the matching fragment from `profiles/<name>.md` into generated `CONVENTIONS.md`.
 3. **Commands** — "What commands do you use for: run, test, build, lint?"
-3b. **Preflight (optional)** — "What single command runs your full local green stack (test + lint + build)? If you don't have one, we'll chain your Test + Lint + Build answers into a **Preflight** row in the Commands table."
+3b. **Preflight (optional)** — "What command runs test, lint, and build together? If none, chain Test + Lint + Build into one **Preflight** row."
 4. **Architecture** — "Key modules and relationships in 1–2 sentences."
 5. **Conventions** — "Any naming, file organization, or patterns all agents must follow?"
 6. **Never-do list** — "What are the hard stops? Things an agent must never touch?"
 7. **Defensive code categories** — "Which apply? (Rate limit / Retry / Circuit breaker / Timeout / Graceful degradation)"
 8. **Local tool wiring (optional)** — "Wire bigpowers for project-local tools? (Cursor, OpenCode, Cline, Aider, Codex CLI)" If yes, generate AGENTS.md spine artifacts per [REFERENCE.md](REFERENCE.md) §Local tool wiring and §AGENTS.md spine. If no, skip — standard seed output unchanged (no AGENTS.md spine unless opted in).
+
+## Agentic STE for generated prose (e79s03)
+
+When writing instructional lines in `CLAUDE.md`, `AGENTS.md`, or `CONVENTIONS.md`, follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md):
+
+- Use directive vocabulary: MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT
+- Do NOT use hedge modals listed in AGENTIC-STE.md Rule 3
+- Cap each instruction sentence at 20 words
+- Write imperative, active-voice lines — one instruction per line
+- Do NOT apply Agentic STE to `terse-mode` (output compression is out of scope)
+
+After generation, run `bash scripts/validate-agentic-ste.sh --strict CLAUDE.md CONVENTIONS.md` when those files exist in the target project.
 
 ## Generate files
 
@@ -64,9 +77,11 @@ echo "# Specs\n\nAll planning documents for this project." > specs/README.md
 
 **Note:** `specs/state.yaml.lock` is NOT pre-created — acquired/released dynamically.
 
-`specs/state.yaml` carries a top-level `workflow_mode` key (`team-pr` | `solo-git`, default `solo-git`). This is the **canonical integrate-mode signal** for all skills — set it once here and skills such as `release-branch` read it from this file instead of sniffing profile files.
+`specs/state.yaml` carries top-level `workflow_mode` (`team-pr` | `solo-git`, default `solo-git`).
+This is the **canonical integrate-mode signal** for all skills.
+Set it once here. Skills such as `release-branch` read this file instead of sniffing profiles.
 
-When generating `CLAUDE.md`, if the user did not name a Preflight command, chain the Test + Lint + Build interview answers into one **Preflight** row (e.g. `npm test && npm run lint && npm run build`).
+When generating `CLAUDE.md`, chain Test + Lint + Build into one **Preflight** row if the user named no Preflight command.
 
 ### Self-installing fenced markers (e45s21)
 
@@ -78,7 +93,9 @@ Skills that write into `CLAUDE.md` or `AGENTS.md` MUST use **fenced HTML comment
 <!-- END bigpowers:section-id -->
 ```
 
-**Merge rule:** On update, replace only the content *between* matching `BEGIN`/`END` pairs. If a marker pair is missing, append a new fenced block at the end of the file — never rewrite the whole file.
+**Merge rule:** On update, replace only content between matching `BEGIN`/`END` pairs.
+If a marker pair is missing, append a new fenced block at file end.
+Never rewrite the whole file.
 
 **Standard marker IDs** for seeded projects (see [REFERENCE.md](REFERENCE.md) § Fenced markers):
 

--- a/.cursor/rules/stocktake-skills.mdc
+++ b/.cursor/rules/stocktake-skills.mdc
@@ -5,6 +5,7 @@ alwaysApply: false
 
 # story: e09s01
 <!-- story: e45s12 -->
+<!-- story: e79s04 -->
 
 
 # Stocktake Skills
@@ -24,6 +25,7 @@ Audit SKILL.md catalog for drift, stale triggers, missing HARD GATEs, and INDEX 
 ## Process
 
 0. **Catalog validator (code-enforced)** — run `bash scripts/validate-skill-catalog.sh`. Any FAIL is a critical finding before manual review. Add `--archive` to list zero-usage skills from `metrics.skill_timings` for auto-archiving candidates (move to `specs/epics/archive/` or delete after user confirms).
+0b. **Agentic STE audit (e79s04)** — run `bash scripts/validate-agentic-ste.sh --audit skills/`. Flag hedge words and sentences over 20 words per [AGENTIC-STE.md](../../docs/AGENTIC-STE.md). Record WARN lines in the stocktake report as **STE debt** — do NOT rewrite the full catalog in one pass. Route critical repeat offenders to `evolve-skill`.
 1. Run `bash scripts/audit-catalog.sh` to verify pi/skills ↔ source SKILL.md sync. Mismatch is a critical finding.
 2. Run mode; for each skill check: exists, verb-noun, &lt;300 lines total, HARD GATE present, INDEX row matches.
 3. Write `specs/STOCKTAKE-<date>.md` with findings table (skill, issue, severity).

--- a/.gemini/extensions/bigpowers/commands/prompts/craft-skill.md
+++ b/.gemini/extensions/bigpowers/commands/prompts/craft-skill.md
@@ -5,7 +5,7 @@ description: "Create new bigpowers skills with proper structure, progressive dis
 
 # Craft Skill
 
-> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh` — the generated `.cursor/rules/` and `.gemini/` artifacts must match the source SKILL.md.
+> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh`. Generated `.cursor/rules/` and `.gemini/` artifacts MUST match the source SKILL.md.
 
 ## CSO Description Discipline (e45s02)
 
@@ -20,11 +20,25 @@ The YAML `description` is the **Catalog Selection Object** — the only field ag
 
 Move process detail into the SKILL.md body or REFERENCE.md — never into `description`.
 
+## Agentic STE body discipline (e79s02)
+
+Skill-body instructional prose MUST follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md).
+
+| Rule | Limit |
+|------|-------|
+| Sentence length | ≤20 words per instruction sentence |
+| Voice | Imperative, active |
+| Directive terms | MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT |
+| Banned modals | should, might, could, may, consider, try, generally, typically |
+| Scope | SKILL.md body only — not YAML `description`, not `terse-mode` output |
+
+> **HARD GATE** — Do NOT merge a new or edited skill until `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` exits 0. Fix violations before `sync-skills.sh`.
+
 ## Process
 
 1. **Gather requirements** — ask user about:
    - What task/domain does the skill cover?
-   - What specific use cases should it handle?
+   - Which use cases must the skill handle?
    - Does it need executable scripts or just instructions?
    - Any reference materials to include?
    - What specs/ output does it produce (if any)?
@@ -40,7 +54,8 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
    - Additional reference files if content exceeds 100 lines
    - Utility scripts if deterministic operations needed
 
-   **Auto-skill from library README:** When user provides a library README or API docs URL, extract: triggers, HARD GATEs, verify commands, specs/ output — draft SKILL.md without inventing APIs not in the source.
+   **Auto-skill from library README:** When user provides a library README or API docs URL, extract triggers and HARD GATEs.
+   Draft verify commands and specs/ output into SKILL.md. Do NOT invent APIs not in the source.
 
 4. Add `model:` frontmatter (`haiku` | `sonnet` | `opus`) per [model-profiles.md](https://github.com/danielvm-git/bigpowers/blob/main/docs/references/model-profiles.md).
 
@@ -49,10 +64,11 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
 5. **Review with user** — present draft and ask:
    - Does this cover your use cases?
    - Anything missing or unclear?
-   - Should any section be more/less detailed?
+   - Does any section need more or less detail?
 
 6. **Completion-honesty gate (HARD GATE — e45s02)** — Before declaring done:
    - Run `bash scripts/validate-skill-description.sh skills/<name>/SKILL.md` — must exit 0
+   - Run `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` — must exit 0 (e79s02)
    - Run `bash scripts/sync-skills.sh` — must complete without error
    - Run `bash scripts/run-skill-verify.sh <name>` if the skill defines a verify command
    - Show terminal output for each — narration without evidence is rejected
@@ -77,6 +93,7 @@ After drafting, verify:
 - [ ] Consistent terminology with CONVENTIONS.md
 - [ ] specs/ output documented if applicable
 - [ ] `validate-skill-description.sh` exits 0
+- [ ] `validate-agentic-ste.sh --strict` exits 0 (e79s02)
 - [ ] `sync-skills.sh` run to propagate to Cursor/Gemini
 - [ ] `bash scripts/validate-skill-catalog.sh` passes for the new skill (HARD GATE — completion honesty)
 

--- a/.gemini/extensions/bigpowers/commands/prompts/seed-conventions.md
+++ b/.gemini/extensions/bigpowers/commands/prompts/seed-conventions.md
@@ -8,6 +8,7 @@ description: "Generate CLAUDE.md and CONVENTIONS.md for a brand-new project thro
 # story: e10s02
 # story: e51s02
 # story: e45s21
+# story: e79s03
 
 
 # Seed Conventions
@@ -31,12 +32,24 @@ Ask the user these questions (one at a time, wait for each answer):
 2. **Stack** — "What language, framework, and runtime? (e.g. TypeScript / Next.js / Node 22)"
 2b. **Stack profile (optional)** — Offer: `swift`, `typescript-vue`, `node-service`, or none. If chosen, merge the matching fragment from `profiles/<name>.md` into generated `CONVENTIONS.md`.
 3. **Commands** — "What commands do you use for: run, test, build, lint?"
-3b. **Preflight (optional)** — "What single command runs your full local green stack (test + lint + build)? If you don't have one, we'll chain your Test + Lint + Build answers into a **Preflight** row in the Commands table."
+3b. **Preflight (optional)** — "What command runs test, lint, and build together? If none, chain Test + Lint + Build into one **Preflight** row."
 4. **Architecture** — "Key modules and relationships in 1–2 sentences."
 5. **Conventions** — "Any naming, file organization, or patterns all agents must follow?"
 6. **Never-do list** — "What are the hard stops? Things an agent must never touch?"
 7. **Defensive code categories** — "Which apply? (Rate limit / Retry / Circuit breaker / Timeout / Graceful degradation)"
 8. **Local tool wiring (optional)** — "Wire bigpowers for project-local tools? (Cursor, OpenCode, Cline, Aider, Codex CLI)" If yes, generate AGENTS.md spine artifacts per [REFERENCE.md](REFERENCE.md) §Local tool wiring and §AGENTS.md spine. If no, skip — standard seed output unchanged (no AGENTS.md spine unless opted in).
+
+## Agentic STE for generated prose (e79s03)
+
+When writing instructional lines in `CLAUDE.md`, `AGENTS.md`, or `CONVENTIONS.md`, follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md):
+
+- Use directive vocabulary: MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT
+- Do NOT use hedge modals listed in AGENTIC-STE.md Rule 3
+- Cap each instruction sentence at 20 words
+- Write imperative, active-voice lines — one instruction per line
+- Do NOT apply Agentic STE to `terse-mode` (output compression is out of scope)
+
+After generation, run `bash scripts/validate-agentic-ste.sh --strict CLAUDE.md CONVENTIONS.md` when those files exist in the target project.
 
 ## Generate files
 
@@ -64,9 +77,11 @@ echo "# Specs\n\nAll planning documents for this project." > specs/README.md
 
 **Note:** `specs/state.yaml.lock` is NOT pre-created — acquired/released dynamically.
 
-`specs/state.yaml` carries a top-level `workflow_mode` key (`team-pr` | `solo-git`, default `solo-git`). This is the **canonical integrate-mode signal** for all skills — set it once here and skills such as `release-branch` read it from this file instead of sniffing profile files.
+`specs/state.yaml` carries top-level `workflow_mode` (`team-pr` | `solo-git`, default `solo-git`).
+This is the **canonical integrate-mode signal** for all skills.
+Set it once here. Skills such as `release-branch` read this file instead of sniffing profiles.
 
-When generating `CLAUDE.md`, if the user did not name a Preflight command, chain the Test + Lint + Build interview answers into one **Preflight** row (e.g. `npm test && npm run lint && npm run build`).
+When generating `CLAUDE.md`, chain Test + Lint + Build into one **Preflight** row if the user named no Preflight command.
 
 ### Self-installing fenced markers (e45s21)
 
@@ -78,7 +93,9 @@ Skills that write into `CLAUDE.md` or `AGENTS.md` MUST use **fenced HTML comment
 <!-- END bigpowers:section-id -->
 ```
 
-**Merge rule:** On update, replace only the content *between* matching `BEGIN`/`END` pairs. If a marker pair is missing, append a new fenced block at the end of the file — never rewrite the whole file.
+**Merge rule:** On update, replace only content between matching `BEGIN`/`END` pairs.
+If a marker pair is missing, append a new fenced block at file end.
+Never rewrite the whole file.
 
 **Standard marker IDs** for seeded projects (see [REFERENCE.md](REFERENCE.md) § Fenced markers):
 

--- a/.gemini/extensions/bigpowers/commands/prompts/stocktake-skills.md
+++ b/.gemini/extensions/bigpowers/commands/prompts/stocktake-skills.md
@@ -5,6 +5,7 @@ description: "Sequential subagent batch audit of the bigpowers skill catalog —
 
 # story: e09s01
 <!-- story: e45s12 -->
+<!-- story: e79s04 -->
 
 
 # Stocktake Skills
@@ -24,6 +25,7 @@ Audit SKILL.md catalog for drift, stale triggers, missing HARD GATEs, and INDEX 
 ## Process
 
 0. **Catalog validator (code-enforced)** — run `bash scripts/validate-skill-catalog.sh`. Any FAIL is a critical finding before manual review. Add `--archive` to list zero-usage skills from `metrics.skill_timings` for auto-archiving candidates (move to `specs/epics/archive/` or delete after user confirms).
+0b. **Agentic STE audit (e79s04)** — run `bash scripts/validate-agentic-ste.sh --audit skills/`. Flag hedge words and sentences over 20 words per [AGENTIC-STE.md](../../docs/AGENTIC-STE.md). Record WARN lines in the stocktake report as **STE debt** — do NOT rewrite the full catalog in one pass. Route critical repeat offenders to `evolve-skill`.
 1. Run `bash scripts/audit-catalog.sh` to verify pi/skills ↔ source SKILL.md sync. Mismatch is a critical finding.
 2. Run mode; for each skill check: exists, verb-noun, &lt;300 lines total, HARD GATE present, INDEX row matches.
 3. Write `specs/STOCKTAKE-<date>.md` with findings table (skill, issue, severity).

--- a/.gemini/extensions/bigpowers/skills/craft-skill/SKILL.md
+++ b/.gemini/extensions/bigpowers/skills/craft-skill/SKILL.md
@@ -7,7 +7,7 @@ disable-model-invocation: true
 
 # Craft Skill
 
-> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh` — the generated `.cursor/rules/` and `.gemini/` artifacts must match the source SKILL.md.
+> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh`. Generated `.cursor/rules/` and `.gemini/` artifacts MUST match the source SKILL.md.
 
 ## CSO Description Discipline (e45s02)
 
@@ -22,11 +22,25 @@ The YAML `description` is the **Catalog Selection Object** — the only field ag
 
 Move process detail into the SKILL.md body or REFERENCE.md — never into `description`.
 
+## Agentic STE body discipline (e79s02)
+
+Skill-body instructional prose MUST follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md).
+
+| Rule | Limit |
+|------|-------|
+| Sentence length | ≤20 words per instruction sentence |
+| Voice | Imperative, active |
+| Directive terms | MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT |
+| Banned modals | should, might, could, may, consider, try, generally, typically |
+| Scope | SKILL.md body only — not YAML `description`, not `terse-mode` output |
+
+> **HARD GATE** — Do NOT merge a new or edited skill until `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` exits 0. Fix violations before `sync-skills.sh`.
+
 ## Process
 
 1. **Gather requirements** — ask user about:
    - What task/domain does the skill cover?
-   - What specific use cases should it handle?
+   - Which use cases must the skill handle?
    - Does it need executable scripts or just instructions?
    - Any reference materials to include?
    - What specs/ output does it produce (if any)?
@@ -42,7 +56,8 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
    - Additional reference files if content exceeds 100 lines
    - Utility scripts if deterministic operations needed
 
-   **Auto-skill from library README:** When user provides a library README or API docs URL, extract: triggers, HARD GATEs, verify commands, specs/ output — draft SKILL.md without inventing APIs not in the source.
+   **Auto-skill from library README:** When user provides a library README or API docs URL, extract triggers and HARD GATEs.
+   Draft verify commands and specs/ output into SKILL.md. Do NOT invent APIs not in the source.
 
 4. Add `model:` frontmatter (`haiku` | `sonnet` | `opus`) per [model-profiles.md](https://github.com/danielvm-git/bigpowers/blob/main/docs/references/model-profiles.md).
 
@@ -51,10 +66,11 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
 5. **Review with user** — present draft and ask:
    - Does this cover your use cases?
    - Anything missing or unclear?
-   - Should any section be more/less detailed?
+   - Does any section need more or less detail?
 
 6. **Completion-honesty gate (HARD GATE — e45s02)** — Before declaring done:
    - Run `bash scripts/validate-skill-description.sh skills/<name>/SKILL.md` — must exit 0
+   - Run `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` — must exit 0 (e79s02)
    - Run `bash scripts/sync-skills.sh` — must complete without error
    - Run `bash scripts/run-skill-verify.sh <name>` if the skill defines a verify command
    - Show terminal output for each — narration without evidence is rejected
@@ -79,6 +95,7 @@ After drafting, verify:
 - [ ] Consistent terminology with CONVENTIONS.md
 - [ ] specs/ output documented if applicable
 - [ ] `validate-skill-description.sh` exits 0
+- [ ] `validate-agentic-ste.sh --strict` exits 0 (e79s02)
 - [ ] `sync-skills.sh` run to propagate to Cursor/Gemini
 - [ ] `bash scripts/validate-skill-catalog.sh` passes for the new skill (HARD GATE — completion honesty)
 

--- a/.gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md
+++ b/.gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md
@@ -10,6 +10,7 @@ disable-model-invocation: true
 # story: e10s02
 # story: e51s02
 # story: e45s21
+# story: e79s03
 
 
 # Seed Conventions
@@ -33,12 +34,24 @@ Ask the user these questions (one at a time, wait for each answer):
 2. **Stack** — "What language, framework, and runtime? (e.g. TypeScript / Next.js / Node 22)"
 2b. **Stack profile (optional)** — Offer: `swift`, `typescript-vue`, `node-service`, or none. If chosen, merge the matching fragment from `profiles/<name>.md` into generated `CONVENTIONS.md`.
 3. **Commands** — "What commands do you use for: run, test, build, lint?"
-3b. **Preflight (optional)** — "What single command runs your full local green stack (test + lint + build)? If you don't have one, we'll chain your Test + Lint + Build answers into a **Preflight** row in the Commands table."
+3b. **Preflight (optional)** — "What command runs test, lint, and build together? If none, chain Test + Lint + Build into one **Preflight** row."
 4. **Architecture** — "Key modules and relationships in 1–2 sentences."
 5. **Conventions** — "Any naming, file organization, or patterns all agents must follow?"
 6. **Never-do list** — "What are the hard stops? Things an agent must never touch?"
 7. **Defensive code categories** — "Which apply? (Rate limit / Retry / Circuit breaker / Timeout / Graceful degradation)"
 8. **Local tool wiring (optional)** — "Wire bigpowers for project-local tools? (Cursor, OpenCode, Cline, Aider, Codex CLI)" If yes, generate AGENTS.md spine artifacts per [REFERENCE.md](REFERENCE.md) §Local tool wiring and §AGENTS.md spine. If no, skip — standard seed output unchanged (no AGENTS.md spine unless opted in).
+
+## Agentic STE for generated prose (e79s03)
+
+When writing instructional lines in `CLAUDE.md`, `AGENTS.md`, or `CONVENTIONS.md`, follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md):
+
+- Use directive vocabulary: MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT
+- Do NOT use hedge modals listed in AGENTIC-STE.md Rule 3
+- Cap each instruction sentence at 20 words
+- Write imperative, active-voice lines — one instruction per line
+- Do NOT apply Agentic STE to `terse-mode` (output compression is out of scope)
+
+After generation, run `bash scripts/validate-agentic-ste.sh --strict CLAUDE.md CONVENTIONS.md` when those files exist in the target project.
 
 ## Generate files
 
@@ -66,9 +79,11 @@ echo "# Specs\n\nAll planning documents for this project." > specs/README.md
 
 **Note:** `specs/state.yaml.lock` is NOT pre-created — acquired/released dynamically.
 
-`specs/state.yaml` carries a top-level `workflow_mode` key (`team-pr` | `solo-git`, default `solo-git`). This is the **canonical integrate-mode signal** for all skills — set it once here and skills such as `release-branch` read it from this file instead of sniffing profile files.
+`specs/state.yaml` carries top-level `workflow_mode` (`team-pr` | `solo-git`, default `solo-git`).
+This is the **canonical integrate-mode signal** for all skills.
+Set it once here. Skills such as `release-branch` read this file instead of sniffing profiles.
 
-When generating `CLAUDE.md`, if the user did not name a Preflight command, chain the Test + Lint + Build interview answers into one **Preflight** row (e.g. `npm test && npm run lint && npm run build`).
+When generating `CLAUDE.md`, chain Test + Lint + Build into one **Preflight** row if the user named no Preflight command.
 
 ### Self-installing fenced markers (e45s21)
 
@@ -80,7 +95,9 @@ Skills that write into `CLAUDE.md` or `AGENTS.md` MUST use **fenced HTML comment
 <!-- END bigpowers:section-id -->
 ```
 
-**Merge rule:** On update, replace only the content *between* matching `BEGIN`/`END` pairs. If a marker pair is missing, append a new fenced block at the end of the file — never rewrite the whole file.
+**Merge rule:** On update, replace only content between matching `BEGIN`/`END` pairs.
+If a marker pair is missing, append a new fenced block at file end.
+Never rewrite the whole file.
 
 **Standard marker IDs** for seeded projects (see [REFERENCE.md](REFERENCE.md) § Fenced markers):
 

--- a/.gemini/extensions/bigpowers/skills/stocktake-skills/SKILL.md
+++ b/.gemini/extensions/bigpowers/skills/stocktake-skills/SKILL.md
@@ -7,6 +7,7 @@ disable-model-invocation: true
 
 # story: e09s01
 <!-- story: e45s12 -->
+<!-- story: e79s04 -->
 
 
 # Stocktake Skills
@@ -26,6 +27,7 @@ Audit SKILL.md catalog for drift, stale triggers, missing HARD GATEs, and INDEX 
 ## Process
 
 0. **Catalog validator (code-enforced)** — run `bash scripts/validate-skill-catalog.sh`. Any FAIL is a critical finding before manual review. Add `--archive` to list zero-usage skills from `metrics.skill_timings` for auto-archiving candidates (move to `specs/epics/archive/` or delete after user confirms).
+0b. **Agentic STE audit (e79s04)** — run `bash scripts/validate-agentic-ste.sh --audit skills/`. Flag hedge words and sentences over 20 words per [AGENTIC-STE.md](../../docs/AGENTIC-STE.md). Record WARN lines in the stocktake report as **STE debt** — do NOT rewrite the full catalog in one pass. Route critical repeat offenders to `evolve-skill`.
 1. Run `bash scripts/audit-catalog.sh` to verify pi/skills ↔ source SKILL.md sync. Mismatch is a critical finding.
 2. Run mode; for each skill check: exists, verb-noun, &lt;300 lines total, HARD GATE present, INDEX row matches.
 3. Write `specs/STOCKTAKE-<date>.md` with findings table (skill, issue, severity).

--- a/.kilocode/rules/craft-skill.md
+++ b/.kilocode/rules/craft-skill.md
@@ -6,7 +6,7 @@ description: "Create new bigpowers skills with proper structure, progressive dis
 
 # Craft Skill
 
-> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh` — the generated `.cursor/rules/` and `.gemini/` artifacts must match the source SKILL.md.
+> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh`. Generated `.cursor/rules/` and `.gemini/` artifacts MUST match the source SKILL.md.
 
 ## CSO Description Discipline (e45s02)
 
@@ -21,11 +21,25 @@ The YAML `description` is the **Catalog Selection Object** — the only field ag
 
 Move process detail into the SKILL.md body or REFERENCE.md — never into `description`.
 
+## Agentic STE body discipline (e79s02)
+
+Skill-body instructional prose MUST follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md).
+
+| Rule | Limit |
+|------|-------|
+| Sentence length | ≤20 words per instruction sentence |
+| Voice | Imperative, active |
+| Directive terms | MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT |
+| Banned modals | should, might, could, may, consider, try, generally, typically |
+| Scope | SKILL.md body only — not YAML `description`, not `terse-mode` output |
+
+> **HARD GATE** — Do NOT merge a new or edited skill until `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` exits 0. Fix violations before `sync-skills.sh`.
+
 ## Process
 
 1. **Gather requirements** — ask user about:
    - What task/domain does the skill cover?
-   - What specific use cases should it handle?
+   - Which use cases must the skill handle?
    - Does it need executable scripts or just instructions?
    - Any reference materials to include?
    - What specs/ output does it produce (if any)?
@@ -41,7 +55,8 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
    - Additional reference files if content exceeds 100 lines
    - Utility scripts if deterministic operations needed
 
-   **Auto-skill from library README:** When user provides a library README or API docs URL, extract: triggers, HARD GATEs, verify commands, specs/ output — draft SKILL.md without inventing APIs not in the source.
+   **Auto-skill from library README:** When user provides a library README or API docs URL, extract triggers and HARD GATEs.
+   Draft verify commands and specs/ output into SKILL.md. Do NOT invent APIs not in the source.
 
 4. Add `model:` frontmatter (`haiku` | `sonnet` | `opus`) per [model-profiles.md](https://github.com/danielvm-git/bigpowers/blob/main/docs/references/model-profiles.md).
 
@@ -50,10 +65,11 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
 5. **Review with user** — present draft and ask:
    - Does this cover your use cases?
    - Anything missing or unclear?
-   - Should any section be more/less detailed?
+   - Does any section need more or less detail?
 
 6. **Completion-honesty gate (HARD GATE — e45s02)** — Before declaring done:
    - Run `bash scripts/validate-skill-description.sh skills/<name>/SKILL.md` — must exit 0
+   - Run `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` — must exit 0 (e79s02)
    - Run `bash scripts/sync-skills.sh` — must complete without error
    - Run `bash scripts/run-skill-verify.sh <name>` if the skill defines a verify command
    - Show terminal output for each — narration without evidence is rejected
@@ -78,6 +94,7 @@ After drafting, verify:
 - [ ] Consistent terminology with CONVENTIONS.md
 - [ ] specs/ output documented if applicable
 - [ ] `validate-skill-description.sh` exits 0
+- [ ] `validate-agentic-ste.sh --strict` exits 0 (e79s02)
 - [ ] `sync-skills.sh` run to propagate to Cursor/Gemini
 - [ ] `bash scripts/validate-skill-catalog.sh` passes for the new skill (HARD GATE — completion honesty)
 

--- a/.kilocode/rules/seed-conventions.md
+++ b/.kilocode/rules/seed-conventions.md
@@ -9,6 +9,7 @@ description: "Generate CLAUDE.md and CONVENTIONS.md for a brand-new project thro
 # story: e10s02
 # story: e51s02
 # story: e45s21
+# story: e79s03
 
 
 # Seed Conventions
@@ -32,12 +33,24 @@ Ask the user these questions (one at a time, wait for each answer):
 2. **Stack** — "What language, framework, and runtime? (e.g. TypeScript / Next.js / Node 22)"
 2b. **Stack profile (optional)** — Offer: `swift`, `typescript-vue`, `node-service`, or none. If chosen, merge the matching fragment from `profiles/<name>.md` into generated `CONVENTIONS.md`.
 3. **Commands** — "What commands do you use for: run, test, build, lint?"
-3b. **Preflight (optional)** — "What single command runs your full local green stack (test + lint + build)? If you don't have one, we'll chain your Test + Lint + Build answers into a **Preflight** row in the Commands table."
+3b. **Preflight (optional)** — "What command runs test, lint, and build together? If none, chain Test + Lint + Build into one **Preflight** row."
 4. **Architecture** — "Key modules and relationships in 1–2 sentences."
 5. **Conventions** — "Any naming, file organization, or patterns all agents must follow?"
 6. **Never-do list** — "What are the hard stops? Things an agent must never touch?"
 7. **Defensive code categories** — "Which apply? (Rate limit / Retry / Circuit breaker / Timeout / Graceful degradation)"
 8. **Local tool wiring (optional)** — "Wire bigpowers for project-local tools? (Cursor, OpenCode, Cline, Aider, Codex CLI)" If yes, generate AGENTS.md spine artifacts per [REFERENCE.md](REFERENCE.md) §Local tool wiring and §AGENTS.md spine. If no, skip — standard seed output unchanged (no AGENTS.md spine unless opted in).
+
+## Agentic STE for generated prose (e79s03)
+
+When writing instructional lines in `CLAUDE.md`, `AGENTS.md`, or `CONVENTIONS.md`, follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md):
+
+- Use directive vocabulary: MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT
+- Do NOT use hedge modals listed in AGENTIC-STE.md Rule 3
+- Cap each instruction sentence at 20 words
+- Write imperative, active-voice lines — one instruction per line
+- Do NOT apply Agentic STE to `terse-mode` (output compression is out of scope)
+
+After generation, run `bash scripts/validate-agentic-ste.sh --strict CLAUDE.md CONVENTIONS.md` when those files exist in the target project.
 
 ## Generate files
 
@@ -65,9 +78,11 @@ echo "# Specs\n\nAll planning documents for this project." > specs/README.md
 
 **Note:** `specs/state.yaml.lock` is NOT pre-created — acquired/released dynamically.
 
-`specs/state.yaml` carries a top-level `workflow_mode` key (`team-pr` | `solo-git`, default `solo-git`). This is the **canonical integrate-mode signal** for all skills — set it once here and skills such as `release-branch` read it from this file instead of sniffing profile files.
+`specs/state.yaml` carries top-level `workflow_mode` (`team-pr` | `solo-git`, default `solo-git`).
+This is the **canonical integrate-mode signal** for all skills.
+Set it once here. Skills such as `release-branch` read this file instead of sniffing profiles.
 
-When generating `CLAUDE.md`, if the user did not name a Preflight command, chain the Test + Lint + Build interview answers into one **Preflight** row (e.g. `npm test && npm run lint && npm run build`).
+When generating `CLAUDE.md`, chain Test + Lint + Build into one **Preflight** row if the user named no Preflight command.
 
 ### Self-installing fenced markers (e45s21)
 
@@ -79,7 +94,9 @@ Skills that write into `CLAUDE.md` or `AGENTS.md` MUST use **fenced HTML comment
 <!-- END bigpowers:section-id -->
 ```
 
-**Merge rule:** On update, replace only the content *between* matching `BEGIN`/`END` pairs. If a marker pair is missing, append a new fenced block at the end of the file — never rewrite the whole file.
+**Merge rule:** On update, replace only content between matching `BEGIN`/`END` pairs.
+If a marker pair is missing, append a new fenced block at file end.
+Never rewrite the whole file.
 
 **Standard marker IDs** for seeded projects (see [REFERENCE.md](REFERENCE.md) § Fenced markers):
 

--- a/.kilocode/rules/stocktake-skills.md
+++ b/.kilocode/rules/stocktake-skills.md
@@ -6,6 +6,7 @@ description: "Sequential subagent batch audit of the bigpowers skill catalog —
 
 # story: e09s01
 <!-- story: e45s12 -->
+<!-- story: e79s04 -->
 
 
 # Stocktake Skills
@@ -25,6 +26,7 @@ Audit SKILL.md catalog for drift, stale triggers, missing HARD GATEs, and INDEX 
 ## Process
 
 0. **Catalog validator (code-enforced)** — run `bash scripts/validate-skill-catalog.sh`. Any FAIL is a critical finding before manual review. Add `--archive` to list zero-usage skills from `metrics.skill_timings` for auto-archiving candidates (move to `specs/epics/archive/` or delete after user confirms).
+0b. **Agentic STE audit (e79s04)** — run `bash scripts/validate-agentic-ste.sh --audit skills/`. Flag hedge words and sentences over 20 words per [AGENTIC-STE.md](../../docs/AGENTIC-STE.md). Record WARN lines in the stocktake report as **STE debt** — do NOT rewrite the full catalog in one pass. Route critical repeat offenders to `evolve-skill`.
 1. Run `bash scripts/audit-catalog.sh` to verify pi/skills ↔ source SKILL.md sync. Mismatch is a critical finding.
 2. Run mode; for each skill check: exists, verb-noun, &lt;300 lines total, HARD GATE present, INDEX row matches.
 3. Write `specs/STOCKTAKE-<date>.md` with findings table (skill, issue, severity).

--- a/.pi/prompts/craft-skill.md
+++ b/.pi/prompts/craft-skill.md
@@ -5,7 +5,7 @@ description: "Create new bigpowers skills with proper structure, progressive dis
 
 # Craft Skill
 
-> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh` — the generated `.cursor/rules/` and `.gemini/` artifacts must match the source SKILL.md.
+> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh`. Generated `.cursor/rules/` and `.gemini/` artifacts MUST match the source SKILL.md.
 
 ## CSO Description Discipline (e45s02)
 
@@ -20,11 +20,25 @@ The YAML `description` is the **Catalog Selection Object** — the only field ag
 
 Move process detail into the SKILL.md body or REFERENCE.md — never into `description`.
 
+## Agentic STE body discipline (e79s02)
+
+Skill-body instructional prose MUST follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md).
+
+| Rule | Limit |
+|------|-------|
+| Sentence length | ≤20 words per instruction sentence |
+| Voice | Imperative, active |
+| Directive terms | MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT |
+| Banned modals | should, might, could, may, consider, try, generally, typically |
+| Scope | SKILL.md body only — not YAML `description`, not `terse-mode` output |
+
+> **HARD GATE** — Do NOT merge a new or edited skill until `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` exits 0. Fix violations before `sync-skills.sh`.
+
 ## Process
 
 1. **Gather requirements** — ask user about:
    - What task/domain does the skill cover?
-   - What specific use cases should it handle?
+   - Which use cases must the skill handle?
    - Does it need executable scripts or just instructions?
    - Any reference materials to include?
    - What specs/ output does it produce (if any)?
@@ -40,7 +54,8 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
    - Additional reference files if content exceeds 100 lines
    - Utility scripts if deterministic operations needed
 
-   **Auto-skill from library README:** When user provides a library README or API docs URL, extract: triggers, HARD GATEs, verify commands, specs/ output — draft SKILL.md without inventing APIs not in the source.
+   **Auto-skill from library README:** When user provides a library README or API docs URL, extract triggers and HARD GATEs.
+   Draft verify commands and specs/ output into SKILL.md. Do NOT invent APIs not in the source.
 
 4. Add `model:` frontmatter (`haiku` | `sonnet` | `opus`) per [model-profiles.md](https://github.com/danielvm-git/bigpowers/blob/main/docs/references/model-profiles.md).
 
@@ -49,10 +64,11 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
 5. **Review with user** — present draft and ask:
    - Does this cover your use cases?
    - Anything missing or unclear?
-   - Should any section be more/less detailed?
+   - Does any section need more or less detail?
 
 6. **Completion-honesty gate (HARD GATE — e45s02)** — Before declaring done:
    - Run `bash scripts/validate-skill-description.sh skills/<name>/SKILL.md` — must exit 0
+   - Run `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` — must exit 0 (e79s02)
    - Run `bash scripts/sync-skills.sh` — must complete without error
    - Run `bash scripts/run-skill-verify.sh <name>` if the skill defines a verify command
    - Show terminal output for each — narration without evidence is rejected
@@ -77,6 +93,7 @@ After drafting, verify:
 - [ ] Consistent terminology with CONVENTIONS.md
 - [ ] specs/ output documented if applicable
 - [ ] `validate-skill-description.sh` exits 0
+- [ ] `validate-agentic-ste.sh --strict` exits 0 (e79s02)
 - [ ] `sync-skills.sh` run to propagate to Cursor/Gemini
 - [ ] `bash scripts/validate-skill-catalog.sh` passes for the new skill (HARD GATE — completion honesty)
 

--- a/.pi/prompts/seed-conventions.md
+++ b/.pi/prompts/seed-conventions.md
@@ -8,6 +8,7 @@ description: "Generate CLAUDE.md and CONVENTIONS.md for a brand-new project thro
 # story: e10s02
 # story: e51s02
 # story: e45s21
+# story: e79s03
 
 
 # Seed Conventions
@@ -31,12 +32,24 @@ Ask the user these questions (one at a time, wait for each answer):
 2. **Stack** — "What language, framework, and runtime? (e.g. TypeScript / Next.js / Node 22)"
 2b. **Stack profile (optional)** — Offer: `swift`, `typescript-vue`, `node-service`, or none. If chosen, merge the matching fragment from `profiles/<name>.md` into generated `CONVENTIONS.md`.
 3. **Commands** — "What commands do you use for: run, test, build, lint?"
-3b. **Preflight (optional)** — "What single command runs your full local green stack (test + lint + build)? If you don't have one, we'll chain your Test + Lint + Build answers into a **Preflight** row in the Commands table."
+3b. **Preflight (optional)** — "What command runs test, lint, and build together? If none, chain Test + Lint + Build into one **Preflight** row."
 4. **Architecture** — "Key modules and relationships in 1–2 sentences."
 5. **Conventions** — "Any naming, file organization, or patterns all agents must follow?"
 6. **Never-do list** — "What are the hard stops? Things an agent must never touch?"
 7. **Defensive code categories** — "Which apply? (Rate limit / Retry / Circuit breaker / Timeout / Graceful degradation)"
 8. **Local tool wiring (optional)** — "Wire bigpowers for project-local tools? (Cursor, OpenCode, Cline, Aider, Codex CLI)" If yes, generate AGENTS.md spine artifacts per [REFERENCE.md](REFERENCE.md) §Local tool wiring and §AGENTS.md spine. If no, skip — standard seed output unchanged (no AGENTS.md spine unless opted in).
+
+## Agentic STE for generated prose (e79s03)
+
+When writing instructional lines in `CLAUDE.md`, `AGENTS.md`, or `CONVENTIONS.md`, follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md):
+
+- Use directive vocabulary: MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT
+- Do NOT use hedge modals listed in AGENTIC-STE.md Rule 3
+- Cap each instruction sentence at 20 words
+- Write imperative, active-voice lines — one instruction per line
+- Do NOT apply Agentic STE to `terse-mode` (output compression is out of scope)
+
+After generation, run `bash scripts/validate-agentic-ste.sh --strict CLAUDE.md CONVENTIONS.md` when those files exist in the target project.
 
 ## Generate files
 
@@ -64,9 +77,11 @@ echo "# Specs\n\nAll planning documents for this project." > specs/README.md
 
 **Note:** `specs/state.yaml.lock` is NOT pre-created — acquired/released dynamically.
 
-`specs/state.yaml` carries a top-level `workflow_mode` key (`team-pr` | `solo-git`, default `solo-git`). This is the **canonical integrate-mode signal** for all skills — set it once here and skills such as `release-branch` read it from this file instead of sniffing profile files.
+`specs/state.yaml` carries top-level `workflow_mode` (`team-pr` | `solo-git`, default `solo-git`).
+This is the **canonical integrate-mode signal** for all skills.
+Set it once here. Skills such as `release-branch` read this file instead of sniffing profiles.
 
-When generating `CLAUDE.md`, if the user did not name a Preflight command, chain the Test + Lint + Build interview answers into one **Preflight** row (e.g. `npm test && npm run lint && npm run build`).
+When generating `CLAUDE.md`, chain Test + Lint + Build into one **Preflight** row if the user named no Preflight command.
 
 ### Self-installing fenced markers (e45s21)
 
@@ -78,7 +93,9 @@ Skills that write into `CLAUDE.md` or `AGENTS.md` MUST use **fenced HTML comment
 <!-- END bigpowers:section-id -->
 ```
 
-**Merge rule:** On update, replace only the content *between* matching `BEGIN`/`END` pairs. If a marker pair is missing, append a new fenced block at the end of the file — never rewrite the whole file.
+**Merge rule:** On update, replace only content between matching `BEGIN`/`END` pairs.
+If a marker pair is missing, append a new fenced block at file end.
+Never rewrite the whole file.
 
 **Standard marker IDs** for seeded projects (see [REFERENCE.md](REFERENCE.md) § Fenced markers):
 

--- a/.pi/prompts/stocktake-skills.md
+++ b/.pi/prompts/stocktake-skills.md
@@ -5,6 +5,7 @@ description: "Sequential subagent batch audit of the bigpowers skill catalog —
 
 # story: e09s01
 <!-- story: e45s12 -->
+<!-- story: e79s04 -->
 
 
 # Stocktake Skills
@@ -24,6 +25,7 @@ Audit SKILL.md catalog for drift, stale triggers, missing HARD GATEs, and INDEX 
 ## Process
 
 0. **Catalog validator (code-enforced)** — run `bash scripts/validate-skill-catalog.sh`. Any FAIL is a critical finding before manual review. Add `--archive` to list zero-usage skills from `metrics.skill_timings` for auto-archiving candidates (move to `specs/epics/archive/` or delete after user confirms).
+0b. **Agentic STE audit (e79s04)** — run `bash scripts/validate-agentic-ste.sh --audit skills/`. Flag hedge words and sentences over 20 words per [AGENTIC-STE.md](../../docs/AGENTIC-STE.md). Record WARN lines in the stocktake report as **STE debt** — do NOT rewrite the full catalog in one pass. Route critical repeat offenders to `evolve-skill`.
 1. Run `bash scripts/audit-catalog.sh` to verify pi/skills ↔ source SKILL.md sync. Mismatch is a critical finding.
 2. Run mode; for each skill check: exists, verb-noun, &lt;300 lines total, HARD GATE present, INDEX row matches.
 3. Write `specs/STOCKTAKE-<date>.md` with findings table (skill, issue, severity).

--- a/.pi/skills/craft-skill/SKILL.md
+++ b/.pi/skills/craft-skill/SKILL.md
@@ -6,7 +6,7 @@ description: "Create new bigpowers skills with proper structure, progressive dis
 
 # Craft Skill
 
-> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh` — the generated `.cursor/rules/` and `.gemini/` artifacts must match the source SKILL.md.
+> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh`. Generated `.cursor/rules/` and `.gemini/` artifacts MUST match the source SKILL.md.
 
 ## CSO Description Discipline (e45s02)
 
@@ -21,11 +21,25 @@ The YAML `description` is the **Catalog Selection Object** — the only field ag
 
 Move process detail into the SKILL.md body or REFERENCE.md — never into `description`.
 
+## Agentic STE body discipline (e79s02)
+
+Skill-body instructional prose MUST follow [AGENTIC-STE.md](../../../docs/AGENTIC-STE.md).
+
+| Rule | Limit |
+|------|-------|
+| Sentence length | ≤20 words per instruction sentence |
+| Voice | Imperative, active |
+| Directive terms | MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT |
+| Banned modals | should, might, could, may, consider, try, generally, typically |
+| Scope | SKILL.md body only — not YAML `description`, not `terse-mode` output |
+
+> **HARD GATE** — Do NOT merge a new or edited skill until `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` exits 0. Fix violations before `sync-skills.sh`.
+
 ## Process
 
 1. **Gather requirements** — ask user about:
    - What task/domain does the skill cover?
-   - What specific use cases should it handle?
+   - Which use cases must the skill handle?
    - Does it need executable scripts or just instructions?
    - Any reference materials to include?
    - What specs/ output does it produce (if any)?
@@ -41,7 +55,8 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
    - Additional reference files if content exceeds 100 lines
    - Utility scripts if deterministic operations needed
 
-   **Auto-skill from library README:** When user provides a library README or API docs URL, extract: triggers, HARD GATEs, verify commands, specs/ output — draft SKILL.md without inventing APIs not in the source.
+   **Auto-skill from library README:** When user provides a library README or API docs URL, extract triggers and HARD GATEs.
+   Draft verify commands and specs/ output into SKILL.md. Do NOT invent APIs not in the source.
 
 4. Add `model:` frontmatter (`haiku` | `sonnet` | `opus`) per [model-profiles.md](https://github.com/danielvm-git/bigpowers/blob/main/docs/references/model-profiles.md).
 
@@ -50,10 +65,11 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
 5. **Review with user** — present draft and ask:
    - Does this cover your use cases?
    - Anything missing or unclear?
-   - Should any section be more/less detailed?
+   - Does any section need more or less detail?
 
 6. **Completion-honesty gate (HARD GATE — e45s02)** — Before declaring done:
    - Run `bash scripts/validate-skill-description.sh skills/<name>/SKILL.md` — must exit 0
+   - Run `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` — must exit 0 (e79s02)
    - Run `bash scripts/sync-skills.sh` — must complete without error
    - Run `bash scripts/run-skill-verify.sh <name>` if the skill defines a verify command
    - Show terminal output for each — narration without evidence is rejected
@@ -78,6 +94,7 @@ After drafting, verify:
 - [ ] Consistent terminology with CONVENTIONS.md
 - [ ] specs/ output documented if applicable
 - [ ] `validate-skill-description.sh` exits 0
+- [ ] `validate-agentic-ste.sh --strict` exits 0 (e79s02)
 - [ ] `sync-skills.sh` run to propagate to Cursor/Gemini
 - [ ] `bash scripts/validate-skill-catalog.sh` passes for the new skill (HARD GATE — completion honesty)
 

--- a/.pi/skills/seed-conventions/SKILL.md
+++ b/.pi/skills/seed-conventions/SKILL.md
@@ -9,6 +9,7 @@ description: "Generate CLAUDE.md and CONVENTIONS.md for a brand-new project thro
 # story: e10s02
 # story: e51s02
 # story: e45s21
+# story: e79s03
 
 
 # Seed Conventions
@@ -32,12 +33,24 @@ Ask the user these questions (one at a time, wait for each answer):
 2. **Stack** — "What language, framework, and runtime? (e.g. TypeScript / Next.js / Node 22)"
 2b. **Stack profile (optional)** — Offer: `swift`, `typescript-vue`, `node-service`, or none. If chosen, merge the matching fragment from `profiles/<name>.md` into generated `CONVENTIONS.md`.
 3. **Commands** — "What commands do you use for: run, test, build, lint?"
-3b. **Preflight (optional)** — "What single command runs your full local green stack (test + lint + build)? If you don't have one, we'll chain your Test + Lint + Build answers into a **Preflight** row in the Commands table."
+3b. **Preflight (optional)** — "What command runs test, lint, and build together? If none, chain Test + Lint + Build into one **Preflight** row."
 4. **Architecture** — "Key modules and relationships in 1–2 sentences."
 5. **Conventions** — "Any naming, file organization, or patterns all agents must follow?"
 6. **Never-do list** — "What are the hard stops? Things an agent must never touch?"
 7. **Defensive code categories** — "Which apply? (Rate limit / Retry / Circuit breaker / Timeout / Graceful degradation)"
 8. **Local tool wiring (optional)** — "Wire bigpowers for project-local tools? (Cursor, OpenCode, Cline, Aider, Codex CLI)" If yes, generate AGENTS.md spine artifacts per [REFERENCE.md](../../../skills/seed-conventions/REFERENCE.md) §Local tool wiring and §AGENTS.md spine. If no, skip — standard seed output unchanged (no AGENTS.md spine unless opted in).
+
+## Agentic STE for generated prose (e79s03)
+
+When writing instructional lines in `CLAUDE.md`, `AGENTS.md`, or `CONVENTIONS.md`, follow [AGENTIC-STE.md](../../../docs/AGENTIC-STE.md):
+
+- Use directive vocabulary: MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT
+- Do NOT use hedge modals listed in AGENTIC-STE.md Rule 3
+- Cap each instruction sentence at 20 words
+- Write imperative, active-voice lines — one instruction per line
+- Do NOT apply Agentic STE to `terse-mode` (output compression is out of scope)
+
+After generation, run `bash scripts/validate-agentic-ste.sh --strict CLAUDE.md CONVENTIONS.md` when those files exist in the target project.
 
 ## Generate files
 
@@ -65,9 +78,11 @@ echo "# Specs\n\nAll planning documents for this project." > specs/README.md
 
 **Note:** `specs/state.yaml.lock` is NOT pre-created — acquired/released dynamically.
 
-`specs/state.yaml` carries a top-level `workflow_mode` key (`team-pr` | `solo-git`, default `solo-git`). This is the **canonical integrate-mode signal** for all skills — set it once here and skills such as `release-branch` read it from this file instead of sniffing profile files.
+`specs/state.yaml` carries top-level `workflow_mode` (`team-pr` | `solo-git`, default `solo-git`).
+This is the **canonical integrate-mode signal** for all skills.
+Set it once here. Skills such as `release-branch` read this file instead of sniffing profiles.
 
-When generating `CLAUDE.md`, if the user did not name a Preflight command, chain the Test + Lint + Build interview answers into one **Preflight** row (e.g. `npm test && npm run lint && npm run build`).
+When generating `CLAUDE.md`, chain Test + Lint + Build into one **Preflight** row if the user named no Preflight command.
 
 ### Self-installing fenced markers (e45s21)
 
@@ -79,7 +94,9 @@ Skills that write into `CLAUDE.md` or `AGENTS.md` MUST use **fenced HTML comment
 <!-- END bigpowers:section-id -->
 ```
 
-**Merge rule:** On update, replace only the content *between* matching `BEGIN`/`END` pairs. If a marker pair is missing, append a new fenced block at the end of the file — never rewrite the whole file.
+**Merge rule:** On update, replace only content between matching `BEGIN`/`END` pairs.
+If a marker pair is missing, append a new fenced block at file end.
+Never rewrite the whole file.
 
 **Standard marker IDs** for seeded projects (see [REFERENCE.md](../../../skills/seed-conventions/REFERENCE.md) § Fenced markers):
 

--- a/.pi/skills/stocktake-skills/SKILL.md
+++ b/.pi/skills/stocktake-skills/SKILL.md
@@ -6,6 +6,7 @@ description: "Sequential subagent batch audit of the bigpowers skill catalog —
 
 # story: e09s01
 <!-- story: e45s12 -->
+<!-- story: e79s04 -->
 
 
 # Stocktake Skills
@@ -25,6 +26,7 @@ Audit SKILL.md catalog for drift, stale triggers, missing HARD GATEs, and INDEX 
 ## Process
 
 0. **Catalog validator (code-enforced)** — run `bash scripts/validate-skill-catalog.sh`. Any FAIL is a critical finding before manual review. Add `--archive` to list zero-usage skills from `metrics.skill_timings` for auto-archiving candidates (move to `specs/epics/archive/` or delete after user confirms).
+0b. **Agentic STE audit (e79s04)** — run `bash scripts/validate-agentic-ste.sh --audit skills/`. Flag hedge words and sentences over 20 words per [AGENTIC-STE.md](../../../docs/AGENTIC-STE.md). Record WARN lines in the stocktake report as **STE debt** — do NOT rewrite the full catalog in one pass. Route critical repeat offenders to `evolve-skill`.
 1. Run `bash scripts/audit-catalog.sh` to verify pi/skills ↔ source SKILL.md sync. Mismatch is a critical finding.
 2. Run mode; for each skill check: exists, verb-noun, &lt;300 lines total, HARD GATE present, INDEX row matches.
 3. Write `specs/STOCKTAKE-<date>.md` with findings table (skill, issue, severity).

--- a/.trae/skills/craft-skill/SKILL.md
+++ b/.trae/skills/craft-skill/SKILL.md
@@ -6,7 +6,7 @@ description: "Create new bigpowers skills with proper structure, progressive dis
 
 # Craft Skill
 
-> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh` — the generated `.cursor/rules/` and `.gemini/` artifacts must match the source SKILL.md.
+> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh`. Generated `.cursor/rules/` and `.gemini/` artifacts MUST match the source SKILL.md.
 
 ## CSO Description Discipline (e45s02)
 
@@ -21,11 +21,25 @@ The YAML `description` is the **Catalog Selection Object** — the only field ag
 
 Move process detail into the SKILL.md body or REFERENCE.md — never into `description`.
 
+## Agentic STE body discipline (e79s02)
+
+Skill-body instructional prose MUST follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md).
+
+| Rule | Limit |
+|------|-------|
+| Sentence length | ≤20 words per instruction sentence |
+| Voice | Imperative, active |
+| Directive terms | MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT |
+| Banned modals | should, might, could, may, consider, try, generally, typically |
+| Scope | SKILL.md body only — not YAML `description`, not `terse-mode` output |
+
+> **HARD GATE** — Do NOT merge a new or edited skill until `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` exits 0. Fix violations before `sync-skills.sh`.
+
 ## Process
 
 1. **Gather requirements** — ask user about:
    - What task/domain does the skill cover?
-   - What specific use cases should it handle?
+   - Which use cases must the skill handle?
    - Does it need executable scripts or just instructions?
    - Any reference materials to include?
    - What specs/ output does it produce (if any)?
@@ -41,7 +55,8 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
    - Additional reference files if content exceeds 100 lines
    - Utility scripts if deterministic operations needed
 
-   **Auto-skill from library README:** When user provides a library README or API docs URL, extract: triggers, HARD GATEs, verify commands, specs/ output — draft SKILL.md without inventing APIs not in the source.
+   **Auto-skill from library README:** When user provides a library README or API docs URL, extract triggers and HARD GATEs.
+   Draft verify commands and specs/ output into SKILL.md. Do NOT invent APIs not in the source.
 
 4. Add `model:` frontmatter (`haiku` | `sonnet` | `opus`) per [model-profiles.md](https://github.com/danielvm-git/bigpowers/blob/main/docs/references/model-profiles.md).
 
@@ -50,10 +65,11 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
 5. **Review with user** — present draft and ask:
    - Does this cover your use cases?
    - Anything missing or unclear?
-   - Should any section be more/less detailed?
+   - Does any section need more or less detail?
 
 6. **Completion-honesty gate (HARD GATE — e45s02)** — Before declaring done:
    - Run `bash scripts/validate-skill-description.sh skills/<name>/SKILL.md` — must exit 0
+   - Run `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` — must exit 0 (e79s02)
    - Run `bash scripts/sync-skills.sh` — must complete without error
    - Run `bash scripts/run-skill-verify.sh <name>` if the skill defines a verify command
    - Show terminal output for each — narration without evidence is rejected
@@ -78,6 +94,7 @@ After drafting, verify:
 - [ ] Consistent terminology with CONVENTIONS.md
 - [ ] specs/ output documented if applicable
 - [ ] `validate-skill-description.sh` exits 0
+- [ ] `validate-agentic-ste.sh --strict` exits 0 (e79s02)
 - [ ] `sync-skills.sh` run to propagate to Cursor/Gemini
 - [ ] `bash scripts/validate-skill-catalog.sh` passes for the new skill (HARD GATE — completion honesty)
 

--- a/.trae/skills/seed-conventions/SKILL.md
+++ b/.trae/skills/seed-conventions/SKILL.md
@@ -9,6 +9,7 @@ description: "Generate CLAUDE.md and CONVENTIONS.md for a brand-new project thro
 # story: e10s02
 # story: e51s02
 # story: e45s21
+# story: e79s03
 
 
 # Seed Conventions
@@ -32,12 +33,24 @@ Ask the user these questions (one at a time, wait for each answer):
 2. **Stack** — "What language, framework, and runtime? (e.g. TypeScript / Next.js / Node 22)"
 2b. **Stack profile (optional)** — Offer: `swift`, `typescript-vue`, `node-service`, or none. If chosen, merge the matching fragment from `profiles/<name>.md` into generated `CONVENTIONS.md`.
 3. **Commands** — "What commands do you use for: run, test, build, lint?"
-3b. **Preflight (optional)** — "What single command runs your full local green stack (test + lint + build)? If you don't have one, we'll chain your Test + Lint + Build answers into a **Preflight** row in the Commands table."
+3b. **Preflight (optional)** — "What command runs test, lint, and build together? If none, chain Test + Lint + Build into one **Preflight** row."
 4. **Architecture** — "Key modules and relationships in 1–2 sentences."
 5. **Conventions** — "Any naming, file organization, or patterns all agents must follow?"
 6. **Never-do list** — "What are the hard stops? Things an agent must never touch?"
 7. **Defensive code categories** — "Which apply? (Rate limit / Retry / Circuit breaker / Timeout / Graceful degradation)"
 8. **Local tool wiring (optional)** — "Wire bigpowers for project-local tools? (Cursor, OpenCode, Cline, Aider, Codex CLI)" If yes, generate AGENTS.md spine artifacts per [REFERENCE.md](REFERENCE.md) §Local tool wiring and §AGENTS.md spine. If no, skip — standard seed output unchanged (no AGENTS.md spine unless opted in).
+
+## Agentic STE for generated prose (e79s03)
+
+When writing instructional lines in `CLAUDE.md`, `AGENTS.md`, or `CONVENTIONS.md`, follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md):
+
+- Use directive vocabulary: MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT
+- Do NOT use hedge modals listed in AGENTIC-STE.md Rule 3
+- Cap each instruction sentence at 20 words
+- Write imperative, active-voice lines — one instruction per line
+- Do NOT apply Agentic STE to `terse-mode` (output compression is out of scope)
+
+After generation, run `bash scripts/validate-agentic-ste.sh --strict CLAUDE.md CONVENTIONS.md` when those files exist in the target project.
 
 ## Generate files
 
@@ -65,9 +78,11 @@ echo "# Specs\n\nAll planning documents for this project." > specs/README.md
 
 **Note:** `specs/state.yaml.lock` is NOT pre-created — acquired/released dynamically.
 
-`specs/state.yaml` carries a top-level `workflow_mode` key (`team-pr` | `solo-git`, default `solo-git`). This is the **canonical integrate-mode signal** for all skills — set it once here and skills such as `release-branch` read it from this file instead of sniffing profile files.
+`specs/state.yaml` carries top-level `workflow_mode` (`team-pr` | `solo-git`, default `solo-git`).
+This is the **canonical integrate-mode signal** for all skills.
+Set it once here. Skills such as `release-branch` read this file instead of sniffing profiles.
 
-When generating `CLAUDE.md`, if the user did not name a Preflight command, chain the Test + Lint + Build interview answers into one **Preflight** row (e.g. `npm test && npm run lint && npm run build`).
+When generating `CLAUDE.md`, chain Test + Lint + Build into one **Preflight** row if the user named no Preflight command.
 
 ### Self-installing fenced markers (e45s21)
 
@@ -79,7 +94,9 @@ Skills that write into `CLAUDE.md` or `AGENTS.md` MUST use **fenced HTML comment
 <!-- END bigpowers:section-id -->
 ```
 
-**Merge rule:** On update, replace only the content *between* matching `BEGIN`/`END` pairs. If a marker pair is missing, append a new fenced block at the end of the file — never rewrite the whole file.
+**Merge rule:** On update, replace only content between matching `BEGIN`/`END` pairs.
+If a marker pair is missing, append a new fenced block at file end.
+Never rewrite the whole file.
 
 **Standard marker IDs** for seeded projects (see [REFERENCE.md](REFERENCE.md) § Fenced markers):
 

--- a/.trae/skills/stocktake-skills/SKILL.md
+++ b/.trae/skills/stocktake-skills/SKILL.md
@@ -6,6 +6,7 @@ description: "Sequential subagent batch audit of the bigpowers skill catalog —
 
 # story: e09s01
 <!-- story: e45s12 -->
+<!-- story: e79s04 -->
 
 
 # Stocktake Skills
@@ -25,6 +26,7 @@ Audit SKILL.md catalog for drift, stale triggers, missing HARD GATEs, and INDEX 
 ## Process
 
 0. **Catalog validator (code-enforced)** — run `bash scripts/validate-skill-catalog.sh`. Any FAIL is a critical finding before manual review. Add `--archive` to list zero-usage skills from `metrics.skill_timings` for auto-archiving candidates (move to `specs/epics/archive/` or delete after user confirms).
+0b. **Agentic STE audit (e79s04)** — run `bash scripts/validate-agentic-ste.sh --audit skills/`. Flag hedge words and sentences over 20 words per [AGENTIC-STE.md](../../docs/AGENTIC-STE.md). Record WARN lines in the stocktake report as **STE debt** — do NOT rewrite the full catalog in one pass. Route critical repeat offenders to `evolve-skill`.
 1. Run `bash scripts/audit-catalog.sh` to verify pi/skills ↔ source SKILL.md sync. Mismatch is a critical finding.
 2. Run mode; for each skill check: exists, verb-noun, &lt;300 lines total, HARD GATE present, INDEX row matches.
 3. Write `specs/STOCKTAKE-<date>.md` with findings table (skill, issue, severity).

--- a/.windsurf/rules/craft-skill.md
+++ b/.windsurf/rules/craft-skill.md
@@ -6,7 +6,7 @@ description: "Create new bigpowers skills with proper structure, progressive dis
 
 # Craft Skill
 
-> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh` — the generated `.cursor/rules/` and `.gemini/` artifacts must match the source SKILL.md.
+> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh`. Generated `.cursor/rules/` and `.gemini/` artifacts MUST match the source SKILL.md.
 
 ## CSO Description Discipline (e45s02)
 
@@ -21,11 +21,25 @@ The YAML `description` is the **Catalog Selection Object** — the only field ag
 
 Move process detail into the SKILL.md body or REFERENCE.md — never into `description`.
 
+## Agentic STE body discipline (e79s02)
+
+Skill-body instructional prose MUST follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md).
+
+| Rule | Limit |
+|------|-------|
+| Sentence length | ≤20 words per instruction sentence |
+| Voice | Imperative, active |
+| Directive terms | MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT |
+| Banned modals | should, might, could, may, consider, try, generally, typically |
+| Scope | SKILL.md body only — not YAML `description`, not `terse-mode` output |
+
+> **HARD GATE** — Do NOT merge a new or edited skill until `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` exits 0. Fix violations before `sync-skills.sh`.
+
 ## Process
 
 1. **Gather requirements** — ask user about:
    - What task/domain does the skill cover?
-   - What specific use cases should it handle?
+   - Which use cases must the skill handle?
    - Does it need executable scripts or just instructions?
    - Any reference materials to include?
    - What specs/ output does it produce (if any)?
@@ -41,7 +55,8 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
    - Additional reference files if content exceeds 100 lines
    - Utility scripts if deterministic operations needed
 
-   **Auto-skill from library README:** When user provides a library README or API docs URL, extract: triggers, HARD GATEs, verify commands, specs/ output — draft SKILL.md without inventing APIs not in the source.
+   **Auto-skill from library README:** When user provides a library README or API docs URL, extract triggers and HARD GATEs.
+   Draft verify commands and specs/ output into SKILL.md. Do NOT invent APIs not in the source.
 
 4. Add `model:` frontmatter (`haiku` | `sonnet` | `opus`) per [model-profiles.md](https://github.com/danielvm-git/bigpowers/blob/main/docs/references/model-profiles.md).
 
@@ -50,10 +65,11 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
 5. **Review with user** — present draft and ask:
    - Does this cover your use cases?
    - Anything missing or unclear?
-   - Should any section be more/less detailed?
+   - Does any section need more or less detail?
 
 6. **Completion-honesty gate (HARD GATE — e45s02)** — Before declaring done:
    - Run `bash scripts/validate-skill-description.sh skills/<name>/SKILL.md` — must exit 0
+   - Run `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` — must exit 0 (e79s02)
    - Run `bash scripts/sync-skills.sh` — must complete without error
    - Run `bash scripts/run-skill-verify.sh <name>` if the skill defines a verify command
    - Show terminal output for each — narration without evidence is rejected
@@ -78,6 +94,7 @@ After drafting, verify:
 - [ ] Consistent terminology with CONVENTIONS.md
 - [ ] specs/ output documented if applicable
 - [ ] `validate-skill-description.sh` exits 0
+- [ ] `validate-agentic-ste.sh --strict` exits 0 (e79s02)
 - [ ] `sync-skills.sh` run to propagate to Cursor/Gemini
 - [ ] `bash scripts/validate-skill-catalog.sh` passes for the new skill (HARD GATE — completion honesty)
 

--- a/.windsurf/rules/seed-conventions.md
+++ b/.windsurf/rules/seed-conventions.md
@@ -9,6 +9,7 @@ description: "Generate CLAUDE.md and CONVENTIONS.md for a brand-new project thro
 # story: e10s02
 # story: e51s02
 # story: e45s21
+# story: e79s03
 
 
 # Seed Conventions
@@ -32,12 +33,24 @@ Ask the user these questions (one at a time, wait for each answer):
 2. **Stack** — "What language, framework, and runtime? (e.g. TypeScript / Next.js / Node 22)"
 2b. **Stack profile (optional)** — Offer: `swift`, `typescript-vue`, `node-service`, or none. If chosen, merge the matching fragment from `profiles/<name>.md` into generated `CONVENTIONS.md`.
 3. **Commands** — "What commands do you use for: run, test, build, lint?"
-3b. **Preflight (optional)** — "What single command runs your full local green stack (test + lint + build)? If you don't have one, we'll chain your Test + Lint + Build answers into a **Preflight** row in the Commands table."
+3b. **Preflight (optional)** — "What command runs test, lint, and build together? If none, chain Test + Lint + Build into one **Preflight** row."
 4. **Architecture** — "Key modules and relationships in 1–2 sentences."
 5. **Conventions** — "Any naming, file organization, or patterns all agents must follow?"
 6. **Never-do list** — "What are the hard stops? Things an agent must never touch?"
 7. **Defensive code categories** — "Which apply? (Rate limit / Retry / Circuit breaker / Timeout / Graceful degradation)"
 8. **Local tool wiring (optional)** — "Wire bigpowers for project-local tools? (Cursor, OpenCode, Cline, Aider, Codex CLI)" If yes, generate AGENTS.md spine artifacts per [REFERENCE.md](REFERENCE.md) §Local tool wiring and §AGENTS.md spine. If no, skip — standard seed output unchanged (no AGENTS.md spine unless opted in).
+
+## Agentic STE for generated prose (e79s03)
+
+When writing instructional lines in `CLAUDE.md`, `AGENTS.md`, or `CONVENTIONS.md`, follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md):
+
+- Use directive vocabulary: MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT
+- Do NOT use hedge modals listed in AGENTIC-STE.md Rule 3
+- Cap each instruction sentence at 20 words
+- Write imperative, active-voice lines — one instruction per line
+- Do NOT apply Agentic STE to `terse-mode` (output compression is out of scope)
+
+After generation, run `bash scripts/validate-agentic-ste.sh --strict CLAUDE.md CONVENTIONS.md` when those files exist in the target project.
 
 ## Generate files
 
@@ -65,9 +78,11 @@ echo "# Specs\n\nAll planning documents for this project." > specs/README.md
 
 **Note:** `specs/state.yaml.lock` is NOT pre-created — acquired/released dynamically.
 
-`specs/state.yaml` carries a top-level `workflow_mode` key (`team-pr` | `solo-git`, default `solo-git`). This is the **canonical integrate-mode signal** for all skills — set it once here and skills such as `release-branch` read it from this file instead of sniffing profile files.
+`specs/state.yaml` carries top-level `workflow_mode` (`team-pr` | `solo-git`, default `solo-git`).
+This is the **canonical integrate-mode signal** for all skills.
+Set it once here. Skills such as `release-branch` read this file instead of sniffing profiles.
 
-When generating `CLAUDE.md`, if the user did not name a Preflight command, chain the Test + Lint + Build interview answers into one **Preflight** row (e.g. `npm test && npm run lint && npm run build`).
+When generating `CLAUDE.md`, chain Test + Lint + Build into one **Preflight** row if the user named no Preflight command.
 
 ### Self-installing fenced markers (e45s21)
 
@@ -79,7 +94,9 @@ Skills that write into `CLAUDE.md` or `AGENTS.md` MUST use **fenced HTML comment
 <!-- END bigpowers:section-id -->
 ```
 
-**Merge rule:** On update, replace only the content *between* matching `BEGIN`/`END` pairs. If a marker pair is missing, append a new fenced block at the end of the file — never rewrite the whole file.
+**Merge rule:** On update, replace only content between matching `BEGIN`/`END` pairs.
+If a marker pair is missing, append a new fenced block at file end.
+Never rewrite the whole file.
 
 **Standard marker IDs** for seeded projects (see [REFERENCE.md](REFERENCE.md) § Fenced markers):
 

--- a/.windsurf/rules/stocktake-skills.md
+++ b/.windsurf/rules/stocktake-skills.md
@@ -6,6 +6,7 @@ description: "Sequential subagent batch audit of the bigpowers skill catalog —
 
 # story: e09s01
 <!-- story: e45s12 -->
+<!-- story: e79s04 -->
 
 
 # Stocktake Skills
@@ -25,6 +26,7 @@ Audit SKILL.md catalog for drift, stale triggers, missing HARD GATEs, and INDEX 
 ## Process
 
 0. **Catalog validator (code-enforced)** — run `bash scripts/validate-skill-catalog.sh`. Any FAIL is a critical finding before manual review. Add `--archive` to list zero-usage skills from `metrics.skill_timings` for auto-archiving candidates (move to `specs/epics/archive/` or delete after user confirms).
+0b. **Agentic STE audit (e79s04)** — run `bash scripts/validate-agentic-ste.sh --audit skills/`. Flag hedge words and sentences over 20 words per [AGENTIC-STE.md](../../docs/AGENTIC-STE.md). Record WARN lines in the stocktake report as **STE debt** — do NOT rewrite the full catalog in one pass. Route critical repeat offenders to `evolve-skill`.
 1. Run `bash scripts/audit-catalog.sh` to verify pi/skills ↔ source SKILL.md sync. Mismatch is a critical finding.
 2. Run mode; for each skill check: exists, verb-noun, &lt;300 lines total, HARD GATE present, INDEX row matches.
 3. Write `specs/STOCKTAKE-<date>.md` with findings table (skill, issue, severity).

--- a/docs/AGENTIC-STE.md
+++ b/docs/AGENTIC-STE.md
@@ -1,0 +1,76 @@
+# story: e79s01
+# Agentic STE — Controlled English for Instructional Prose
+
+Agentic STE adapts [ASD-STE100](https://www.asd-ste100.org/) discipline for documents agents **read before acting**. It targets **input precision**, not output compression.
+
+## Scope boundary (Rule 1)
+
+Apply Agentic STE to instructional prose in:
+
+- `skills/*/SKILL.md` body (below frontmatter)
+- `CLAUDE.md` / `AGENTS.md` agent-managed fenced blocks
+- `CONVENTIONS.md` agent-facing rules
+
+**Out of scope:** YAML frontmatter, code blocks, tables, URLs, story tags, and **`terse-mode`** (output compression under context pressure). Do not conflate input-precision rules with terse-mode.
+
+## Approved directive vocabulary (Rule 2)
+
+Use only these terms for binding instructions:
+
+| Term | Meaning |
+|------|---------|
+| MUST | Required action |
+| MUST NOT | Forbidden action |
+| NEVER | Absolute prohibition |
+| ALWAYS | Required every time |
+| DO | Positive imperative |
+| DO NOT | Negative imperative |
+
+Prefer **MUST NOT** / **NEVER** over soft modals for hard stops.
+
+## Banned hedge modals (Rule 3)
+
+Do **NOT** use these words in instructional sentences (case-insensitive, whole word):
+
+`should`, `might`, `could`, `may`, `consider`, `try`, `generally`, `typically`
+
+Replace with directive vocabulary. Example: "You should run tests" → "Run tests before commit."
+
+## Sentence length cap (Rule 4)
+
+Each instruction sentence: **maximum 20 words**. Split long sentences into separate lines. One instruction per sentence.
+
+## Imperative mood (Rule 5)
+
+Start instruction sentences with a verb. Use "Run …", "Write …", "Do NOT …" — not "You should …" or "It is recommended that …".
+
+## Active voice (Rule 6)
+
+Name the actor. "Run Preflight" not "Preflight should be run." "The agent MUST …" when the actor is ambiguous.
+
+## One instruction per line (Rule 7)
+
+Put each instruction on its own line or bullet. Do not chain multiple instructions in one sentence with "and then" or semicolons.
+
+## Pronoun back-reference (Rule 8)
+
+Do not use "it", "this", or "they" to refer to a noun more than one clause away. Repeat the noun or use a bullet label.
+
+## Enforcement (Rule 9)
+
+| When | Tool |
+|------|------|
+| New or edited skill | `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` |
+| Generated CLAUDE.md / CONVENTIONS.md | Apply Rules 2–8 during `seed-conventions` |
+| Catalog audit | `bash scripts/validate-agentic-ste.sh --audit skills/` (flags debt; does not rewrite catalog) |
+
+Validator is the mechanical backstop. Writers MUST follow this doc first.
+
+## Numeric summary (Rule 10)
+
+| Limit | Value |
+|-------|-------|
+| Max words per instruction sentence | 20 |
+| Banned hedge modals | 8 terms (Rule 3) |
+| Approved directive terms | 6 terms (Rule 2) |
+| Scope files | SKILL.md body, CLAUDE.md, CONVENTIONS.md |

--- a/scripts/validate-agentic-ste.sh
+++ b/scripts/validate-agentic-ste.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# story: e79s02
+# validate-agentic-ste.sh — mechanical Agentic STE checks for instructional prose.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+MAX_WORDS=20
+BANNED_RE='\b(should|might|could|may|consider|try|generally|typically)\b'
+
+STRICT=false
+AUDIT=false
+SELF_TEST=false
+TARGETS=()
+
+ste_usage() {
+  echo "Usage: bash scripts/validate-agentic-ste.sh [--self-test|--strict|--audit] [file|dir ...]"
+  echo "  (no args)     Run built-in fixture self-test"
+  echo "  --strict      Exit 1 on violations (craft-skill gate)"
+  echo "  --audit       WARN-only catalog scan (stocktake)"
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --strict) STRICT=true; shift ;;
+    --audit) AUDIT=true; shift ;;
+    --self-test) SELF_TEST=true; shift ;;
+    -h|--help) ste_usage ;;
+    --) shift; TARGETS+=("$@"); break ;;
+    -*) echo "Unknown flag: $1" >&2; ste_usage ;;
+    *) TARGETS+=("$1"); shift ;;
+  esac
+done
+
+VIOLATIONS=0
+WARNINGS=0
+
+ste_report_fail() {
+  echo "FAIL: $1" >&2
+  VIOLATIONS=$((VIOLATIONS + 1))
+}
+
+ste_report_warn() {
+  echo "WARN: $1" >&2
+  WARNINGS=$((WARNINGS + 1))
+}
+
+ste_strip_frontmatter() {
+  awk '
+    BEGIN { n=0; emit=0 }
+    /^---$/ { n++; if (n==1) next; if (n==2) { emit=1; next } }
+    emit { print }
+  ' "$1"
+}
+
+ste_extract_prose() {
+  local file="$1"
+  local body
+  if [[ "$(basename "$file")" == "SKILL.md" ]]; then
+    body="$(ste_strip_frontmatter "$file")"
+  else
+    body="$(cat "$file")"
+  fi
+  printf '%s\n' "$body" | awk '
+    BEGIN { in_code=0 }
+    /^```/ { in_code = !in_code; next }
+    in_code { next }
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*\|/ { next }
+    /^[[:space:]]*<!--/ { next }
+    /^[[:space:]]*$/ { next }
+    /^# story:/ { next }
+    /^<!-- story:/ { next }
+    { print }
+  '
+}
+
+ste_count_words() {
+  # shellcheck disable=SC2207
+  local words=($1)
+  echo "${#words[@]}"
+}
+
+ste_audit_line() {
+  local file="$1"
+  local line_no="$2"
+  local line="$3"
+  local label="${file}:${line_no}"
+
+  if echo "$line" | grep -qiE "$BANNED_RE"; then
+    local word
+    word="$(echo "$line" | grep -oiE "$BANNED_RE" | head -1)"
+    if $STRICT; then
+      ste_report_fail "$label — banned hedge modal '$word'"
+    else
+      ste_report_warn "$label — banned hedge modal '$word'"
+    fi
+  fi
+
+  local sentence
+  while IFS= read -r sentence; do
+    [[ -z "$sentence" ]] && continue
+    local trimmed
+    trimmed="$(echo "$sentence" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    [[ -z "$trimmed" ]] && continue
+    local wc
+    wc="$(ste_count_words "$trimmed")"
+    if (( wc > MAX_WORDS )); then
+      if $STRICT; then
+        ste_report_fail "$label — sentence has ${wc} words (max ${MAX_WORDS}): ${trimmed:0:60}..."
+      else
+        ste_report_warn "$label — sentence has ${wc} words (max ${MAX_WORDS}): ${trimmed:0:60}..."
+      fi
+    fi
+  done < <(echo "$line" | sed 's/[.!?]/&\n/g')
+}
+
+ste_audit_file() {
+  local file="$1"
+  [[ -f "$file" ]] || { ste_report_fail "not found: $file"; return; }
+
+  local prose line_no=0
+  prose="$(ste_extract_prose "$file")"
+  while IFS= read -r line; do
+    line_no=$((line_no + 1))
+    ste_audit_line "$file" "$line_no" "$line"
+  done <<< "$prose"
+}
+
+ste_collect_files() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    echo "$path"
+  elif [[ -d "$path" ]]; then
+    find "$path" -type f \( -name 'SKILL.md' -o -name 'CLAUDE.md' -o -name 'CONVENTIONS.md' -o -name 'AGENTS.md' \) | sort
+  fi
+}
+
+ste_run_self_test() {
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  cat > "$tmp/good-skill.md" <<'EOF'
+---
+name: fixture-good
+description: Test fixture for Agentic STE validator. Use when running self-test.
+---
+# Fixture Good
+> **HARD GATE** — Run Preflight before forward work.
+Run tests after every change.
+Write specs to specs/ at project root.
+EOF
+
+  cat > "$tmp/bad-hedge.md" <<'EOF'
+---
+name: fixture-bad
+description: Bad fixture.
+---
+You should consider running tests generally.
+EOF
+
+  cat > "$tmp/bad-long.md" <<'EOF'
+---
+name: fixture-long
+description: Long sentence fixture.
+---
+Run the full local green stack including compliance verification gates sync skills trace stories and catalog drift check before any forward implementation work on this repository.
+EOF
+
+  local saved_strict=$STRICT saved_audit=$AUDIT
+  STRICT=true
+  AUDIT=false
+  VIOLATIONS=0
+
+  ste_audit_file "$tmp/good-skill.md"
+  if (( VIOLATIONS > 0 )); then
+    echo "SELF-TEST FAIL: good fixture should pass" >&2
+    return 1
+  fi
+
+  VIOLATIONS=0
+  ste_audit_file "$tmp/bad-hedge.md"
+  if (( VIOLATIONS == 0 )); then
+    echo "SELF-TEST FAIL: hedge fixture should fail" >&2
+    return 1
+  fi
+
+  VIOLATIONS=0
+  ste_audit_file "$tmp/bad-long.md"
+  if (( VIOLATIONS == 0 )); then
+    echo "SELF-TEST FAIL: long-sentence fixture should fail" >&2
+    return 1
+  fi
+
+  STRICT=$saved_strict
+  AUDIT=$saved_audit
+  VIOLATIONS=0
+  echo "validate-agentic-ste: self-test PASS"
+  return 0
+}
+
+if $SELF_TEST || [[ ${#TARGETS[@]} -eq 0 ]]; then
+  ste_run_self_test
+  exit $?
+fi
+
+if $AUDIT; then
+  STRICT=false
+fi
+
+for target in "${TARGETS[@]}"; do
+  while IFS= read -r f; do
+    [[ -n "$f" ]] && ste_audit_file "$f"
+  done < <(ste_collect_files "$target")
+done
+
+if (( VIOLATIONS > 0 )); then
+  echo "validate-agentic-ste: $VIOLATIONS violation(s)" >&2
+  exit 1
+fi
+
+if $AUDIT; then
+  echo "validate-agentic-ste: audit complete ($WARNINGS warning(s))"
+else
+  echo "validate-agentic-ste: PASS"
+fi

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -48,7 +48,7 @@
     },
     "craft-skill": {
       "description": "Create new bigpowers skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill for the bigpowers lifecycle.",
-      "sha256": "2caa9d8ae9298b4b",
+      "sha256": "07d1cc8eddca50c5",
       "path": "skills/craft-skillSKILL.md"
     },
     "deepen-architecture": {
@@ -308,7 +308,7 @@
     },
     "seed-conventions": {
       "description": "Generate CLAUDE.md and CONVENTIONS.md for a brand-new project through a brief interview, and create the specs/ directory with evolved bigpowers structure (product/, tech-architecture/, verifications/, epics/archive/). Entry point for greenfield projects. Use when starting a new project from scratch, when user asks to set up AI agent conventions, or when there is no CLAUDE.md yet.",
-      "sha256": "35c335385c4ad48b",
+      "sha256": "6cb91bf0b5cdd9b3",
       "path": "skills/seed-conventionsSKILL.md"
     },
     "session-state": {
@@ -343,7 +343,7 @@
     },
     "stocktake-skills": {
       "description": "Sequential subagent batch audit of the bigpowers skill catalog — Quick Scan (changed only) or Full (all skills). Use during sustain phase, before a major release, or when catalog drift is suspected.",
-      "sha256": "6833c900df48a98a",
+      "sha256": "9595b954341217d7",
       "path": "skills/stocktake-skillsSKILL.md"
     },
     "survey-context": {

--- a/skills/craft-skill/SKILL.md
+++ b/skills/craft-skill/SKILL.md
@@ -1,5 +1,6 @@
 # story: e45s02
 <!-- story: e45s12 -->
+<!-- story: e79s02 -->
 ---
 name: craft-skill
 model: sonnet
@@ -9,7 +10,7 @@ description: Create new bigpowers skills with proper structure, progressive disc
 
 # Craft Skill
 
-> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh` — the generated `.cursor/rules/` and `.gemini/` artifacts must match the source SKILL.md.
+> **HARD GATE** — Do NOT name a skill without a two-word verb-noun pair. Do NOT merge a new skill without running `sync-skills.sh`. Generated `.cursor/rules/` and `.gemini/` artifacts MUST match the source SKILL.md.
 
 ## CSO Description Discipline (e45s02)
 
@@ -24,11 +25,25 @@ The YAML `description` is the **Catalog Selection Object** — the only field ag
 
 Move process detail into the SKILL.md body or REFERENCE.md — never into `description`.
 
+## Agentic STE body discipline (e79s02)
+
+Skill-body instructional prose MUST follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md).
+
+| Rule | Limit |
+|------|-------|
+| Sentence length | ≤20 words per instruction sentence |
+| Voice | Imperative, active |
+| Directive terms | MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT |
+| Banned modals | should, might, could, may, consider, try, generally, typically |
+| Scope | SKILL.md body only — not YAML `description`, not `terse-mode` output |
+
+> **HARD GATE** — Do NOT merge a new or edited skill until `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` exits 0. Fix violations before `sync-skills.sh`.
+
 ## Process
 
 1. **Gather requirements** — ask user about:
    - What task/domain does the skill cover?
-   - What specific use cases should it handle?
+   - Which use cases must the skill handle?
    - Does it need executable scripts or just instructions?
    - Any reference materials to include?
    - What specs/ output does it produce (if any)?
@@ -44,7 +59,8 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
    - Additional reference files if content exceeds 100 lines
    - Utility scripts if deterministic operations needed
 
-   **Auto-skill from library README:** When user provides a library README or API docs URL, extract: triggers, HARD GATEs, verify commands, specs/ output — draft SKILL.md without inventing APIs not in the source.
+   **Auto-skill from library README:** When user provides a library README or API docs URL, extract triggers and HARD GATEs.
+   Draft verify commands and specs/ output into SKILL.md. Do NOT invent APIs not in the source.
 
 4. Add `model:` frontmatter (`haiku` | `sonnet` | `opus`) per [model-profiles.md](https://github.com/danielvm-git/bigpowers/blob/main/docs/references/model-profiles.md).
 
@@ -53,10 +69,11 @@ Move process detail into the SKILL.md body or REFERENCE.md — never into `descr
 5. **Review with user** — present draft and ask:
    - Does this cover your use cases?
    - Anything missing or unclear?
-   - Should any section be more/less detailed?
+   - Does any section need more or less detail?
 
 6. **Completion-honesty gate (HARD GATE — e45s02)** — Before declaring done:
    - Run `bash scripts/validate-skill-description.sh skills/<name>/SKILL.md` — must exit 0
+   - Run `bash scripts/validate-agentic-ste.sh --strict skills/<name>/SKILL.md` — must exit 0 (e79s02)
    - Run `bash scripts/sync-skills.sh` — must complete without error
    - Run `bash scripts/run-skill-verify.sh <name>` if the skill defines a verify command
    - Show terminal output for each — narration without evidence is rejected
@@ -81,6 +98,7 @@ After drafting, verify:
 - [ ] Consistent terminology with CONVENTIONS.md
 - [ ] specs/ output documented if applicable
 - [ ] `validate-skill-description.sh` exits 0
+- [ ] `validate-agentic-ste.sh --strict` exits 0 (e79s02)
 - [ ] `sync-skills.sh` run to propagate to Cursor/Gemini
 - [ ] `bash scripts/validate-skill-catalog.sh` passes for the new skill (HARD GATE — completion honesty)
 

--- a/skills/seed-conventions/SKILL.md
+++ b/skills/seed-conventions/SKILL.md
@@ -10,6 +10,7 @@ description: Generate CLAUDE.md and CONVENTIONS.md for a brand-new project throu
 # story: e10s02
 # story: e51s02
 # story: e45s21
+# story: e79s03
 
 
 # Seed Conventions
@@ -33,12 +34,24 @@ Ask the user these questions (one at a time, wait for each answer):
 2. **Stack** — "What language, framework, and runtime? (e.g. TypeScript / Next.js / Node 22)"
 2b. **Stack profile (optional)** — Offer: `swift`, `typescript-vue`, `node-service`, or none. If chosen, merge the matching fragment from `profiles/<name>.md` into generated `CONVENTIONS.md`.
 3. **Commands** — "What commands do you use for: run, test, build, lint?"
-3b. **Preflight (optional)** — "What single command runs your full local green stack (test + lint + build)? If you don't have one, we'll chain your Test + Lint + Build answers into a **Preflight** row in the Commands table."
+3b. **Preflight (optional)** — "What command runs test, lint, and build together? If none, chain Test + Lint + Build into one **Preflight** row."
 4. **Architecture** — "Key modules and relationships in 1–2 sentences."
 5. **Conventions** — "Any naming, file organization, or patterns all agents must follow?"
 6. **Never-do list** — "What are the hard stops? Things an agent must never touch?"
 7. **Defensive code categories** — "Which apply? (Rate limit / Retry / Circuit breaker / Timeout / Graceful degradation)"
 8. **Local tool wiring (optional)** — "Wire bigpowers for project-local tools? (Cursor, OpenCode, Cline, Aider, Codex CLI)" If yes, generate AGENTS.md spine artifacts per [REFERENCE.md](REFERENCE.md) §Local tool wiring and §AGENTS.md spine. If no, skip — standard seed output unchanged (no AGENTS.md spine unless opted in).
+
+## Agentic STE for generated prose (e79s03)
+
+When writing instructional lines in `CLAUDE.md`, `AGENTS.md`, or `CONVENTIONS.md`, follow [AGENTIC-STE.md](../../docs/AGENTIC-STE.md):
+
+- Use directive vocabulary: MUST, MUST NOT, NEVER, ALWAYS, DO, DO NOT
+- Do NOT use hedge modals listed in AGENTIC-STE.md Rule 3
+- Cap each instruction sentence at 20 words
+- Write imperative, active-voice lines — one instruction per line
+- Do NOT apply Agentic STE to `terse-mode` (output compression is out of scope)
+
+After generation, run `bash scripts/validate-agentic-ste.sh --strict CLAUDE.md CONVENTIONS.md` when those files exist in the target project.
 
 ## Generate files
 
@@ -66,9 +79,11 @@ echo "# Specs\n\nAll planning documents for this project." > specs/README.md
 
 **Note:** `specs/state.yaml.lock` is NOT pre-created — acquired/released dynamically.
 
-`specs/state.yaml` carries a top-level `workflow_mode` key (`team-pr` | `solo-git`, default `solo-git`). This is the **canonical integrate-mode signal** for all skills — set it once here and skills such as `release-branch` read it from this file instead of sniffing profile files.
+`specs/state.yaml` carries top-level `workflow_mode` (`team-pr` | `solo-git`, default `solo-git`).
+This is the **canonical integrate-mode signal** for all skills.
+Set it once here. Skills such as `release-branch` read this file instead of sniffing profiles.
 
-When generating `CLAUDE.md`, if the user did not name a Preflight command, chain the Test + Lint + Build interview answers into one **Preflight** row (e.g. `npm test && npm run lint && npm run build`).
+When generating `CLAUDE.md`, chain Test + Lint + Build into one **Preflight** row if the user named no Preflight command.
 
 ### Self-installing fenced markers (e45s21)
 
@@ -80,7 +95,9 @@ Skills that write into `CLAUDE.md` or `AGENTS.md` MUST use **fenced HTML comment
 <!-- END bigpowers:section-id -->
 ```
 
-**Merge rule:** On update, replace only the content *between* matching `BEGIN`/`END` pairs. If a marker pair is missing, append a new fenced block at the end of the file — never rewrite the whole file.
+**Merge rule:** On update, replace only content between matching `BEGIN`/`END` pairs.
+If a marker pair is missing, append a new fenced block at file end.
+Never rewrite the whole file.
 
 **Standard marker IDs** for seeded projects (see [REFERENCE.md](REFERENCE.md) § Fenced markers):
 

--- a/skills/stocktake-skills/SKILL.md
+++ b/skills/stocktake-skills/SKILL.md
@@ -9,6 +9,7 @@ effort: standard
 
 # story: e09s01
 <!-- story: e45s12 -->
+<!-- story: e79s04 -->
 
 
 # Stocktake Skills
@@ -28,6 +29,7 @@ Audit SKILL.md catalog for drift, stale triggers, missing HARD GATEs, and INDEX 
 ## Process
 
 0. **Catalog validator (code-enforced)** — run `bash scripts/validate-skill-catalog.sh`. Any FAIL is a critical finding before manual review. Add `--archive` to list zero-usage skills from `metrics.skill_timings` for auto-archiving candidates (move to `specs/epics/archive/` or delete after user confirms).
+0b. **Agentic STE audit (e79s04)** — run `bash scripts/validate-agentic-ste.sh --audit skills/`. Flag hedge words and sentences over 20 words per [AGENTIC-STE.md](../../docs/AGENTIC-STE.md). Record WARN lines in the stocktake report as **STE debt** — do NOT rewrite the full catalog in one pass. Route critical repeat offenders to `evolve-skill`.
 1. Run `bash scripts/audit-catalog.sh` to verify pi/skills ↔ source SKILL.md sync. Mismatch is a critical finding.
 2. Run mode; for each skill check: exists, verb-noun, &lt;300 lines total, HARD GATE present, INDEX row matches.
 3. Write `specs/STOCKTAKE-<date>.md` with findings table (skill, issue, severity).

--- a/specs/TRACEABILITY_LATEST.md
+++ b/specs/TRACEABILITY_LATEST.md
@@ -1,28 +1,28 @@
 # Traceability Matrix
 
-**Generated:** 2026-07-24 19:53:42 UTC
-**Total stories:** 112
-**Tagged stories:** 102
+**Generated:** 2026-07-25 05:28:09 UTC
+**Total stories:** 116
+**Tagged stories:** 106
 **Dark stories:** 0
-**Orphan tags:** 149
+**Orphan tags:** 147
 **Stale tags:** 102
 
 ## Oracle Stats
 
-- **High** (explicit tag): 720
-- **Medium** (file heuristic): 2925
-- **Low** (task reference): 66
+- **High** (explicit tag): 759
+- **Medium** (file heuristic): 2023
+- **Low** (task reference): 70
 
 ## Story Coverage
 
 | Story | Title | Epic | BCP | WSJF | Status | Links |
 |-------|-------|------|-----|------|--------|-------|
-| e37s01 | seed-conventions — unified AGENTS.md template with e51 Prefl | e37 | 3 | 7.0 | done | 17 |
+| e37s01 | seed-conventions — unified AGENTS.md template with e51 Prefl | e37 | 3 | 7.0 | done | 18 |
 | e37s02 | verify-install.sh + docs — Cline native AGENTS.md verificati | e37 | 2 | 7.0 | done | 5 |
-| e37s03 | seed-conventions — .aider.conf.yml read:AGENTS.md bridge for | e37 | 1 | 7.0 | done | 9 |
+| e37s03 | seed-conventions — .aider.conf.yml read:AGENTS.md bridge for | e37 | 1 | 7.0 | done | 10 |
 | e37s04 | verify-install.sh — AGENTS.md spine assertions (OSS P1 + opt | e37 | 2 | 7.0 | done | 4 |
 | e37s05 | scripts/targets.yaml — declarative integration registry for  | e37 | 5 | 7.0 | done | 28 |
-| e37s06 | scripts/generate-context-bundle.sh — AGENTS.md single source | e37 | 3 | 7.0 | done | 12 |
+| e37s06 | scripts/generate-context-bundle.sh — AGENTS.md single source | e37 | 3 | 7.0 | done | 11 |
 | e37s07 | sync-skills.sh — adapter dispatch from targets.yaml | e37 | 5 | 7.0 | done | 12 |
 | e37s08 | verify-install.sh — per-target contract matrix from targets. | e37 | 3 | 7.0 | done | 10 |
 | e37s09 | targets.yaml — Wave A: Goose (OSS) + Antigravity agy (propri | e37 | 3 | 7.0 | done | 5 |
@@ -30,30 +30,30 @@
 | e37s11 | targets.yaml — Wave C: qwen, kilocode (markdown commands + r | e37 | 3 | 7.0 | done | 2 |
 | e37s12 | targets.yaml — Wave D: continue (rules adapter; re-opened ac | e37 | 2 | 7.0 | done | 5 |
 | e37s13 | targets.yaml — Wave E: iflow, vibe, shai (markdown commands; | e37 | 2 | 7.0 | done | 6 |
-| e37s14 | seed-conventions — optional Codex wiring step (AGENTS.md + . | e37 | 3 | 7.0 | done | 9 |
+| e37s14 | seed-conventions — optional Codex wiring step (AGENTS.md + . | e37 | 3 | 7.0 | done | 10 |
 | e37s15 | install.sh — global ~/.codex/ AGENTS.md starter symlink | e37 | 2 | 7.0 | done | 4 |
 | e37s16 | using-bigpowers — Codex CLI onboarding section | e37 | 2 | 7.0 | done | 10 |
 | e45s01 | run-benchmark: add train/validation-split + with/without-ski | e45 | 3 | 5.0 | done | 14 |
-| e45s02 | craft-skill: CSO description discipline + completion-honesty | e45 | 2 | 5.0 | done | 14 |
+| e45s02 | craft-skill: CSO description discipline + completion-honesty | e45 | 2 | 5.0 | done | 15 |
 | e45s03 | CLAUDE.md token mgmt: mechanical PreToolUse hook backstop | e45 | 3 | 5.0 | done | 4 |
 | e45s04 | slice-tasks / plan-work: pre-build cross-artifact consistenc | e45 | 3 | 5.0 | done | 17 |
 | e45s05 | verify-work / gate-trace: adversarial gap-finding completene | e45 | 4 | 5.0 | done | 40 |
 | e45s06 | tasks.yaml: literal failing→passing task ledger | e45 | 2 | 5.0 | done | 2 |
 | e45s07 | request-review: dual-blind AND-gate review (Santa Method) | e45 | 2 | 5.0 | done | 38 |
 | e45s08 | develop-tdd / validate-fix: two-commit red/green regression  | e45 | 2 | 5.0 | done | 13 |
-| e45s09 | verify-work / plan-work: Pre-Implementation and Validation g | e45 | 2 | 5.0 | done | 85 |
+| e45s09 | verify-work / plan-work: Pre-Implementation and Validation g | e45 | 2 | 5.0 | done | 84 |
 | e45s10 | docs/references: auto-regenerate from source-of-truth docs v | e45 | 2 | 5.0 | done | 7 |
 | e45s11 | orchestration / dispatch-agents: typed message protocol + 3- | e45 | 2 | 5.0 | done | 17 |
-| e45s12 | stocktake-skills / craft-skill: code-enforced validator + au | e45 | 2 | 5.0 | done | 43 |
+| e45s12 | stocktake-skills / craft-skill: code-enforced validator + au | e45 | 2 | 5.0 | done | 44 |
 | e45s13 | verify-work: one-test-minimum terminal-verdict rule | e45 | 2 | 5.0 | done | 25 |
 | e45s14 | deepen-architecture: declared import-boundary allowlist enfo | e45 | 2 | 5.0 | done | 8 |
 | e45s15 | release-branch / deploy: three-independent-facts verificatio | e45 | 2 | 5.0 | done | 21 |
 | e45s16 | CLAUDE.md rtk mandate: wire rtk-ai/rtk PreToolUse hook | e45 | 2 | 5.0 | done | 4 |
 | e45s17 | request-review: fan-out to parallel review subagents | e45 | 2 | 5.0 | done | 30 |
-| e45s18 | audit-code / security-review: worktree-isolated parallel che | e45 | 2 | 5.0 | done | 582 |
+| e45s18 | audit-code / security-review: worktree-isolated parallel che | e45 | 2 | 5.0 | done | 278 |
 | e45s19 | Context7: bounded retry cap and explicit fallback block | e45 | 2 | 5.0 | done | 8 |
 | e45s20 | Context7 / bts docs: wrap in ETag-revalidated fetch cache | e45 | 2 | 5.0 | done | 1 |
-| e45s21 | seed-conventions / AGENTS.md: self-installing fenced markers | e45 | 2 | 5.0 | done | 32 |
+| e45s21 | seed-conventions / AGENTS.md: self-installing fenced markers | e45 | 2 | 5.0 | done | 33 |
 | e45s22 | CLAUDE.md: context-aware directory routing | e45 | 2 | 5.0 | done | 3 |
 | e45s23 | CLAUDE.md: live Learned User Preferences / Workspace Facts | e45 | 2 | 5.0 | done | 17 |
 | e45s24 | REFERENCE.md files: embedded line-range navigation guides | e45 | 2 | 5.0 | done | 2 |
@@ -63,7 +63,7 @@
 | e45s28 | request-review: hard max-iteration cap | e45 | 2 | 5.0 | done | 18 |
 | e45s29 | requirements: ADDED/MODIFIED/REMOVED/RENAMED tags | e45 | 2 | 5.0 | done | 42 |
 | e45s30 | subagent depth: formalize depth tiers | e45 | 2 | 5.0 | done | 28 |
-| e45s31 | audit-code / deepen-architecture: churn-based look-here-firs | e45 | 2 | 5.0 | done | 572 |
+| e45s31 | audit-code / deepen-architecture: churn-based look-here-firs | e45 | 2 | 5.0 | done | 268 |
 | e45s32 | gate-trace / release-branch: adversarial-review refute frami | e45 | 2 | 5.0 | done | 36 |
 | e45s33 | requirements: per-section approval state | e45 | 2 | 5.0 | done | 3 |
 | e45s34 | develop-tdd: snapshot-before-transition hardening | e45 | 2 | 5.0 | done | 7 |
@@ -75,10 +75,10 @@
 | e45s40 | verify-work: mandatory real-browser verification | e45 | 2 | 5.0 | done | 23 |
 | e45s41 | security-review: proven authorship SQL-safety doctrine | e45 | 2 | 5.0 | done | 18 |
 | e48s01 | Generate epics-wiki and adr-wiki as OKF concept bundles from | e48 | 2 | 2.5 | done | 33 |
-| e48s02 | Emit verification reports as OKF bundles from run-golden-sui | e48 | 2 | 2.5 | done | 43 |
-| e48s03 | OKF-ify bug-registry: specs/bugs/registry.yaml emits concept | e48 | 1 | 2.5 | done | 141 |
+| e48s02 | Emit verification reports as OKF bundles from run-golden-sui | e48 | 2 | 2.5 | done | 30 |
+| e48s03 | OKF-ify bug-registry: specs/bugs/registry.yaml emits concept | e48 | 1 | 2.5 | done | 142 |
 | e48s04 | Create viz.html — interactive force-layout graph companion f | e48 | 2 | 2.5 | done | 12 |
-| e48s05 | Wire OKF validation into CI (sync-skills.yml) and document i | e48 | 1 | 2.5 | done | 182 |
+| e48s05 | Wire OKF validation into CI (sync-skills.yml) and document i | e48 | 1 | 2.5 | done | 170 |
 | e48s06 | Add tier: field (core/extended/specialized) to OKF wiki inde | e48 | 2 | 2.5 | done | 10 |
 | e48s07 | Create publish-to-wiki kernel tool | e48 | 3 | 2.5 | done | 2 |
 | e48s08 | Add GitHub Action Template for publish-wiki.yml [HARD GATE] | e48 | 1 | 2.5 | done | 8 |
@@ -90,9 +90,9 @@
 | e48s14 | Build-epic integration — BCP Plus in story sizing workflow | e48 | 4 | 2.5 | done | 14 |
 | e48s15 | Refactor Skills Render Pipeline to Hybrid JSON Seam | e48 | 4 | 2.5 | done | 7 |
 | e51s01 | CONVENTIONS — Always Green, Shift Left, Discovered Defects,  | e51 | 3 | 7.0 | done | 8 |
-| e51s02 | seed-conventions — Preflight default, solo-git default, embe | e51 | 3 | 7.0 | done | 39 |
-| e51s03 | kickoff-branch + verify-work — Preflight hard block and CI g | e51 | 2 | 7.0 | done | 62 |
-| e51s04 | audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log rou | e51 | 2 | 7.0 | done | 625 |
+| e51s02 | seed-conventions — Preflight default, solo-git default, embe | e51 | 3 | 7.0 | done | 40 |
+| e51s03 | kickoff-branch + verify-work — Preflight hard block and CI g | e51 | 2 | 7.0 | done | 64 |
+| e51s04 | audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log rou | e51 | 2 | 7.0 | done | 321 |
 | e51s05 | CLAUDE.md — solo-default agent rules + bigpowers Preflight c | e51 | 2 | 7.0 | done | 7 |
 | e54s01 | Snapshot the current skill catalog as an immutable baseline | e54 | 2 | 6.7 | done | 9 |
 | e54s02 | Add a soft drift-detection gate for the freeze window | e54 | 3 | 6.7 | done | 14 |
@@ -100,7 +100,7 @@
 | e55s01 | Map every current doctrine source to a B0-B10 + Capstone blo | e55 | 0 | 6.0 | done | 8 |
 | e55s02 | Write constitution.md from the mapping, CLAUDE.md/CONVENTION | e55 | 0 | 6.0 | done | 5 |
 | e55s03 | Point CLAUDE.md/CONVENTIONS.md at constitution.md, don't del | e55 | 0 | 6.0 | done | 9 |
-| e60s01 | Interactive installer with ASCII banner, global/local, tool  | e60 | 0 | 9.0 | done | 8 |
+| e60s01 | Interactive installer with ASCII banner, global/local, tool  | e60 | 0 | 9.0 | done | 9 |
 | e61s01 | Hermes adapter + hook templates (Wave A) | e61 | 0 | 5.0 | done | 11 |
 | e61s02 | Install hub wiring (Wave B) | e61 | 0 | 5.0 | done | 15 |
 | e62s01 | Integration: OpenCode adapter (Wave A) | e62 | 0 | 4.0 | done | 3 |
@@ -129,6 +129,10 @@
 | e74s02 | Install hub wiring (Wave B) | e74 | 0 | 4.0 | done | 26 |
 | e76s01 | ZCode adapter — Wave A greenfield skills-dir | e76 | 0 | 5.0 | done | 8 |
 | e76s02 | Install hub wiring (Wave B) | e76 | 0 | 5.0 | done | 16 |
+| e79s01 | AGENTIC-STE ruleset document | e79 | 0 | 6.0 | backlog | 8 |
+| e79s02 | Validator script + craft-skill HARD GATE | e79 | 0 | 6.0 | backlog | 21 |
+| e79s03 | seed-conventions applies ruleset | e79 | 0 | 6.0 | backlog | 20 |
+| e79s04 | stocktake-skills violation scanner | e79 | 0 | 6.0 | backlog | 20 |
 
 ## Orphan Tags (tag in code, no matching story)
 
@@ -264,8 +268,6 @@
 - `e42s02`
 - `e42s03`
 - `e42s04`
-- `e43s01`
-- `e43s02`
 - `e44s01`
 - `e44s02`
 - `e44s03`

--- a/specs/benchmarks/reports/GOLDEN-2026-07-25.yaml
+++ b/specs/benchmarks/reports/GOLDEN-2026-07-25.yaml
@@ -1,5 +1,5 @@
-timestamp: "2026-07-25T03:38:11Z"
-git_commit: "d1993d31437bfbdb5bda81e84650628215365754"
+timestamp: "2026-07-25T05:21:25Z"
+git_commit: "094b731fb22f2fc1b4cddda1c9a9f692b69e1287"
 suite: "golden-combined"
 mode: "daily"
 deterministic:
@@ -11,51 +11,51 @@ deterministic:
 gates:
   - name: compliance
     exit_code: 0
-    duration_seconds: 80.16
+    duration_seconds: 197.99
     status: pass
   - name: g04-selftest
     exit_code: 0
-    duration_seconds: .04
+    duration_seconds: .17
     status: pass
   - name: g06-migrate-version
     exit_code: 0
-    duration_seconds: 9.07
+    duration_seconds: 70.94
     status: pass
   - name: g07-negative-path
     exit_code: 0
-    duration_seconds: .06
+    duration_seconds: .14
     status: pass
   - name: g08-anti-vacuity
     exit_code: 0
-    duration_seconds: .09
+    duration_seconds: .79
     status: pass
   - name: g09-yaml-roundtrip
     exit_code: 0
-    duration_seconds: .13
+    duration_seconds: 1.41
     status: pass
   - name: g10-trace-anti-vacuity
     exit_code: 0
-    duration_seconds: .11
+    duration_seconds: .94
     status: pass
   - name: g11-gitignore-venv
     exit_code: 0
-    duration_seconds: .08
+    duration_seconds: .15
     status: pass
   - name: install-helpers
     exit_code: 0
-    duration_seconds: .06
+    duration_seconds: .13
     status: pass
   - name: import-boundaries
     exit_code: 0
-    duration_seconds: .25
+    duration_seconds: .47
     status: pass
   - name: skill-catalog
     exit_code: 0
-    duration_seconds: 1.78
+    duration_seconds: 3.92
     status: pass
   - name: specs-parse
     exit_code: 0
-    duration_seconds: .84
+    duration_seconds: 5.49
     status: pass
 agent_stories:
   total: 0

--- a/specs/codebase-wiki/e37s01.md
+++ b/specs/codebase-wiki/e37s01.md
@@ -28,6 +28,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/epics/e79-agentic-ste/e79s03-seed-conventions.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/epics/archive/e51-always-green-shift-left/e51s01-conventions-always-green.md
     line: 0
     confidence: medium
@@ -91,6 +95,7 @@ links:
 - `.windsurf/rules/seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/wayfinder/doc-templates/tickets/T18-agents-and-conventions.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/epics/e79-agentic-ste/e79s03-seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/archive/e51-always-green-shift-left/e51s01-conventions-always-green.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/archive/e51-always-green-shift-left/e51s02-seed-preflight-default.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/archive/e51-always-green-shift-left/e51s05-claude-preflight-row.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e37s03.md
+++ b/specs/codebase-wiki/e37s03.md
@@ -24,6 +24,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/epics/e79-agentic-ste/e79s03-seed-conventions.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: .continue/rules/seed-conventions.md
     line: 0
     confidence: medium
@@ -58,6 +62,7 @@ links:
 - `specs/epics/archive/e37-reach/e37s03-aider-bridge.md` (line 1, confidence: high, method: explicit_tag)
 - `.windsurf/rules/seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/epics/e79-agentic-ste/e79s03-seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
 - `.continue/rules/seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
 - `website/src/content/docs/skills/seed-conventions.mdx` (line 0, confidence: medium, method: file_heuristic)
 - `.kilocode/rules/seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e37s06.md
+++ b/specs/codebase-wiki/e37s06.md
@@ -40,10 +40,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: website/src/content/docs/decisions/0007-agents-md-spine-context-derivatives.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/epics/archive/e37-reach/e37s08-tasks.yaml
     line: 0
     confidence: low
@@ -74,7 +70,6 @@ links:
 - `specs/verifications/steps/and-files-should-be-small-enough-to-avoid-context-window-truncation-300-lines.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-i-should-automatically-bootstrap-project-context-at-session-start.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/adr-wiki/0007-agents-md-spine-context-derivatives.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `website/src/content/docs/decisions/0007-agents-md-spine-context-derivatives.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/archive/e37-reach/e37s08-tasks.yaml` (line 0, confidence: low, method: task_reference)
 - `specs/epics/archive/e37-reach/e37s07-tasks.yaml` (line 0, confidence: low, method: task_reference)
 - `specs/epics/archive/e37-reach/e37s10-tasks.yaml` (line 0, confidence: low, method: task_reference)

--- a/specs/codebase-wiki/e37s14.md
+++ b/specs/codebase-wiki/e37s14.md
@@ -16,6 +16,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/epics/e79-agentic-ste/e79s03-seed-conventions.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/epics/archive/e37-reach/e37s14-seed-codex-wiring.md
     line: 0
     confidence: medium
@@ -56,6 +60,7 @@ links:
 
 - `.windsurf/rules/seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/epics/e79-agentic-ste/e79s03-seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/archive/e37-reach/e37s14-seed-codex-wiring.md` (line 0, confidence: medium, method: file_heuristic)
 - `.continue/rules/seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
 - `website/src/content/docs/skills/seed-conventions.mdx` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s09.md
+++ b/specs/codebase-wiki/e45s09.md
@@ -280,10 +280,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: website/dist/pagefind/pagefind-worker.js
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: website/src/content/docs/guides/WORKFLOW-SOP-v2.md
     line: 0
     confidence: medium
@@ -426,7 +422,6 @@ links:
 - `.continue/rules/verify-work.md` (line 0, confidence: medium, method: file_heuristic)
 - `.continue/rules/compose-workflow.md` (line 0, confidence: medium, method: file_heuristic)
 - `.continue/rules/organize-workspace.md` (line 0, confidence: medium, method: file_heuristic)
-- `website/dist/pagefind/pagefind-worker.js` (line 0, confidence: medium, method: file_heuristic)
 - `website/src/content/docs/guides/WORKFLOW-SOP-v2.md` (line 0, confidence: medium, method: file_heuristic)
 - `website/src/content/docs/skills/scope-work.mdx` (line 0, confidence: medium, method: file_heuristic)
 - `website/src/content/docs/skills/compose-workflow.mdx` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s12.md
+++ b/specs/codebase-wiki/e45s12.md
@@ -112,6 +112,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/epics/e79-agentic-ste/e79s02-validator-craft-skill.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/epics/archive/e37-reach/e37s10-wave-b-skills-dir.md
     line: 0
     confidence: medium
@@ -216,6 +220,7 @@ links:
 - `specs/verifications/steps/then-skills-should-include-bold-hard-gate-callout-blocks.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-craft-skill-sync-oversized.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-craft-skill-sync-oversized.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/epics/e79-agentic-ste/e79s02-validator-craft-skill.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/archive/e37-reach/e37s10-wave-b-skills-dir.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/archive/e12-pi-support/e12s04-sync-skills-pi-target.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/archive/e35-historical-refs/e35s10-cross-reference-skills.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s18.md
+++ b/specs/codebase-wiki/e45s18.md
@@ -88,14 +88,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190334.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-144556.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-175346.md
     line: 0
     confidence: medium
@@ -104,35 +96,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-102313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-103815.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163934.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202335.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145222.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165427.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-151538.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132836.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -144,23 +108,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-155647.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181947.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212931.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-160106.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-180858.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -169,34 +117,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-143153.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215320.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-132011.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-172717.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174039.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132651.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212830.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182718.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -209,14 +129,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-122420.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-154721.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183547.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -244,10 +156,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-160627.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-165137.md
     line: 0
     confidence: medium
@@ -256,31 +164,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-205519.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-131516.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101228.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-102150.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214411.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260622-001710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-165047.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -289,26 +173,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-000102.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-131912.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-132538.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133327.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001605.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105239.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -324,39 +188,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101847.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173628.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182629.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-161434.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154217.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-165703.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-143839.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163159.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260711-001225.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -368,23 +204,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-185319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183644.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260629-132810.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001328.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -396,19 +216,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-202226.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164609.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192340.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165651.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -420,31 +228,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-160550.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-134603.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091641.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163954.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-210053.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190002.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-093104.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -453,18 +237,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164251.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132615.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-172212.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-140513.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -484,23 +256,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154135.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170532.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154323.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-082500.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101730.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -512,75 +272,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-165007.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-205711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-182236.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-135136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-103737.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-093242.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-213042.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-134029.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164826.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-162400.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110426.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-223023.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-134126.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-162245.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-105652.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-114127.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-164053.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154055.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -596,19 +292,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164801.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131809.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-175313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181604.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -624,27 +308,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-110149.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-131715.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-133750.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-181656.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174414.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -652,15 +316,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192541.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-233740.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173515.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -668,35 +324,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190415.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192435.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-094025.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-161022.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-125910.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215656.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-135950.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092605.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -712,14 +340,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154936.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132530.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174045.md
     line: 0
     confidence: medium
@@ -732,23 +352,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091938.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-133945.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174055.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001312.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110458.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -788,39 +392,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105145.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-193609.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174351.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-154353.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-131211.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-130715.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182555.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-124641.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -832,23 +408,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120114.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-234357.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110242.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-143756.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-235505.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -857,14 +417,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-160732.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-145214.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-161026.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -880,10 +432,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001100.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-150417.md
     line: 0
     confidence: medium
@@ -896,15 +444,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-151437.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-143504.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-185913.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -912,19 +452,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-140559.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001518.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-184837.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -940,35 +468,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-154541.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-105728.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-111510.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-180901.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-133532.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145423.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-105643.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-141624.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -984,18 +488,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181236.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163830.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092533.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174025.md
     line: 0
     confidence: medium
@@ -1004,39 +496,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145349.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-164643.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-205433.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132944.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163746.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-091141.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184856.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-143844.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133446.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1048,39 +508,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-182836.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202450.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194130.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-213831.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174245.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-005800.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-173348.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-165006.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1092,19 +524,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-005225.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-143007.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-171058.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-150742.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1113,10 +533,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165618.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-130546.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1148,35 +564,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-154637.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001919.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-144757.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-220941.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174117.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-093202.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110206.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120150.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1192,31 +580,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131734.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182807.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173917.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-185210.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-101322.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165256.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192433.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1224,27 +588,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105013.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-200110.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-114242.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001233.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-130623.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-162439.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1252,27 +596,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002229.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-144202.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183102.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-133837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-233707.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212919.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1288,19 +616,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164345.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120250.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165035.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-112952.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1312,43 +628,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194053.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001439.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202651.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-165120.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-143840.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-000955.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-144557.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174133.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115538.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-113034.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1360,39 +644,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-161502.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170255.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164704.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132813.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164342.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-154344.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-120815.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-164833.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154835.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1404,27 +660,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-155747.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173218.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260626-204822.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202348.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-161543.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1436,10 +676,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-113257.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-181044.md
     line: 0
     confidence: medium
@@ -1448,27 +684,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-133458.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164823.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-180900.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-104009.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-163929.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1481,10 +697,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-081735.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-154818.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1504,10 +716,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170738.md
     line: 0
     confidence: medium
@@ -1521,10 +729,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-153801.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194215.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1544,23 +748,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084719.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132017.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-171157.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183350.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-150937.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1576,14 +764,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-110050.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001337.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260627-133613.md
     line: 0
     confidence: medium
@@ -1596,10 +776,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-220404.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-085740.md
     line: 0
     confidence: medium
@@ -1608,27 +784,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-193756.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163218.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163309.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-130821.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-160906.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-094142.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1640,15 +796,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202442.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164036.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1664,39 +812,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214125.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-164249.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132604.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-142359.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-163353.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132933.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-175550.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174408.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-163120.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1708,10 +828,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182339.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165418.md
     line: 0
     confidence: medium
@@ -1720,11 +836,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-155114.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133637.md
+  - file: specs/verifications/reports/audit-cleancode-20260725-021918.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1736,15 +848,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-131140.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165111.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-144700.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1780,7 +884,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202558.md
+  - file: specs/verifications/reports/audit-cleancode-20260725-022131.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1788,31 +892,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-163657.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215213.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-160919.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-204345.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-153739.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175227.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1821,42 +901,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-225313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164721.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-093336.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132207.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130940.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105058.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-163457.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084617.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084805.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174631.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1872,35 +916,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002322.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-220022.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-135838.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-093012.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-152233.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-131617.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181159.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1912,10 +928,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131350.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-083101.md
     line: 0
     confidence: medium
@@ -1924,23 +936,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115557.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-114525.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-093128.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-221847.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-154451.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1948,51 +944,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212552.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-161624.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181706.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-105035.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092013.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001702.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132130.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-163956.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001902.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-093246.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-204300.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2008,14 +960,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132858.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165902.md
     line: 0
     confidence: medium
@@ -2024,19 +968,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001029.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-172425.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145255.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-133730.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2044,51 +976,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175929.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-172525.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133254.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184658.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164258.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-164418.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194009.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-092924.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260629-130359.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130821.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190539.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2100,27 +992,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-163613.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-142458.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-005318.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-235409.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001952.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2132,27 +1004,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002154.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-171134.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-182630.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165733.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091717.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084911.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2168,31 +1020,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182346.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115503.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-101402.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-231038.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-123626.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184355.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-172751.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2200,27 +1028,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101633.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130900.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-103924.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101425.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-163837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175105.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2236,15 +1044,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-234704.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163238.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-172133.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2252,19 +1052,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214329.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-144506.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-210010.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173306.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2281,10 +1069,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-151341.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131314.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2366,172 +1150,73 @@ links:
 - `specs/skills-wiki/skills/security-review.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/audit-code.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/wayfinder/doc-templates/tickets/T14-security-review.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190334.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-144556.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-175346.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-165245.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-102313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-103815.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163934.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202335.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145222.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165427.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-151538.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132836.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180022.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163733.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-155647.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181947.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212931.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160106.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-180858.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181109.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143153.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215320.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-132011.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-172717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174039.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132651.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212830.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182718.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170744.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005609.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-122420.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-154721.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183547.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-205129.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-081618.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-162136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234209.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-160627.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-165137.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223301.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-205519.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-131516.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101228.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-102150.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214411.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260622-001710.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-165047.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165920.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000102.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-131912.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-132538.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133327.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001605.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105239.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181904.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150326.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170432.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101847.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173628.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182629.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-161434.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154217.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-165703.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-143839.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163159.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260711-001225.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-010055.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163108.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-185319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183644.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215759.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132810.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001328.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-235439.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164718.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-202226.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192340.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165651.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172406.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173408.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-160550.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-134603.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091641.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163954.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-210053.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190002.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-093104.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-222132.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164251.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132615.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-172212.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-140513.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170547.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173125.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180244.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170506.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154135.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170532.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154323.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082500.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101730.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170710.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-205844.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-165007.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-205711.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-182236.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-135136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-103737.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-093242.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-213042.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-134029.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164826.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-162400.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110426.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223023.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-134126.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-162245.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-105652.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-114127.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-164053.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154055.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170704.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173014.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174734.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164801.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131809.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181604.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163821.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-201018.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-165945.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-110149.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-131715.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-133750.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105711.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181656.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174414.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142931.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192541.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-233740.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173515.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-090946.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190415.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192435.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-094025.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-161022.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-125910.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215656.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-135950.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092605.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-225914.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165619.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154936.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132530.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174045.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-131004.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091938.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-133945.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174055.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001312.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164534.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005128.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-235526.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2541,89 +1226,42 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260703-005444.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223636.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181759.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105145.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-193609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174351.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154353.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-131211.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130715.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182555.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-124641.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-083430.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080042.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120114.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234357.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110242.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-143756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-235505.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-220905.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160732.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-145214.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-161026.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164627.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143840.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-214041.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001100.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150417.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155813.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164603.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-151437.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143504.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-185913.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-154427.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-140559.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001518.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-184837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170909.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154246.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-154541.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-105728.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-111510.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180901.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-133532.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145423.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-105643.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-141624.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164911.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174207.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181236.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163830.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092533.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174025.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204652.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145349.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-164643.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-205433.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132944.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163746.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-091141.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184856.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-143844.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133446.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-154339.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223425.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-182836.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202450.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133710.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194130.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-213831.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174245.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005800.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173348.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-165006.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005515.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165022.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-005225.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-143007.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-171058.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-150742.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164733.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165618.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-130546.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164707.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155946.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170347.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2631,156 +1269,78 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260704-083149.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170223.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164441.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-154637.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001919.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-144757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-220941.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174117.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-093202.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110206.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120150.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080057.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170448.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131734.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182807.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173917.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-185210.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-101322.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165256.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192433.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165207.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105013.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200110.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-114242.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001233.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-130623.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-162439.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130939.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002229.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-144202.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183102.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-133837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-233707.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212919.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163256.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005720.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164345.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120250.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165035.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-112952.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130756.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130915.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194053.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001439.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202651.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-165120.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-143840.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-000955.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-144557.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174133.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115538.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-113034.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164833.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181114.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-161502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170255.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164704.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132813.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164342.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-154344.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-120815.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-164833.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154835.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165959.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164817.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164759.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155747.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173218.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204822.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202348.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-161543.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155551.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-125842.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-113257.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181044.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223249.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-133458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164823.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-180900.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-104009.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-163929.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234324.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180916.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-081735.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-154818.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-161735.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005423.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130845.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200055.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170738.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163839.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005546.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153801.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194215.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200030.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-004248.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154311.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204755.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084719.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132017.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-171157.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183350.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-150937.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-091017.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082326.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175521.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-110050.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001337.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260627-133613.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-195653.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005358.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-220404.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-085740.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-193756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163218.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163309.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130821.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-160906.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-094142.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-145833.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142423.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202442.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164036.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165346.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080024.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142902.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214125.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-164249.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132604.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-163353.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132933.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175550.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174408.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-163120.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-080343.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082306.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182339.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165418.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143447.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-155114.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133637.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260725-021918.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005655.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165222.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-131140.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165111.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-144700.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154214.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181546.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165807.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2789,133 +1349,53 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260629-132750.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164343.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163338.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202558.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260725-022131.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170940.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-163657.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215213.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-160919.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-204345.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212711.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153739.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175227.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180125.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-225313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164721.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-093336.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132207.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130940.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105058.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-163457.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084617.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084805.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174631.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174148.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000357.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-222115.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002322.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-220022.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164429.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-135838.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-093012.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-152233.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-131617.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181159.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164518.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131350.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-083101.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-214501.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115557.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-114525.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-093128.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-221847.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-154451.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-004226.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212552.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-161624.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181706.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-105035.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092013.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001702.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132130.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182429.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163956.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001902.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-093246.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-204300.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164141.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173033.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164050.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132858.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174710.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165902.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005336.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001029.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172425.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145255.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-133730.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154726.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154759.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175929.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172525.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133254.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184658.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164258.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-164418.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194009.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-092924.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130821.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190539.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170706.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170757.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-163613.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173429.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142458.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-005318.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-235409.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001952.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-195845.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-164155.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002154.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-171134.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-182630.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165733.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084911.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130700.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172925.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182346.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115503.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-101402.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-231038.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-123626.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184355.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-172751.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170431.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101633.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130900.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-103924.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101425.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163837.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175105.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000548.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150200.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175152.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-234704.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163238.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-172133.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180948.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214329.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-144506.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-210010.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173306.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260622-001925.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164958.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165537.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-151341.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131314.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-185054.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-audit-code-auditor-oversized.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-audit-code-auditor-oversized.okf.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s21.md
+++ b/specs/codebase-wiki/e45s21.md
@@ -13,7 +13,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .gemini/extensions/bigpowers/commands/prompts/seed-conventions.md
-    line: 106
+    line: 123
     confidence: high
     method: explicit_tag
   - file: .gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md
@@ -21,7 +21,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md
-    line: 108
+    line: 125
     confidence: high
     method: explicit_tag
   - file: .trae/skills/seed-conventions/SKILL.md
@@ -29,7 +29,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .trae/skills/seed-conventions/SKILL.md
-    line: 107
+    line: 124
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/seed-conventions.md
@@ -37,7 +37,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/seed-conventions.md
-    line: 107
+    line: 124
     confidence: high
     method: explicit_tag
   - file: .agents/skills/seed-conventions/SKILL.md
@@ -45,7 +45,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .agents/skills/seed-conventions/SKILL.md
-    line: 107
+    line: 124
     confidence: high
     method: explicit_tag
   - file: docs/templates/AGENTS.md
@@ -57,7 +57,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .kilocode/rules/seed-conventions.md
-    line: 107
+    line: 124
     confidence: high
     method: explicit_tag
   - file: .codex/skills/seed-conventions/SKILL.md
@@ -65,7 +65,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .codex/skills/seed-conventions/SKILL.md
-    line: 107
+    line: 124
     confidence: high
     method: explicit_tag
   - file: skills/seed-conventions/REFERENCE.md
@@ -81,7 +81,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .codebuddy/skills/seed-conventions/SKILL.md
-    line: 107
+    line: 124
     confidence: high
     method: explicit_tag
   - file: .zcode/skills/seed-conventions/SKILL.md
@@ -89,7 +89,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .zcode/skills/seed-conventions/SKILL.md
-    line: 107
+    line: 124
     confidence: high
     method: explicit_tag
   - file: .mimocode/skills/seed-conventions/SKILL.md
@@ -97,7 +97,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .mimocode/skills/seed-conventions/SKILL.md
-    line: 107
+    line: 124
     confidence: high
     method: explicit_tag
   - file: .hermes/skills/seed-conventions/SKILL.md
@@ -105,7 +105,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .hermes/skills/seed-conventions/SKILL.md
-    line: 107
+    line: 124
     confidence: high
     method: explicit_tag
   - file: .pi/prompts/seed-conventions.md
@@ -113,7 +113,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .pi/prompts/seed-conventions.md
-    line: 106
+    line: 123
     confidence: high
     method: explicit_tag
   - file: .pi/skills/seed-conventions/SKILL.md
@@ -121,10 +121,14 @@ links:
     confidence: high
     method: explicit_tag
   - file: .pi/skills/seed-conventions/SKILL.md
-    line: 107
+    line: 124
     confidence: high
     method: explicit_tag
   - file: specs/skills-wiki/skills/seed-conventions.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/epics/e79-agentic-ste/e79s03-seed-conventions.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -147,34 +151,35 @@ links:
 ## Implemented In
 
 - `.gemini/extensions/bigpowers/commands/prompts/seed-conventions.md` (line 10, confidence: high, method: explicit_tag)
-- `.gemini/extensions/bigpowers/commands/prompts/seed-conventions.md` (line 106, confidence: high, method: explicit_tag)
+- `.gemini/extensions/bigpowers/commands/prompts/seed-conventions.md` (line 123, confidence: high, method: explicit_tag)
 - `.gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md` (line 12, confidence: high, method: explicit_tag)
-- `.gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md` (line 108, confidence: high, method: explicit_tag)
+- `.gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md` (line 125, confidence: high, method: explicit_tag)
 - `.trae/skills/seed-conventions/SKILL.md` (line 11, confidence: high, method: explicit_tag)
-- `.trae/skills/seed-conventions/SKILL.md` (line 107, confidence: high, method: explicit_tag)
+- `.trae/skills/seed-conventions/SKILL.md` (line 124, confidence: high, method: explicit_tag)
 - `.windsurf/rules/seed-conventions.md` (line 11, confidence: high, method: explicit_tag)
-- `.windsurf/rules/seed-conventions.md` (line 107, confidence: high, method: explicit_tag)
+- `.windsurf/rules/seed-conventions.md` (line 124, confidence: high, method: explicit_tag)
 - `.agents/skills/seed-conventions/SKILL.md` (line 11, confidence: high, method: explicit_tag)
-- `.agents/skills/seed-conventions/SKILL.md` (line 107, confidence: high, method: explicit_tag)
+- `.agents/skills/seed-conventions/SKILL.md` (line 124, confidence: high, method: explicit_tag)
 - `docs/templates/AGENTS.md` (line 2, confidence: high, method: explicit_tag)
 - `.kilocode/rules/seed-conventions.md` (line 11, confidence: high, method: explicit_tag)
-- `.kilocode/rules/seed-conventions.md` (line 107, confidence: high, method: explicit_tag)
+- `.kilocode/rules/seed-conventions.md` (line 124, confidence: high, method: explicit_tag)
 - `.codex/skills/seed-conventions/SKILL.md` (line 11, confidence: high, method: explicit_tag)
-- `.codex/skills/seed-conventions/SKILL.md` (line 107, confidence: high, method: explicit_tag)
+- `.codex/skills/seed-conventions/SKILL.md` (line 124, confidence: high, method: explicit_tag)
 - `skills/seed-conventions/REFERENCE.md` (line 2, confidence: high, method: explicit_tag)
 - `skills/seed-conventions/SKILL.md` (line 12, confidence: high, method: explicit_tag)
 - `.codebuddy/skills/seed-conventions/SKILL.md` (line 11, confidence: high, method: explicit_tag)
-- `.codebuddy/skills/seed-conventions/SKILL.md` (line 107, confidence: high, method: explicit_tag)
+- `.codebuddy/skills/seed-conventions/SKILL.md` (line 124, confidence: high, method: explicit_tag)
 - `.zcode/skills/seed-conventions/SKILL.md` (line 11, confidence: high, method: explicit_tag)
-- `.zcode/skills/seed-conventions/SKILL.md` (line 107, confidence: high, method: explicit_tag)
+- `.zcode/skills/seed-conventions/SKILL.md` (line 124, confidence: high, method: explicit_tag)
 - `.mimocode/skills/seed-conventions/SKILL.md` (line 11, confidence: high, method: explicit_tag)
-- `.mimocode/skills/seed-conventions/SKILL.md` (line 107, confidence: high, method: explicit_tag)
+- `.mimocode/skills/seed-conventions/SKILL.md` (line 124, confidence: high, method: explicit_tag)
 - `.hermes/skills/seed-conventions/SKILL.md` (line 11, confidence: high, method: explicit_tag)
-- `.hermes/skills/seed-conventions/SKILL.md` (line 107, confidence: high, method: explicit_tag)
+- `.hermes/skills/seed-conventions/SKILL.md` (line 124, confidence: high, method: explicit_tag)
 - `.pi/prompts/seed-conventions.md` (line 10, confidence: high, method: explicit_tag)
-- `.pi/prompts/seed-conventions.md` (line 106, confidence: high, method: explicit_tag)
+- `.pi/prompts/seed-conventions.md` (line 123, confidence: high, method: explicit_tag)
 - `.pi/skills/seed-conventions/SKILL.md` (line 11, confidence: high, method: explicit_tag)
-- `.pi/skills/seed-conventions/SKILL.md` (line 107, confidence: high, method: explicit_tag)
+- `.pi/skills/seed-conventions/SKILL.md` (line 124, confidence: high, method: explicit_tag)
 - `specs/skills-wiki/skills/seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/epics/e79-agentic-ste/e79s03-seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
 - `.continue/rules/seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
 - `website/src/content/docs/skills/seed-conventions.mdx` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s31.md
+++ b/specs/codebase-wiki/e45s31.md
@@ -56,14 +56,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190334.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-144556.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-175346.md
     line: 0
     confidence: medium
@@ -72,35 +64,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-102313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-103815.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163934.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202335.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145222.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165427.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-151538.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132836.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -112,23 +76,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-155647.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181947.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212931.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-160106.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-180858.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -137,34 +85,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-143153.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215320.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-132011.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-172717.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174039.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132651.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212830.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182718.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -177,14 +97,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-122420.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-154721.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183547.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -212,10 +124,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-160627.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-165137.md
     line: 0
     confidence: medium
@@ -224,31 +132,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-205519.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-131516.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101228.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-102150.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214411.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260622-001710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-165047.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -257,26 +141,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-000102.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-131912.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-132538.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133327.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001605.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105239.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -292,39 +156,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101847.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173628.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182629.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-161434.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154217.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-165703.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-143839.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163159.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260711-001225.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -336,23 +172,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-185319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183644.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260629-132810.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001328.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -364,19 +184,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-202226.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164609.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192340.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165651.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -388,31 +196,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-160550.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-134603.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091641.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163954.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-210053.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190002.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-093104.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -421,18 +205,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164251.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132615.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-172212.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-140513.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -452,23 +224,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154135.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170532.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154323.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-082500.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101730.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -480,75 +240,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-165007.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-205711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-182236.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-135136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-103737.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-093242.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-213042.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-134029.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164826.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-162400.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110426.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-223023.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-134126.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-162245.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-105652.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-114127.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-164053.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154055.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -564,19 +260,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164801.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131809.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-175313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181604.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -592,27 +276,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-110149.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-131715.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-133750.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-181656.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174414.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -620,15 +284,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192541.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-233740.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173515.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -636,35 +292,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190415.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192435.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-094025.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-161022.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-125910.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215656.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-135950.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092605.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -680,14 +308,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154936.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132530.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174045.md
     line: 0
     confidence: medium
@@ -700,23 +320,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091938.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-133945.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174055.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001312.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110458.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -756,39 +360,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105145.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-193609.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174351.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-154353.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-131211.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-130715.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182555.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-124641.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -800,23 +376,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120114.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-234357.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110242.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-143756.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-235505.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -825,14 +385,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-160732.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-145214.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-161026.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -848,10 +400,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001100.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-150417.md
     line: 0
     confidence: medium
@@ -864,15 +412,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-151437.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-143504.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-185913.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -880,19 +420,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-140559.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001518.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-184837.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -908,35 +436,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-154541.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-105728.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-111510.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-180901.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-133532.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145423.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-105643.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-141624.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -952,18 +456,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181236.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163830.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092533.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174025.md
     line: 0
     confidence: medium
@@ -972,39 +464,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145349.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-164643.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-205433.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132944.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163746.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-091141.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184856.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-143844.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133446.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1016,39 +476,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-182836.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202450.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194130.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-213831.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174245.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-005800.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-173348.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-165006.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1060,19 +492,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-005225.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-143007.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-171058.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-150742.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1081,10 +501,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165618.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-130546.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1116,35 +532,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-154637.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001919.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-144757.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-220941.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174117.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-093202.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110206.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120150.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1160,31 +548,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131734.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182807.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173917.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-185210.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-101322.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165256.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192433.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1192,27 +556,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105013.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-200110.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-114242.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001233.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-130623.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-162439.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1220,27 +564,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002229.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-144202.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183102.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-133837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-233707.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212919.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1256,19 +584,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164345.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120250.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165035.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-112952.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1280,43 +596,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194053.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001439.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202651.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-165120.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-143840.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-000955.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-144557.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174133.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115538.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-113034.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1328,39 +612,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-161502.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170255.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164704.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132813.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164342.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-154344.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-120815.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-164833.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154835.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1372,27 +628,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-155747.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173218.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260626-204822.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202348.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-161543.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1404,10 +644,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-113257.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-181044.md
     line: 0
     confidence: medium
@@ -1416,27 +652,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-133458.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164823.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-180900.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-104009.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-163929.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1449,10 +665,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-081735.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-154818.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1472,10 +684,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170738.md
     line: 0
     confidence: medium
@@ -1489,10 +697,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-153801.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194215.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1512,23 +716,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084719.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132017.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-171157.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183350.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-150937.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1544,14 +732,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-110050.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001337.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260627-133613.md
     line: 0
     confidence: medium
@@ -1564,10 +744,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-220404.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-085740.md
     line: 0
     confidence: medium
@@ -1576,27 +752,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-193756.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163218.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163309.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-130821.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-160906.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-094142.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1608,15 +764,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202442.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164036.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1632,39 +780,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214125.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-164249.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132604.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-142359.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-163353.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132933.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-175550.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174408.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-163120.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1676,10 +796,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182339.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165418.md
     line: 0
     confidence: medium
@@ -1688,11 +804,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-155114.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133637.md
+  - file: specs/verifications/reports/audit-cleancode-20260725-021918.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1704,15 +816,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-131140.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165111.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-144700.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1748,7 +852,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202558.md
+  - file: specs/verifications/reports/audit-cleancode-20260725-022131.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1756,31 +860,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-163657.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215213.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-160919.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-204345.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-153739.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175227.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1789,42 +869,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-225313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164721.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-093336.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132207.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130940.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105058.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-163457.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084617.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084805.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174631.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1840,35 +884,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002322.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-220022.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-135838.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-093012.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-152233.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-131617.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181159.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1880,10 +896,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131350.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-083101.md
     line: 0
     confidence: medium
@@ -1892,23 +904,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115557.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-114525.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-093128.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-221847.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-154451.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1916,51 +912,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212552.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-161624.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181706.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-105035.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092013.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001702.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132130.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-163956.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001902.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-093246.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-204300.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1976,14 +928,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132858.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165902.md
     line: 0
     confidence: medium
@@ -1992,19 +936,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001029.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-172425.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145255.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-133730.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2012,51 +944,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175929.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-172525.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133254.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184658.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164258.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-164418.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194009.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-092924.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260629-130359.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130821.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190539.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2068,27 +960,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-163613.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-142458.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-005318.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-235409.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001952.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2100,27 +972,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002154.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-171134.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-182630.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165733.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091717.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084911.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2136,31 +988,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182346.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115503.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-101402.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-231038.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-123626.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184355.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-172751.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2168,27 +996,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101633.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130900.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-103924.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101425.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-163837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175105.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2204,15 +1012,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-234704.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163238.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-172133.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2220,19 +1020,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214329.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-144506.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-210010.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173306.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2249,10 +1037,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-151341.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131314.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2318,172 +1102,73 @@ links:
 - `specs/verifications/steps/and-there-should-be-no-commented-out-code-c5.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-there-should-be-no-code-duplication-dry-g5.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-there-should-be-no-redundant-comments-that-restate-code.sh` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190334.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-144556.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-175346.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-165245.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-102313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-103815.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163934.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202335.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145222.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165427.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-151538.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132836.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180022.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163733.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-155647.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181947.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212931.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160106.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-180858.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181109.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143153.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215320.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-132011.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-172717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174039.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132651.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212830.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182718.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170744.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005609.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-122420.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-154721.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183547.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-205129.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-081618.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-162136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234209.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-160627.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-165137.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223301.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-205519.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-131516.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101228.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-102150.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214411.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260622-001710.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-165047.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165920.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000102.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-131912.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-132538.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133327.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001605.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105239.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181904.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150326.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170432.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101847.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173628.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182629.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-161434.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154217.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-165703.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-143839.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163159.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260711-001225.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-010055.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163108.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-185319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183644.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215759.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132810.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001328.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-235439.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164718.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-202226.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192340.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165651.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172406.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173408.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-160550.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-134603.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091641.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163954.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-210053.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190002.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-093104.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-222132.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164251.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132615.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-172212.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-140513.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170547.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173125.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180244.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170506.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154135.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170532.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154323.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082500.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101730.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170710.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-205844.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-165007.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-205711.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-182236.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-135136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-103737.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-093242.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-213042.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-134029.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164826.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-162400.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110426.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223023.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-134126.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-162245.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-105652.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-114127.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-164053.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154055.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170704.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173014.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174734.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164801.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131809.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181604.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163821.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-201018.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-165945.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-110149.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-131715.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-133750.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105711.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181656.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174414.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142931.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192541.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-233740.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173515.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-090946.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190415.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192435.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-094025.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-161022.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-125910.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215656.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-135950.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092605.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-225914.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165619.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154936.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132530.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174045.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-131004.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091938.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-133945.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174055.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001312.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164534.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005128.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-235526.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2493,89 +1178,42 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260703-005444.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223636.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181759.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105145.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-193609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174351.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154353.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-131211.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130715.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182555.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-124641.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-083430.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080042.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120114.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234357.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110242.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-143756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-235505.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-220905.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160732.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-145214.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-161026.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164627.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143840.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-214041.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001100.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150417.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155813.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164603.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-151437.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143504.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-185913.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-154427.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-140559.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001518.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-184837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170909.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154246.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-154541.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-105728.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-111510.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180901.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-133532.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145423.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-105643.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-141624.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164911.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174207.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181236.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163830.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092533.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174025.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204652.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145349.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-164643.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-205433.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132944.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163746.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-091141.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184856.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-143844.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133446.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-154339.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223425.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-182836.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202450.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133710.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194130.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-213831.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174245.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005800.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173348.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-165006.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005515.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165022.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-005225.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-143007.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-171058.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-150742.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164733.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165618.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-130546.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164707.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155946.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170347.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2583,156 +1221,78 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260704-083149.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170223.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164441.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-154637.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001919.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-144757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-220941.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174117.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-093202.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110206.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120150.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080057.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170448.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131734.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182807.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173917.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-185210.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-101322.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165256.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192433.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165207.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105013.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200110.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-114242.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001233.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-130623.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-162439.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130939.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002229.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-144202.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183102.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-133837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-233707.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212919.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163256.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005720.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164345.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120250.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165035.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-112952.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130756.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130915.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194053.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001439.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202651.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-165120.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-143840.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-000955.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-144557.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174133.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115538.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-113034.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164833.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181114.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-161502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170255.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164704.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132813.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164342.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-154344.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-120815.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-164833.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154835.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165959.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164817.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164759.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155747.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173218.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204822.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202348.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-161543.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155551.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-125842.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-113257.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181044.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223249.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-133458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164823.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-180900.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-104009.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-163929.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234324.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180916.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-081735.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-154818.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-161735.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005423.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130845.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200055.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170738.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163839.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005546.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153801.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194215.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200030.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-004248.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154311.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204755.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084719.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132017.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-171157.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183350.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-150937.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-091017.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082326.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175521.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-110050.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001337.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260627-133613.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-195653.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005358.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-220404.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-085740.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-193756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163218.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163309.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130821.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-160906.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-094142.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-145833.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142423.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202442.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164036.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165346.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080024.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142902.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214125.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-164249.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132604.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-163353.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132933.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175550.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174408.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-163120.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-080343.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082306.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182339.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165418.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143447.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-155114.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133637.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260725-021918.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005655.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165222.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-131140.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165111.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-144700.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154214.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181546.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165807.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2741,133 +1301,53 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260629-132750.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164343.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163338.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202558.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260725-022131.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170940.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-163657.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215213.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-160919.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-204345.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212711.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153739.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175227.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180125.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-225313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164721.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-093336.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132207.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130940.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105058.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-163457.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084617.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084805.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174631.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174148.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000357.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-222115.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002322.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-220022.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164429.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-135838.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-093012.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-152233.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-131617.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181159.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164518.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131350.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-083101.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-214501.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115557.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-114525.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-093128.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-221847.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-154451.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-004226.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212552.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-161624.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181706.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-105035.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092013.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001702.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132130.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182429.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163956.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001902.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-093246.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-204300.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164141.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173033.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164050.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132858.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174710.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165902.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005336.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001029.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172425.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145255.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-133730.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154726.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154759.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175929.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172525.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133254.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184658.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164258.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-164418.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194009.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-092924.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130821.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190539.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170706.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170757.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-163613.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173429.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142458.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-005318.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-235409.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001952.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-195845.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-164155.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002154.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-171134.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-182630.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165733.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084911.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130700.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172925.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182346.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115503.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-101402.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-231038.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-123626.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184355.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-172751.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170431.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101633.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130900.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-103924.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101425.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163837.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175105.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000548.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150200.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175152.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-234704.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163238.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-172133.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180948.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214329.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-144506.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-210010.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173306.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260622-001925.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164958.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165537.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-151341.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131314.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-185054.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-audit-code-auditor-oversized.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-audit-code-auditor-oversized.okf.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e48s01.md
+++ b/specs/codebase-wiki/e48s01.md
@@ -56,6 +56,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/bugs/BUG-2026-07-25-land-branch-protected.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/bugs/BUG-2026-07-23-epics-wiki-empty-references.okf.md
     line: 0
     confidence: medium
@@ -101,10 +105,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: .continue/rules/maintain-wiki.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: website/src/content/docs/skills/maintain-wiki.mdx
     line: 0
     confidence: medium
     method: file_heuristic
@@ -162,6 +162,7 @@ links:
 - `.windsurf/rules/maintain-wiki.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-complex-logic-should-include-provenance-links-adrs-jira-or-commits.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-evolve-skill-sync-oversized.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/bugs/BUG-2026-07-25-land-branch-protected.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-23-epics-wiki-empty-references.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-24-installer-spinner-freezes-during-sync.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-23-epics-wiki-empty-references.md` (line 0, confidence: medium, method: file_heuristic)
@@ -174,7 +175,6 @@ links:
 - `specs/epics/archive/e39-knowledge-graph/e39s08-integrate-maintain-wiki.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/archive/e39-knowledge-graph/e39s07-maintain-wiki-skill.md` (line 0, confidence: medium, method: file_heuristic)
 - `.continue/rules/maintain-wiki.md` (line 0, confidence: medium, method: file_heuristic)
-- `website/src/content/docs/skills/maintain-wiki.mdx` (line 0, confidence: medium, method: file_heuristic)
 - `docs/references/agent-config-files-and-okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `.kilocode/rules/maintain-wiki.md` (line 0, confidence: medium, method: file_heuristic)
 - `scripts/okf-post-sync.sh` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e48s02.md
+++ b/specs/codebase-wiki/e48s02.md
@@ -36,55 +36,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-09.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-18.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/GOLDEN-2026-07-05.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-06.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-07.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-23.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-24.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-13.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-23.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-07.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-21.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-06.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-18.okf.md
+  - file: specs/verifications/reports/GOLDEN-2026-07-25.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -92,23 +48,15 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-09.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-13.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-11.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-24.okf.md
+  - file: specs/verifications/reports/audit-2026-07-25.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/bugs/BUG-2026-07-06-g06-migrate-version-golden.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/bugs/BUG-2026-07-25-land-branch-protected.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -197,25 +145,12 @@ links:
 - `specs/verifications/steps/and-every-change-should-include-runnable-tests-as-verification.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-tests-should-be-fast-and-run-with-a-single-command-t9.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-the-skill-packaging-pipeline-round-trips-a-golden-fixture-without-data-loss.sh` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-09.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-18.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-05.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-06.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-07.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-23.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-24.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-13.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-23.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-07.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-21.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-06.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-18.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/GOLDEN-2026-07-25.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-05.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-09.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-13.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-11.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-24.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-2026-07-25.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-g06-migrate-version-golden.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/bugs/BUG-2026-07-25-land-branch-protected.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-07-e48-audit-gaps.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-run-evals-golden-suite-oversized.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-03-golden-lock-stale-e37-ids.okf.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e48s03.md
+++ b/specs/codebase-wiki/e48s03.md
@@ -100,6 +100,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/bugs/BUG-2026-07-25-land-branch-protected.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/bugs/BUG-2026-07-06T205700.okf.md
     line: 0
     confidence: medium
@@ -496,6 +500,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/bugs/BUG-2026-07-25-land-branch-protected.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/bugs/BUG-2026-06-11T183000.md
     line: 0
     confidence: medium
@@ -568,10 +576,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: bigpowers-showcase/specs/bugs/BUG-2026-07-05-race-condition.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
 ---
 
 # e48s03: OKF-ify bug-registry: specs/bugs/registry.yaml emits concept bundles per bug
@@ -605,6 +609,7 @@ links:
 - `specs/bugs/BUG-2026-07-04-stale-bak-features.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06T134600-github-pages-deploy-flaky.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-gate-trace-matrix-oversized.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/bugs/BUG-2026-07-25-land-branch-protected.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06T205700.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-04-stale-bak-features.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-09-dead-function-build-skill-graph.okf.md` (line 0, confidence: medium, method: file_heuristic)
@@ -704,6 +709,7 @@ links:
 - `specs/bugs/BUG-2026-07-09T033939-golden-g01-submodule-checkout.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-07-compliance-record-cycle-time-oversized.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-07-compliance-boolean-chains-g28.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/bugs/BUG-2026-07-25-land-branch-protected.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-06-11T183000.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-03T020000.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-craft-skill-sync-oversized.okf.md` (line 0, confidence: medium, method: file_heuristic)
@@ -722,4 +728,3 @@ links:
 - `.kilocode/rules/fix-bug.md` (line 0, confidence: medium, method: file_heuristic)
 - `.kilocode/rules/investigate-bug.md` (line 0, confidence: medium, method: file_heuristic)
 - `scripts/sync-bugs-registry.sh` (line 0, confidence: medium, method: file_heuristic)
-- `bigpowers-showcase/specs/bugs/BUG-2026-07-05-race-condition.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e48s05.md
+++ b/specs/codebase-wiki/e48s05.md
@@ -48,55 +48,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-09.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-18.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/GOLDEN-2026-07-05.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-06.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-07.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-23.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-24.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-13.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-23.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-07.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-21.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-06.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-18.okf.md
+  - file: specs/verifications/reports/GOLDEN-2026-07-25.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -104,19 +60,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-09.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-13.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-2026-07-11.okf.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/GOLDEN-2026-07-24.okf.md
+  - file: specs/verifications/reports/audit-2026-07-25.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -149,6 +93,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/bugs/BUG-2026-07-03-validate-specs-no-real-parser.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/bugs/BUG-2026-07-25-land-branch-protected.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -656,6 +604,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/epics-wiki/e79.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/epics-wiki/e67.okf.md
     line: 0
     confidence: medium
@@ -756,24 +708,10 @@ links:
 - `specs/verifications/steps/and-i-should-enforce-a-two-stage-review-gate.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/then-skills-should-include-bold-hard-gate-callout-blocks.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-i-should-reject-work-that-fails-its-risk-tier-verification-gate.sh` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-09.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-18.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-05.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-06.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-07.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-23.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-24.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-13.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-23.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-07.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-21.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-06.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-18.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/GOLDEN-2026-07-25.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-05.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-09.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-13.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-2026-07-11.okf.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/GOLDEN-2026-07-24.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-2026-07-25.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-03-venv-not-gitignored.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-07-compliance-skill-catalog-n7.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-g06-migrate-version-golden.okf.md` (line 0, confidence: medium, method: file_heuristic)
@@ -782,6 +720,7 @@ links:
 - `specs/bugs/BUG-2026-06-02T164500.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-evolve-skill-sync-oversized.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-03-validate-specs-no-real-parser.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/bugs/BUG-2026-07-25-land-branch-protected.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06T205700.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-04-stale-bak-features.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-09-dead-function-build-skill-graph.okf.md` (line 0, confidence: medium, method: file_heuristic)
@@ -908,6 +847,7 @@ links:
 - `specs/epics-wiki/e16.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics-wiki/e08.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics-wiki/e04.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/epics-wiki/e79.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics-wiki/e67.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics-wiki/e41.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics-wiki/e22.okf.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e51s02.md
+++ b/specs/codebase-wiki/e51s02.md
@@ -13,7 +13,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .gemini/extensions/bigpowers/commands/prompts/seed-conventions.md
-    line: 105
+    line: 122
     confidence: high
     method: explicit_tag
   - file: .gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md
@@ -21,7 +21,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md
-    line: 107
+    line: 124
     confidence: high
     method: explicit_tag
   - file: .trae/skills/seed-conventions/SKILL.md
@@ -29,7 +29,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .trae/skills/seed-conventions/SKILL.md
-    line: 106
+    line: 123
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/seed-conventions.md
@@ -37,7 +37,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/seed-conventions.md
-    line: 106
+    line: 123
     confidence: high
     method: explicit_tag
   - file: specs/epics/archive/e51-always-green-shift-left/e51s02-seed-preflight-default.md
@@ -57,7 +57,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .agents/skills/seed-conventions/SKILL.md
-    line: 106
+    line: 123
     confidence: high
     method: explicit_tag
   - file: .kilocode/rules/seed-conventions.md
@@ -65,7 +65,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .kilocode/rules/seed-conventions.md
-    line: 106
+    line: 123
     confidence: high
     method: explicit_tag
   - file: .codex/skills/seed-conventions/SKILL.md
@@ -73,7 +73,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .codex/skills/seed-conventions/SKILL.md
-    line: 106
+    line: 123
     confidence: high
     method: explicit_tag
   - file: skills/seed-conventions/REFERENCE.md
@@ -89,7 +89,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .codebuddy/skills/seed-conventions/SKILL.md
-    line: 106
+    line: 123
     confidence: high
     method: explicit_tag
   - file: .zcode/skills/seed-conventions/SKILL.md
@@ -97,7 +97,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .zcode/skills/seed-conventions/SKILL.md
-    line: 106
+    line: 123
     confidence: high
     method: explicit_tag
   - file: .mimocode/skills/seed-conventions/SKILL.md
@@ -105,7 +105,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .mimocode/skills/seed-conventions/SKILL.md
-    line: 106
+    line: 123
     confidence: high
     method: explicit_tag
   - file: .hermes/skills/seed-conventions/SKILL.md
@@ -113,7 +113,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .hermes/skills/seed-conventions/SKILL.md
-    line: 106
+    line: 123
     confidence: high
     method: explicit_tag
   - file: .pi/prompts/seed-conventions.md
@@ -121,7 +121,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .pi/prompts/seed-conventions.md
-    line: 105
+    line: 122
     confidence: high
     method: explicit_tag
   - file: .pi/skills/seed-conventions/SKILL.md
@@ -129,7 +129,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: .pi/skills/seed-conventions/SKILL.md
-    line: 106
+    line: 123
     confidence: high
     method: explicit_tag
   - file: specs/WORKFLOW-solo-git.md
@@ -145,6 +145,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/steps/and-solo-git-profile-exists.sh
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/epics/e79-agentic-ste/e79s03-seed-conventions.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -175,40 +179,41 @@ links:
 ## Implemented In
 
 - `.gemini/extensions/bigpowers/commands/prompts/seed-conventions.md` (line 9, confidence: high, method: explicit_tag)
-- `.gemini/extensions/bigpowers/commands/prompts/seed-conventions.md` (line 105, confidence: high, method: explicit_tag)
+- `.gemini/extensions/bigpowers/commands/prompts/seed-conventions.md` (line 122, confidence: high, method: explicit_tag)
 - `.gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md` (line 11, confidence: high, method: explicit_tag)
-- `.gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md` (line 107, confidence: high, method: explicit_tag)
+- `.gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md` (line 124, confidence: high, method: explicit_tag)
 - `.trae/skills/seed-conventions/SKILL.md` (line 10, confidence: high, method: explicit_tag)
-- `.trae/skills/seed-conventions/SKILL.md` (line 106, confidence: high, method: explicit_tag)
+- `.trae/skills/seed-conventions/SKILL.md` (line 123, confidence: high, method: explicit_tag)
 - `.windsurf/rules/seed-conventions.md` (line 10, confidence: high, method: explicit_tag)
-- `.windsurf/rules/seed-conventions.md` (line 106, confidence: high, method: explicit_tag)
+- `.windsurf/rules/seed-conventions.md` (line 123, confidence: high, method: explicit_tag)
 - `specs/epics/archive/e51-always-green-shift-left/e51s02-seed-preflight-default.md` (line 1, confidence: high, method: explicit_tag)
 - `specs/epics/archive/e51-always-green-shift-left/e51s02-tasks.yaml` (line 31, confidence: high, method: explicit_tag)
 - `specs/epics/archive/e51-always-green-shift-left/e51s02-tasks.yaml` (line 32, confidence: high, method: explicit_tag)
 - `.agents/skills/seed-conventions/SKILL.md` (line 10, confidence: high, method: explicit_tag)
-- `.agents/skills/seed-conventions/SKILL.md` (line 106, confidence: high, method: explicit_tag)
+- `.agents/skills/seed-conventions/SKILL.md` (line 123, confidence: high, method: explicit_tag)
 - `.kilocode/rules/seed-conventions.md` (line 10, confidence: high, method: explicit_tag)
-- `.kilocode/rules/seed-conventions.md` (line 106, confidence: high, method: explicit_tag)
+- `.kilocode/rules/seed-conventions.md` (line 123, confidence: high, method: explicit_tag)
 - `.codex/skills/seed-conventions/SKILL.md` (line 10, confidence: high, method: explicit_tag)
-- `.codex/skills/seed-conventions/SKILL.md` (line 106, confidence: high, method: explicit_tag)
+- `.codex/skills/seed-conventions/SKILL.md` (line 123, confidence: high, method: explicit_tag)
 - `skills/seed-conventions/REFERENCE.md` (line 1, confidence: high, method: explicit_tag)
 - `skills/seed-conventions/SKILL.md` (line 11, confidence: high, method: explicit_tag)
 - `.codebuddy/skills/seed-conventions/SKILL.md` (line 10, confidence: high, method: explicit_tag)
-- `.codebuddy/skills/seed-conventions/SKILL.md` (line 106, confidence: high, method: explicit_tag)
+- `.codebuddy/skills/seed-conventions/SKILL.md` (line 123, confidence: high, method: explicit_tag)
 - `.zcode/skills/seed-conventions/SKILL.md` (line 10, confidence: high, method: explicit_tag)
-- `.zcode/skills/seed-conventions/SKILL.md` (line 106, confidence: high, method: explicit_tag)
+- `.zcode/skills/seed-conventions/SKILL.md` (line 123, confidence: high, method: explicit_tag)
 - `.mimocode/skills/seed-conventions/SKILL.md` (line 10, confidence: high, method: explicit_tag)
-- `.mimocode/skills/seed-conventions/SKILL.md` (line 106, confidence: high, method: explicit_tag)
+- `.mimocode/skills/seed-conventions/SKILL.md` (line 123, confidence: high, method: explicit_tag)
 - `.hermes/skills/seed-conventions/SKILL.md` (line 10, confidence: high, method: explicit_tag)
-- `.hermes/skills/seed-conventions/SKILL.md` (line 106, confidence: high, method: explicit_tag)
+- `.hermes/skills/seed-conventions/SKILL.md` (line 123, confidence: high, method: explicit_tag)
 - `.pi/prompts/seed-conventions.md` (line 9, confidence: high, method: explicit_tag)
-- `.pi/prompts/seed-conventions.md` (line 105, confidence: high, method: explicit_tag)
+- `.pi/prompts/seed-conventions.md` (line 122, confidence: high, method: explicit_tag)
 - `.pi/skills/seed-conventions/SKILL.md` (line 10, confidence: high, method: explicit_tag)
-- `.pi/skills/seed-conventions/SKILL.md` (line 106, confidence: high, method: explicit_tag)
+- `.pi/skills/seed-conventions/SKILL.md` (line 123, confidence: high, method: explicit_tag)
 - `specs/WORKFLOW-solo-git.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/conventions-wiki/always-green-shift-left.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-solo-git-profile-exists.sh` (line 0, confidence: medium, method: file_heuristic)
+- `specs/epics/e79-agentic-ste/e79s03-seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/archive/e51-always-green-shift-left/e51s01-conventions-always-green.md` (line 0, confidence: medium, method: file_heuristic)
 - `.continue/rules/seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
 - `website/src/content/docs/skills/seed-conventions.mdx` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e51s03.md
+++ b/specs/codebase-wiki/e51s03.md
@@ -176,11 +176,19 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/bugs/BUG-2026-07-25-land-branch-protected.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/bugs/BUG-2026-07-06-verify-work-runner-scripts-oversized.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/bugs/BUG-2026-07-06-verify-work-runner-scripts-oversized.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/bugs/BUG-2026-07-25-land-branch-protected.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -308,8 +316,10 @@ links:
 - `specs/verifications/steps/then-skills-should-include-bold-hard-gate-callout-blocks.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-i-should-reject-work-that-fails-its-risk-tier-verification-gate.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-it-must-prohibit-direct-work-on-main-master-branches.sh` (line 0, confidence: medium, method: file_heuristic)
+- `specs/bugs/BUG-2026-07-25-land-branch-protected.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-verify-work-runner-scripts-oversized.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-verify-work-runner-scripts-oversized.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/bugs/BUG-2026-07-25-land-branch-protected.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/adr-wiki/0005-hard-gate-mandate.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/benchmarks/verify-work.yaml` (line 0, confidence: medium, method: file_heuristic)
 - `specs/tech-architecture/PLAN-add-hard-gates.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e51s04.md
+++ b/specs/codebase-wiki/e51s04.md
@@ -108,14 +108,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190334.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-144556.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-175346.md
     line: 0
     confidence: medium
@@ -124,35 +116,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-102313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-103815.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163934.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202335.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145222.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165427.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-151538.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132836.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -164,23 +128,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-155647.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181947.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212931.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-160106.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-180858.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -189,34 +137,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-143153.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215320.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-132011.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-172717.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174039.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132651.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212830.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182718.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -229,14 +149,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-122420.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-154721.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183547.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -264,10 +176,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-160627.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-165137.md
     line: 0
     confidence: medium
@@ -276,31 +184,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-205519.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-131516.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101228.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-102150.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214411.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260622-001710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-165047.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -309,26 +193,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-000102.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-131912.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-132538.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133327.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001605.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105239.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -344,39 +208,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101847.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173628.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182629.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-161434.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154217.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-165703.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-143839.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163159.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260711-001225.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -388,23 +224,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-185319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183644.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260629-132810.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001328.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -416,19 +236,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-202226.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164609.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192340.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165651.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -440,31 +248,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-160550.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-134603.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091641.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163954.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-210053.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190002.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-093104.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -473,18 +257,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164251.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132615.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-172212.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-140513.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -504,23 +276,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154135.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170532.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154323.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-082500.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101730.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -532,75 +292,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-165007.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-205711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-182236.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-135136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-103737.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-093242.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-213042.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-134029.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164826.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-162400.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110426.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-223023.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-134126.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-162245.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-105652.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-114127.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-164053.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154055.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -616,19 +312,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164801.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131809.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-175313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181604.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -644,27 +328,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-110149.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-131715.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-133750.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-181656.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174414.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -672,15 +336,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192541.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-233740.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173515.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -688,35 +344,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190415.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192435.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-094025.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-161022.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-125910.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215656.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-135950.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092605.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -732,14 +360,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154936.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132530.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174045.md
     line: 0
     confidence: medium
@@ -752,23 +372,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091938.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-133945.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174055.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001312.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110458.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -808,39 +412,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105145.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-193609.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174351.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-154353.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-131211.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-130715.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182555.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-124641.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -852,23 +428,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120114.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-234357.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110242.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-143756.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-235505.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -877,14 +437,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-160732.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-145214.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-161026.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -900,10 +452,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001100.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-150417.md
     line: 0
     confidence: medium
@@ -916,15 +464,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-151437.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-143504.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-185913.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -932,19 +472,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-140559.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001518.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-184837.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -960,35 +488,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-154541.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-105728.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-111510.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-180901.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-133532.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145423.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-105643.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-141624.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1004,18 +508,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181236.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163830.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092533.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174025.md
     line: 0
     confidence: medium
@@ -1024,39 +516,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145349.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-164643.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-205433.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132944.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163746.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-091141.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184856.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-143844.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133446.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1068,39 +528,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-182836.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202450.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194130.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-213831.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174245.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-005800.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-173348.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-165006.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1112,19 +544,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-005225.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-143007.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-171058.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-150742.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1133,10 +553,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165618.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-130546.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1168,35 +584,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-154637.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001919.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-144757.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-220941.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174117.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-093202.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-110206.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120150.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1212,31 +600,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131734.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182807.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173917.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-185210.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-101322.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165256.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-192433.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1244,27 +608,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105013.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-200110.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-114242.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001233.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-130623.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-162439.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1272,27 +616,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002229.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-144202.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183102.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-133837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-233707.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212919.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1308,19 +636,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164345.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120250.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165035.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-112952.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1332,43 +648,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194053.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001439.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202651.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-165120.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-143840.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-000955.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-144557.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-174133.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115538.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-113034.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1380,39 +664,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-161502.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170255.md
     line: 0
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164704.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132813.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164342.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-154344.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-120815.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-164833.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154835.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1424,27 +680,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-155747.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173218.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260626-204822.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202348.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-161543.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1456,10 +696,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-113257.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-181044.md
     line: 0
     confidence: medium
@@ -1468,27 +704,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-133458.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164823.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-180900.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-120136.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-104009.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-163929.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1501,10 +717,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-081735.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-154818.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1524,10 +736,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-170738.md
     line: 0
     confidence: medium
@@ -1541,10 +749,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-153801.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194215.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1564,23 +768,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084719.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-132017.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-171157.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-183350.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-150937.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1596,14 +784,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-110050.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001337.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260627-133613.md
     line: 0
     confidence: medium
@@ -1616,10 +796,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-220404.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-085740.md
     line: 0
     confidence: medium
@@ -1628,27 +804,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-193756.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163218.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-163309.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-130821.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-160906.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-094142.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1660,15 +816,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202442.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164319.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-164036.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1684,39 +832,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214125.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-164249.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132604.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-142359.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-163353.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132933.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-175550.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174408.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-163120.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1728,10 +848,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182339.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165418.md
     line: 0
     confidence: medium
@@ -1740,11 +856,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-155114.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133637.md
+  - file: specs/verifications/reports/audit-cleancode-20260725-021918.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1756,15 +868,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-131140.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165111.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-144700.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1800,7 +904,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-202558.md
+  - file: specs/verifications/reports/audit-cleancode-20260725-022131.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1808,31 +912,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-163657.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-215213.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-160919.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-204345.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212711.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-153739.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175227.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1841,42 +921,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-225313.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164721.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-093336.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132207.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130940.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-105058.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-163457.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084617.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084805.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174631.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1892,35 +936,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002322.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-220022.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-164429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-135838.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-093012.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260713-152233.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-131617.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181159.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1932,10 +948,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131350.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-083101.md
     line: 0
     confidence: medium
@@ -1944,23 +956,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115557.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-114525.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-093128.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-221847.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-154451.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1968,51 +964,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-212552.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-161624.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-181706.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-105035.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-092013.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001702.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132130.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-163956.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001902.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260721-093246.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-204300.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2028,14 +980,6 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-132858.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-174710.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-165902.md
     line: 0
     confidence: medium
@@ -2044,19 +988,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-001029.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-172425.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-145255.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-133730.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2064,51 +996,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-154759.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175929.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-172525.md
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-133254.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184658.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-164258.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-164418.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-194009.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260724-092924.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260629-130359.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130821.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-190539.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2120,27 +1012,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-163613.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173429.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-142458.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-005318.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-235409.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-001952.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2152,27 +1024,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260709-002154.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-171134.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-182630.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-165733.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-091717.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-084911.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2188,31 +1040,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260705-182346.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-115503.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-101402.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260621-231038.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-123626.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-184355.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-172751.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2220,27 +1048,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101633.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-130900.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-103924.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260707-101425.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260705-163837.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-175105.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2256,15 +1064,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-234704.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-163238.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-172133.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2272,19 +1072,7 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-214329.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260704-144506.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260718-210010.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260706-173306.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2301,10 +1089,6 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-151341.md
-    line: 0
-    confidence: medium
-    method: file_heuristic
-  - file: specs/verifications/reports/audit-cleancode-20260723-131314.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2543,172 +1327,73 @@ links:
 - `specs/conventions-wiki/p1-high-fix-before-merge.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-the-plan-specifies-test-levels-and-fixture-architectures.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/and-the-skill-packaging-pipeline-round-trips-a-golden-fixture-without-data-loss.sh` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190334.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-144556.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-175346.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-165245.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-102313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-103815.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163934.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202335.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145222.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165427.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-151538.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132836.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180022.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163733.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-155647.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181947.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212931.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160106.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-180858.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181109.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143153.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215320.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-132011.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-172717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174039.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132651.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212830.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182718.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170744.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005609.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-122420.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-154721.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183547.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-205129.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-081618.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-162136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234209.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-160627.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-165137.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223301.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-205519.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-131516.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101228.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-102150.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214411.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260622-001710.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-165047.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165920.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000102.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-131912.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-132538.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133327.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001605.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105239.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181904.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150326.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170432.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101847.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173628.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182629.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-161434.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154217.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-165703.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-143839.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163159.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260711-001225.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-010055.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163108.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-185319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183644.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215759.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132810.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001328.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-235439.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164718.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-202226.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192340.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165651.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172406.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173408.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-160550.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-134603.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091641.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163954.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-210053.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190002.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-093104.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-222132.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164251.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132615.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-172212.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-140513.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170547.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173125.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180244.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170506.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154135.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170532.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154323.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082500.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101730.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170710.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-205844.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-165007.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-205711.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-182236.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-135136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-103737.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-093242.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-213042.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-134029.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164826.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-162400.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110426.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223023.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-134126.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-162245.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-105652.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-114127.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-164053.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154055.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170704.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173014.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174734.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164801.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131809.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181604.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163821.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-201018.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-165945.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-110149.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-131715.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-133750.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105711.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181656.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174414.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142931.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192541.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-233740.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173515.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-090946.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190415.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192435.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-094025.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-161022.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-125910.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215656.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-135950.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092605.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-225914.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165619.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154936.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132530.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174045.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-131004.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091938.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-133945.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174055.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001312.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164534.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005128.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-235526.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2718,89 +1403,42 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260703-005444.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223636.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181759.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105145.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-193609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174351.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154353.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-131211.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130715.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182555.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-124641.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-083430.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080042.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120114.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234357.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110242.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-143756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-235505.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-220905.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160732.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-145214.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-161026.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164627.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143840.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-214041.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001100.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150417.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155813.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164603.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-151437.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143504.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-185913.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-154427.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-140559.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001518.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-184837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170909.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154246.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-154541.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-105728.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-111510.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180901.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-133532.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145423.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-105643.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-141624.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164911.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174207.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-160756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181236.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163830.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092533.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174025.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204652.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145349.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-164643.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-205433.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132944.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163746.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-091141.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184856.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-143844.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133446.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-154339.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223425.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-182836.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202450.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133710.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194130.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-213831.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174245.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005800.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173348.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-165006.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005515.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165022.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-005225.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-143007.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-171058.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-150742.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164733.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165618.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-130546.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164707.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155946.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170347.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2808,156 +1446,78 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260704-083149.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170223.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164441.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-154637.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001919.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-144757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-220941.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174117.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-093202.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-110206.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120150.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080057.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170448.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082609.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131734.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182807.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173917.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-185210.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-101322.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165256.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-192433.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165207.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105013.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200110.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-114242.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001233.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-130623.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-162439.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130939.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002229.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-144202.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183102.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-133837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-233707.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212919.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163256.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005720.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164345.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120250.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165035.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-112952.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130756.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130915.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194053.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001439.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202651.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-165120.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-143840.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-000955.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-144557.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174133.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115538.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-113034.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164833.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181114.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-161502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170255.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164704.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132813.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164342.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-154344.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-120815.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-164833.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154835.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165959.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164817.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164759.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155747.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173218.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204822.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202348.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-161543.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-155551.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-125842.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-113257.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-181044.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223249.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-133458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164823.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-180900.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-120136.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-104009.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-163929.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234324.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180916.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-081735.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-154818.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-161735.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005423.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130845.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200055.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170738.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163839.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005546.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153801.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194215.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200030.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-004248.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154311.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-204755.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084719.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-132017.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-171157.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-183350.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-150937.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-091017.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082326.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175521.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-110050.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001337.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260627-133613.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-195653.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005358.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-220404.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-085740.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-193756.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163218.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-163309.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130821.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-160906.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-094142.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-145833.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142423.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202442.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164319.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-164036.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165346.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080024.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142902.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214125.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-164249.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132604.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-163353.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132933.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175550.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174408.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-163120.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-080343.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-082306.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182339.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165418.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-143447.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-155114.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133637.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260725-021918.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005655.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165222.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-131140.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165111.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-144700.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154214.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-181546.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165807.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2966,133 +1526,53 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260629-132750.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164343.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163338.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-202558.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260725-022131.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170940.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-163657.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-215213.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-160919.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-204345.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212711.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153739.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175227.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-180125.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-225313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164721.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-093336.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132207.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130940.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-105058.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-163457.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084617.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084805.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174631.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-174148.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000357.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-222115.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002322.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-220022.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164429.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-135838.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-093012.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260713-152233.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-131617.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181159.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164518.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223313.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131350.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-083101.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260626-214501.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115557.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-114525.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-093128.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-221847.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-154451.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-004226.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-212552.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-161624.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-181706.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-105035.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-092013.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001702.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132130.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182429.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163956.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001902.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260721-093246.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-204300.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164141.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-173033.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164050.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-132858.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-174710.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165902.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005336.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-001029.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172425.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-145255.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-133730.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-154726.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-154759.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175929.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172525.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-133254.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184658.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-164258.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-164418.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-194009.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260724-092924.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130359.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130821.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-190539.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170706.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170757.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-163613.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173429.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142458.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-005318.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-235409.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-001952.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-195845.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-164155.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260709-002154.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-171134.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-182630.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-165733.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-091717.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-084911.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-130700.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-153136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172925.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260705-182346.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-115503.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-101402.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-231038.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-123626.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-184355.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-172751.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170431.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101633.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-130900.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-103924.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260707-101425.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-163837.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-175105.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-000548.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-150200.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-175152.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-234704.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-163238.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-172133.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-180948.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-214329.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-144506.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260718-210010.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260706-173306.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260622-001925.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164958.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165537.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-151341.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/verifications/reports/audit-cleancode-20260723-131314.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260621-185054.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-07-compliance-skill-catalog-n7.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-04-filesize-gate-python-blindspot.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e60s01.md
+++ b/specs/codebase-wiki/e60s01.md
@@ -40,6 +40,10 @@ links:
     line: 2
     confidence: high
     method: explicit_tag
+  - file: docs/images/interactive-installer.png
+    line: 0
+    confidence: medium
+    method: file_heuristic
 ---
 
 # e60s01: Interactive installer with ASCII banner, global/local, tool selection
@@ -58,3 +62,4 @@ links:
 - `scripts/test-install-helpers.js` (line 2, confidence: high, method: explicit_tag)
 - `scripts/lib/install-targets-a.sh` (line 23, confidence: high, method: explicit_tag)
 - `scripts/lib/install-helpers.js` (line 2, confidence: high, method: explicit_tag)
+- `docs/images/interactive-installer.png` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e79s01.md
+++ b/specs/codebase-wiki/e79s01.md
@@ -1,0 +1,60 @@
+---
+type: Story
+id: e79s01
+epic: e79
+bcps: 0
+wsjf: 6.0
+implementation_status: backlog
+coverage_status: covered
+confidence: high
+links:
+  - file: specs/epics/e79-agentic-ste/epic.yaml
+    line: 28
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e79-agentic-ste/e79s01-tasks.yaml
+    line: 12
+    confidence: high
+    method: explicit_tag
+  - file: docs/AGENTIC-STE.md
+    line: 1
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e79-agentic-ste/e79s01-agentic-ste-doc.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: scripts/validate-agentic-ste.sh
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/epics/e79-agentic-ste/e79s02-tasks.yaml
+    line: 0
+    confidence: low
+    method: task_reference
+  - file: specs/epics/e79-agentic-ste/e79s04-tasks.yaml
+    line: 0
+    confidence: low
+    method: task_reference
+  - file: specs/epics/e79-agentic-ste/e79s03-tasks.yaml
+    line: 0
+    confidence: low
+    method: task_reference
+---
+
+# e79s01: AGENTIC-STE ruleset document
+
+**Epic:** e79 — Agentic Controlled English (STE-style instruction precision)
+**Status:** backlog
+**BCP:** 0 | **WSJF:** 6.0
+
+## Implemented In
+
+- `specs/epics/e79-agentic-ste/epic.yaml` (line 28, confidence: high, method: explicit_tag)
+- `specs/epics/e79-agentic-ste/e79s01-tasks.yaml` (line 12, confidence: high, method: explicit_tag)
+- `docs/AGENTIC-STE.md` (line 1, confidence: high, method: explicit_tag)
+- `specs/epics/e79-agentic-ste/e79s01-agentic-ste-doc.md` (line 0, confidence: medium, method: file_heuristic)
+- `scripts/validate-agentic-ste.sh` (line 0, confidence: medium, method: file_heuristic)
+- `specs/epics/e79-agentic-ste/e79s02-tasks.yaml` (line 0, confidence: low, method: task_reference)
+- `specs/epics/e79-agentic-ste/e79s04-tasks.yaml` (line 0, confidence: low, method: task_reference)
+- `specs/epics/e79-agentic-ste/e79s03-tasks.yaml` (line 0, confidence: low, method: task_reference)

--- a/specs/codebase-wiki/e79s02.md
+++ b/specs/codebase-wiki/e79s02.md
@@ -1,31 +1,27 @@
 ---
 type: Story
-id: e45s02
-epic: e45
-bcps: 2
-wsjf: 5.0
-implementation_status: done
+id: e79s02
+epic: e79
+bcps: 0
+wsjf: 6.0
+implementation_status: backlog
 coverage_status: covered
 confidence: high
 links:
-  - file: scripts/lib/audit-compliance-judge.sh
-    line: 2
+  - file: specs/epics/e79-agentic-ste/e79s02-tasks.yaml
+    line: 13
     confidence: high
     method: explicit_tag
-  - file: scripts/lib/audit-compliance-runner.sh
-    line: 2
+  - file: specs/epics/e79-agentic-ste/epic.yaml
+    line: 42
     confidence: high
     method: explicit_tag
-  - file: scripts/lib/audit-compliance-report.sh
-    line: 2
-    confidence: high
-    method: explicit_tag
-  - file: scripts/validate-skill-description.sh
+  - file: scripts/validate-agentic-ste.sh
     line: 2
     confidence: high
     method: explicit_tag
   - file: skills/craft-skill/SKILL.md
-    line: 1
+    line: 3
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/craft-skill.md
@@ -33,6 +29,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/skills-wiki/skills/craft-skill.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/adr/0005-hard-gate-mandate.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -48,6 +48,18 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/adr-wiki/0005-hard-gate-mandate.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/tech-architecture/PLAN-add-hard-gates.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/tech-architecture/HARD-GATES-REFERENCE.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/epics/e79-agentic-ste/e79s02-validator-craft-skill.md
     line: 0
     confidence: medium
@@ -60,6 +72,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: website/src/content/docs/decisions/0005-hard-gate-mandate.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: website/src/content/docs/skills/craft-skill.mdx
     line: 0
     confidence: medium
@@ -68,28 +84,42 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: scripts/validate-skill-description.sh
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/epics/e79-agentic-ste/e79s04-tasks.yaml
+    line: 0
+    confidence: low
+    method: task_reference
 ---
 
-# e45s02: craft-skill: CSO description discipline + completion-honesty gate
+# e79s02: Validator script + craft-skill HARD GATE
 
-**Epic:** e45 — Quality Core — Skill Hardening & Verification Patterns
-**Status:** done
-**BCP:** 2 | **WSJF:** 5.0
+**Epic:** e79 — Agentic Controlled English (STE-style instruction precision)
+**Status:** backlog
+**BCP:** 0 | **WSJF:** 6.0
 
 ## Implemented In
 
-- `scripts/lib/audit-compliance-judge.sh` (line 2, confidence: high, method: explicit_tag)
-- `scripts/lib/audit-compliance-runner.sh` (line 2, confidence: high, method: explicit_tag)
-- `scripts/lib/audit-compliance-report.sh` (line 2, confidence: high, method: explicit_tag)
-- `scripts/validate-skill-description.sh` (line 2, confidence: high, method: explicit_tag)
-- `skills/craft-skill/SKILL.md` (line 1, confidence: high, method: explicit_tag)
+- `specs/epics/e79-agentic-ste/e79s02-tasks.yaml` (line 13, confidence: high, method: explicit_tag)
+- `specs/epics/e79-agentic-ste/epic.yaml` (line 42, confidence: high, method: explicit_tag)
+- `scripts/validate-agentic-ste.sh` (line 2, confidence: high, method: explicit_tag)
+- `skills/craft-skill/SKILL.md` (line 3, confidence: high, method: explicit_tag)
 - `.windsurf/rules/craft-skill.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/craft-skill.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/adr/0005-hard-gate-mandate.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/then-skills-should-include-bold-hard-gate-callout-blocks.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-craft-skill-sync-oversized.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-craft-skill-sync-oversized.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/adr-wiki/0005-hard-gate-mandate.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/tech-architecture/PLAN-add-hard-gates.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/tech-architecture/HARD-GATES-REFERENCE.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/e79-agentic-ste/e79s02-validator-craft-skill.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/archive/e38-traceability-gate/e38s06-gate-trace-skill.md` (line 0, confidence: medium, method: file_heuristic)
 - `.continue/rules/craft-skill.md` (line 0, confidence: medium, method: file_heuristic)
+- `website/src/content/docs/decisions/0005-hard-gate-mandate.md` (line 0, confidence: medium, method: file_heuristic)
 - `website/src/content/docs/skills/craft-skill.mdx` (line 0, confidence: medium, method: file_heuristic)
 - `.kilocode/rules/craft-skill.md` (line 0, confidence: medium, method: file_heuristic)
+- `scripts/validate-skill-description.sh` (line 0, confidence: medium, method: file_heuristic)
+- `specs/epics/e79-agentic-ste/e79s04-tasks.yaml` (line 0, confidence: low, method: task_reference)

--- a/specs/codebase-wiki/e79s03.md
+++ b/specs/codebase-wiki/e79s03.md
@@ -1,0 +1,120 @@
+---
+type: Story
+id: e79s03
+epic: e79
+bcps: 0
+wsjf: 6.0
+implementation_status: backlog
+coverage_status: covered
+confidence: high
+links:
+  - file: .gemini/extensions/bigpowers/commands/prompts/seed-conventions.md
+    line: 11
+    confidence: high
+    method: explicit_tag
+  - file: .gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md
+    line: 13
+    confidence: high
+    method: explicit_tag
+  - file: .trae/skills/seed-conventions/SKILL.md
+    line: 12
+    confidence: high
+    method: explicit_tag
+  - file: .windsurf/rules/seed-conventions.md
+    line: 12
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e79-agentic-ste/epic.yaml
+    line: 54
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e79-agentic-ste/e79s03-tasks.yaml
+    line: 13
+    confidence: high
+    method: explicit_tag
+  - file: .agents/skills/seed-conventions/SKILL.md
+    line: 12
+    confidence: high
+    method: explicit_tag
+  - file: .kilocode/rules/seed-conventions.md
+    line: 12
+    confidence: high
+    method: explicit_tag
+  - file: .codex/skills/seed-conventions/SKILL.md
+    line: 12
+    confidence: high
+    method: explicit_tag
+  - file: skills/seed-conventions/SKILL.md
+    line: 13
+    confidence: high
+    method: explicit_tag
+  - file: .codebuddy/skills/seed-conventions/SKILL.md
+    line: 12
+    confidence: high
+    method: explicit_tag
+  - file: .zcode/skills/seed-conventions/SKILL.md
+    line: 12
+    confidence: high
+    method: explicit_tag
+  - file: .mimocode/skills/seed-conventions/SKILL.md
+    line: 12
+    confidence: high
+    method: explicit_tag
+  - file: .hermes/skills/seed-conventions/SKILL.md
+    line: 12
+    confidence: high
+    method: explicit_tag
+  - file: .pi/prompts/seed-conventions.md
+    line: 11
+    confidence: high
+    method: explicit_tag
+  - file: .pi/skills/seed-conventions/SKILL.md
+    line: 12
+    confidence: high
+    method: explicit_tag
+  - file: specs/skills-wiki/skills/seed-conventions.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/epics/e79-agentic-ste/e79s03-seed-conventions.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: .continue/rules/seed-conventions.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: website/src/content/docs/skills/seed-conventions.mdx
+    line: 0
+    confidence: medium
+    method: file_heuristic
+---
+
+# e79s03: seed-conventions applies ruleset
+
+**Epic:** e79 — Agentic Controlled English (STE-style instruction precision)
+**Status:** backlog
+**BCP:** 0 | **WSJF:** 6.0
+
+## Implemented In
+
+- `.gemini/extensions/bigpowers/commands/prompts/seed-conventions.md` (line 11, confidence: high, method: explicit_tag)
+- `.gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md` (line 13, confidence: high, method: explicit_tag)
+- `.trae/skills/seed-conventions/SKILL.md` (line 12, confidence: high, method: explicit_tag)
+- `.windsurf/rules/seed-conventions.md` (line 12, confidence: high, method: explicit_tag)
+- `specs/epics/e79-agentic-ste/epic.yaml` (line 54, confidence: high, method: explicit_tag)
+- `specs/epics/e79-agentic-ste/e79s03-tasks.yaml` (line 13, confidence: high, method: explicit_tag)
+- `.agents/skills/seed-conventions/SKILL.md` (line 12, confidence: high, method: explicit_tag)
+- `.kilocode/rules/seed-conventions.md` (line 12, confidence: high, method: explicit_tag)
+- `.codex/skills/seed-conventions/SKILL.md` (line 12, confidence: high, method: explicit_tag)
+- `skills/seed-conventions/SKILL.md` (line 13, confidence: high, method: explicit_tag)
+- `.codebuddy/skills/seed-conventions/SKILL.md` (line 12, confidence: high, method: explicit_tag)
+- `.zcode/skills/seed-conventions/SKILL.md` (line 12, confidence: high, method: explicit_tag)
+- `.mimocode/skills/seed-conventions/SKILL.md` (line 12, confidence: high, method: explicit_tag)
+- `.hermes/skills/seed-conventions/SKILL.md` (line 12, confidence: high, method: explicit_tag)
+- `.pi/prompts/seed-conventions.md` (line 11, confidence: high, method: explicit_tag)
+- `.pi/skills/seed-conventions/SKILL.md` (line 12, confidence: high, method: explicit_tag)
+- `specs/skills-wiki/skills/seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/epics/e79-agentic-ste/e79s03-seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
+- `.continue/rules/seed-conventions.md` (line 0, confidence: medium, method: file_heuristic)
+- `website/src/content/docs/skills/seed-conventions.mdx` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e79s04.md
+++ b/specs/codebase-wiki/e79s04.md
@@ -1,0 +1,120 @@
+---
+type: Story
+id: e79s04
+epic: e79
+bcps: 0
+wsjf: 6.0
+implementation_status: backlog
+coverage_status: covered
+confidence: high
+links:
+  - file: .gemini/extensions/bigpowers/commands/prompts/stocktake-skills.md
+    line: 8
+    confidence: high
+    method: explicit_tag
+  - file: .gemini/extensions/bigpowers/skills/stocktake-skills/SKILL.md
+    line: 10
+    confidence: high
+    method: explicit_tag
+  - file: .trae/skills/stocktake-skills/SKILL.md
+    line: 9
+    confidence: high
+    method: explicit_tag
+  - file: .windsurf/rules/stocktake-skills.md
+    line: 9
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e79-agentic-ste/epic.yaml
+    line: 66
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/e79-agentic-ste/e79s04-tasks.yaml
+    line: 14
+    confidence: high
+    method: explicit_tag
+  - file: .agents/skills/stocktake-skills/SKILL.md
+    line: 9
+    confidence: high
+    method: explicit_tag
+  - file: .kilocode/rules/stocktake-skills.md
+    line: 9
+    confidence: high
+    method: explicit_tag
+  - file: .codex/skills/stocktake-skills/SKILL.md
+    line: 9
+    confidence: high
+    method: explicit_tag
+  - file: skills/stocktake-skills/SKILL.md
+    line: 12
+    confidence: high
+    method: explicit_tag
+  - file: .codebuddy/skills/stocktake-skills/SKILL.md
+    line: 9
+    confidence: high
+    method: explicit_tag
+  - file: .zcode/skills/stocktake-skills/SKILL.md
+    line: 9
+    confidence: high
+    method: explicit_tag
+  - file: .mimocode/skills/stocktake-skills/SKILL.md
+    line: 9
+    confidence: high
+    method: explicit_tag
+  - file: .hermes/skills/stocktake-skills/SKILL.md
+    line: 9
+    confidence: high
+    method: explicit_tag
+  - file: .pi/prompts/stocktake-skills.md
+    line: 8
+    confidence: high
+    method: explicit_tag
+  - file: .pi/skills/stocktake-skills/SKILL.md
+    line: 9
+    confidence: high
+    method: explicit_tag
+  - file: specs/skills-wiki/skills/stocktake-skills.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/epics/e79-agentic-ste/e79s04-stocktake-scanner.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: .continue/rules/stocktake-skills.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: website/src/content/docs/skills/stocktake-skills.mdx
+    line: 0
+    confidence: medium
+    method: file_heuristic
+---
+
+# e79s04: stocktake-skills violation scanner
+
+**Epic:** e79 — Agentic Controlled English (STE-style instruction precision)
+**Status:** backlog
+**BCP:** 0 | **WSJF:** 6.0
+
+## Implemented In
+
+- `.gemini/extensions/bigpowers/commands/prompts/stocktake-skills.md` (line 8, confidence: high, method: explicit_tag)
+- `.gemini/extensions/bigpowers/skills/stocktake-skills/SKILL.md` (line 10, confidence: high, method: explicit_tag)
+- `.trae/skills/stocktake-skills/SKILL.md` (line 9, confidence: high, method: explicit_tag)
+- `.windsurf/rules/stocktake-skills.md` (line 9, confidence: high, method: explicit_tag)
+- `specs/epics/e79-agentic-ste/epic.yaml` (line 66, confidence: high, method: explicit_tag)
+- `specs/epics/e79-agentic-ste/e79s04-tasks.yaml` (line 14, confidence: high, method: explicit_tag)
+- `.agents/skills/stocktake-skills/SKILL.md` (line 9, confidence: high, method: explicit_tag)
+- `.kilocode/rules/stocktake-skills.md` (line 9, confidence: high, method: explicit_tag)
+- `.codex/skills/stocktake-skills/SKILL.md` (line 9, confidence: high, method: explicit_tag)
+- `skills/stocktake-skills/SKILL.md` (line 12, confidence: high, method: explicit_tag)
+- `.codebuddy/skills/stocktake-skills/SKILL.md` (line 9, confidence: high, method: explicit_tag)
+- `.zcode/skills/stocktake-skills/SKILL.md` (line 9, confidence: high, method: explicit_tag)
+- `.mimocode/skills/stocktake-skills/SKILL.md` (line 9, confidence: high, method: explicit_tag)
+- `.hermes/skills/stocktake-skills/SKILL.md` (line 9, confidence: high, method: explicit_tag)
+- `.pi/prompts/stocktake-skills.md` (line 8, confidence: high, method: explicit_tag)
+- `.pi/skills/stocktake-skills/SKILL.md` (line 9, confidence: high, method: explicit_tag)
+- `specs/skills-wiki/skills/stocktake-skills.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/epics/e79-agentic-ste/e79s04-stocktake-scanner.md` (line 0, confidence: medium, method: file_heuristic)
+- `.continue/rules/stocktake-skills.md` (line 0, confidence: medium, method: file_heuristic)
+- `website/src/content/docs/skills/stocktake-skills.mdx` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/index.md
+++ b/specs/codebase-wiki/index.md
@@ -1,7 +1,7 @@
 ---
 type: Index
-generated_at: 2026-07-24T19:53:42.397638+00:00
-total_concepts: 112
+generated_at: 2026-07-25T05:28:09.657214+00:00
+total_concepts: 116
 ---
 
 # Codebase Wiki — Story Traceability
@@ -10,12 +10,12 @@ Auto-generated OKF bundle from trace-stories.sh.
 
 | Story | Title | Confidence | Links |
 |-------|-------|------------|-------|
-| [e37s01](./e37s01.md) | seed-conventions — unified AGENTS.md template with e51 Prefl | high | 17 |
+| [e37s01](./e37s01.md) | seed-conventions — unified AGENTS.md template with e51 Prefl | high | 18 |
 | [e37s02](./e37s02.md) | verify-install.sh + docs — Cline native AGENTS.md verificati | high | 5 |
-| [e37s03](./e37s03.md) | seed-conventions — .aider.conf.yml read:AGENTS.md bridge for | high | 9 |
+| [e37s03](./e37s03.md) | seed-conventions — .aider.conf.yml read:AGENTS.md bridge for | high | 10 |
 | [e37s04](./e37s04.md) | verify-install.sh — AGENTS.md spine assertions (OSS P1 + opt | high | 4 |
 | [e37s05](./e37s05.md) | scripts/targets.yaml — declarative integration registry for  | high | 28 |
-| [e37s06](./e37s06.md) | scripts/generate-context-bundle.sh — AGENTS.md single source | high | 12 |
+| [e37s06](./e37s06.md) | scripts/generate-context-bundle.sh — AGENTS.md single source | high | 11 |
 | [e37s07](./e37s07.md) | sync-skills.sh — adapter dispatch from targets.yaml | high | 12 |
 | [e37s08](./e37s08.md) | verify-install.sh — per-target contract matrix from targets. | high | 10 |
 | [e37s09](./e37s09.md) | targets.yaml — Wave A: Goose (OSS) + Antigravity agy (propri | high | 5 |
@@ -23,30 +23,30 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e37s11](./e37s11.md) | targets.yaml — Wave C: qwen, kilocode (markdown commands + r | high | 2 |
 | [e37s12](./e37s12.md) | targets.yaml — Wave D: continue (rules adapter; re-opened ac | high | 5 |
 | [e37s13](./e37s13.md) | targets.yaml — Wave E: iflow, vibe, shai (markdown commands; | high | 6 |
-| [e37s14](./e37s14.md) | seed-conventions — optional Codex wiring step (AGENTS.md + . | medium | 9 |
+| [e37s14](./e37s14.md) | seed-conventions — optional Codex wiring step (AGENTS.md + . | medium | 10 |
 | [e37s15](./e37s15.md) | install.sh — global ~/.codex/ AGENTS.md starter symlink | high | 4 |
 | [e37s16](./e37s16.md) | using-bigpowers — Codex CLI onboarding section | medium | 10 |
 | [e45s01](./e45s01.md) | run-benchmark: add train/validation-split + with/without-ski | high | 14 |
-| [e45s02](./e45s02.md) | craft-skill: CSO description discipline + completion-honesty | high | 14 |
+| [e45s02](./e45s02.md) | craft-skill: CSO description discipline + completion-honesty | high | 15 |
 | [e45s03](./e45s03.md) | CLAUDE.md token mgmt: mechanical PreToolUse hook backstop | high | 4 |
 | [e45s04](./e45s04.md) | slice-tasks / plan-work: pre-build cross-artifact consistenc | high | 17 |
 | [e45s05](./e45s05.md) | verify-work / gate-trace: adversarial gap-finding completene | high | 40 |
 | [e45s06](./e45s06.md) | tasks.yaml: literal failing→passing task ledger | high | 2 |
 | [e45s07](./e45s07.md) | request-review: dual-blind AND-gate review (Santa Method) | high | 38 |
 | [e45s08](./e45s08.md) | develop-tdd / validate-fix: two-commit red/green regression  | high | 13 |
-| [e45s09](./e45s09.md) | verify-work / plan-work: Pre-Implementation and Validation g | high | 85 |
+| [e45s09](./e45s09.md) | verify-work / plan-work: Pre-Implementation and Validation g | high | 84 |
 | [e45s10](./e45s10.md) | docs/references: auto-regenerate from source-of-truth docs v | high | 7 |
 | [e45s11](./e45s11.md) | orchestration / dispatch-agents: typed message protocol + 3- | high | 17 |
-| [e45s12](./e45s12.md) | stocktake-skills / craft-skill: code-enforced validator + au | high | 43 |
+| [e45s12](./e45s12.md) | stocktake-skills / craft-skill: code-enforced validator + au | high | 44 |
 | [e45s13](./e45s13.md) | verify-work: one-test-minimum terminal-verdict rule | high | 25 |
 | [e45s14](./e45s14.md) | deepen-architecture: declared import-boundary allowlist enfo | high | 8 |
 | [e45s15](./e45s15.md) | release-branch / deploy: three-independent-facts verificatio | high | 21 |
 | [e45s16](./e45s16.md) | CLAUDE.md rtk mandate: wire rtk-ai/rtk PreToolUse hook | high | 4 |
 | [e45s17](./e45s17.md) | request-review: fan-out to parallel review subagents | high | 30 |
-| [e45s18](./e45s18.md) | audit-code / security-review: worktree-isolated parallel che | high | 582 |
+| [e45s18](./e45s18.md) | audit-code / security-review: worktree-isolated parallel che | high | 278 |
 | [e45s19](./e45s19.md) | Context7: bounded retry cap and explicit fallback block | high | 8 |
 | [e45s20](./e45s20.md) | Context7 / bts docs: wrap in ETag-revalidated fetch cache | high | 1 |
-| [e45s21](./e45s21.md) | seed-conventions / AGENTS.md: self-installing fenced markers | high | 32 |
+| [e45s21](./e45s21.md) | seed-conventions / AGENTS.md: self-installing fenced markers | high | 33 |
 | [e45s22](./e45s22.md) | CLAUDE.md: context-aware directory routing | high | 3 |
 | [e45s23](./e45s23.md) | CLAUDE.md: live Learned User Preferences / Workspace Facts | high | 17 |
 | [e45s24](./e45s24.md) | REFERENCE.md files: embedded line-range navigation guides | medium | 2 |
@@ -56,7 +56,7 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e45s28](./e45s28.md) | request-review: hard max-iteration cap | high | 18 |
 | [e45s29](./e45s29.md) | requirements: ADDED/MODIFIED/REMOVED/RENAMED tags | high | 42 |
 | [e45s30](./e45s30.md) | subagent depth: formalize depth tiers | high | 28 |
-| [e45s31](./e45s31.md) | audit-code / deepen-architecture: churn-based look-here-firs | high | 572 |
+| [e45s31](./e45s31.md) | audit-code / deepen-architecture: churn-based look-here-firs | high | 268 |
 | [e45s32](./e45s32.md) | gate-trace / release-branch: adversarial-review refute frami | high | 36 |
 | [e45s33](./e45s33.md) | requirements: per-section approval state | high | 3 |
 | [e45s34](./e45s34.md) | develop-tdd: snapshot-before-transition hardening | high | 7 |
@@ -68,10 +68,10 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e45s40](./e45s40.md) | verify-work: mandatory real-browser verification | high | 23 |
 | [e45s41](./e45s41.md) | security-review: proven authorship SQL-safety doctrine | high | 18 |
 | [e48s01](./e48s01.md) | Generate epics-wiki and adr-wiki as OKF concept bundles from | high | 33 |
-| [e48s02](./e48s02.md) | Emit verification reports as OKF bundles from run-golden-sui | medium | 43 |
-| [e48s03](./e48s03.md) | OKF-ify bug-registry: specs/bugs/registry.yaml emits concept | high | 141 |
+| [e48s02](./e48s02.md) | Emit verification reports as OKF bundles from run-golden-sui | medium | 30 |
+| [e48s03](./e48s03.md) | OKF-ify bug-registry: specs/bugs/registry.yaml emits concept | high | 142 |
 | [e48s04](./e48s04.md) | Create viz.html — interactive force-layout graph companion f | medium | 12 |
-| [e48s05](./e48s05.md) | Wire OKF validation into CI (sync-skills.yml) and document i | medium | 182 |
+| [e48s05](./e48s05.md) | Wire OKF validation into CI (sync-skills.yml) and document i | medium | 170 |
 | [e48s06](./e48s06.md) | Add tier: field (core/extended/specialized) to OKF wiki inde | medium | 10 |
 | [e48s07](./e48s07.md) | Create publish-to-wiki kernel tool | high | 2 |
 | [e48s08](./e48s08.md) | Add GitHub Action Template for publish-wiki.yml [HARD GATE] | high | 8 |
@@ -83,9 +83,9 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e48s14](./e48s14.md) | Build-epic integration — BCP Plus in story sizing workflow | high | 14 |
 | [e48s15](./e48s15.md) | Refactor Skills Render Pipeline to Hybrid JSON Seam | high | 7 |
 | [e51s01](./e51s01.md) | CONVENTIONS — Always Green, Shift Left, Discovered Defects,  | high | 8 |
-| [e51s02](./e51s02.md) | seed-conventions — Preflight default, solo-git default, embe | high | 39 |
-| [e51s03](./e51s03.md) | kickoff-branch + verify-work — Preflight hard block and CI g | high | 62 |
-| [e51s04](./e51s04.md) | audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log rou | high | 625 |
+| [e51s02](./e51s02.md) | seed-conventions — Preflight default, solo-git default, embe | high | 40 |
+| [e51s03](./e51s03.md) | kickoff-branch + verify-work — Preflight hard block and CI g | high | 64 |
+| [e51s04](./e51s04.md) | audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log rou | high | 321 |
 | [e51s05](./e51s05.md) | CLAUDE.md — solo-default agent rules + bigpowers Preflight c | high | 7 |
 | [e54s01](./e54s01.md) | Snapshot the current skill catalog as an immutable baseline | high | 9 |
 | [e54s02](./e54s02.md) | Add a soft drift-detection gate for the freeze window | high | 14 |
@@ -93,7 +93,7 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e55s01](./e55s01.md) | Map every current doctrine source to a B0-B10 + Capstone blo | high | 8 |
 | [e55s02](./e55s02.md) | Write constitution.md from the mapping, CLAUDE.md/CONVENTION | high | 5 |
 | [e55s03](./e55s03.md) | Point CLAUDE.md/CONVENTIONS.md at constitution.md, don't del | high | 9 |
-| [e60s01](./e60s01.md) | Interactive installer with ASCII banner, global/local, tool  | high | 8 |
+| [e60s01](./e60s01.md) | Interactive installer with ASCII banner, global/local, tool  | high | 9 |
 | [e61s01](./e61s01.md) | Hermes adapter + hook templates (Wave A) | high | 11 |
 | [e61s02](./e61s02.md) | Install hub wiring (Wave B) | high | 15 |
 | [e62s01](./e62s01.md) | Integration: OpenCode adapter (Wave A) | high | 3 |
@@ -122,3 +122,7 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e74s02](./e74s02.md) | Install hub wiring (Wave B) | high | 26 |
 | [e76s01](./e76s01.md) | ZCode adapter — Wave A greenfield skills-dir | high | 8 |
 | [e76s02](./e76s02.md) | Install hub wiring (Wave B) | high | 16 |
+| [e79s01](./e79s01.md) | AGENTIC-STE ruleset document | high | 8 |
+| [e79s02](./e79s02.md) | Validator script + craft-skill HARD GATE | high | 21 |
+| [e79s03](./e79s03.md) | seed-conventions applies ruleset | high | 20 |
+| [e79s04](./e79s04.md) | stocktake-skills violation scanner | high | 20 |

--- a/specs/epics-wiki/e01.okf.md
+++ b/specs/epics-wiki/e01.okf.md
@@ -25,4 +25,4 @@ references:
 **Epic:** e01 | **WSJF:** 4.5 | **BCP:** 4 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-4 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e01-security/epic.yaml` for full specifications.
+4 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e01-security/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e02.okf.md
+++ b/specs/epics-wiki/e02.okf.md
@@ -25,4 +25,4 @@ references:
 **Epic:** e02 | **WSJF:** 4.3 | **BCP:** 4 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-4 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e02-verification-evals/epic.yaml` for full specifications.
+4 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e02-verification-evals/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e03.okf.md
+++ b/specs/epics-wiki/e03.okf.md
@@ -24,4 +24,4 @@ references:
 **Epic:** e03 | **WSJF:** 4.0 | **BCP:** 2 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-3 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e03-discovery-planning/epic.yaml` for full specifications.
+3 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e03-discovery-planning/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e04.okf.md
+++ b/specs/epics-wiki/e04.okf.md
@@ -24,4 +24,4 @@ references:
 **Epic:** e04 | **WSJF:** 3.8 | **BCP:** 3 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-3 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e04-ergonomics/epic.yaml` for full specifications.
+3 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e04-ergonomics/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e05.okf.md
+++ b/specs/epics-wiki/e05.okf.md
@@ -24,4 +24,4 @@ references:
 **Epic:** e05 | **WSJF:** 3.3 | **BCP:** 3 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-3 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e05-context-isolation-routing/epic.yaml` for full specifications.
+3 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e05-context-isolation-routing/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e06.okf.md
+++ b/specs/epics-wiki/e06.okf.md
@@ -24,4 +24,4 @@ references:
 **Epic:** e06 | **WSJF:** 3.0 | **BCP:** 3 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-3 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e06-taxonomy-provenance/epic.yaml` for full specifications.
+3 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e06-taxonomy-provenance/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e07.okf.md
+++ b/specs/epics-wiki/e07.okf.md
@@ -24,4 +24,4 @@ references:
 **Epic:** e07 | **WSJF:** 2.8 | **BCP:** 3 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-3 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e07-architectural-complexity/epic.yaml` for full specifications.
+3 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e07-architectural-complexity/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e08.okf.md
+++ b/specs/epics-wiki/e08.okf.md
@@ -22,4 +22,4 @@ references:
 **Epic:** e08 | **WSJF:** 2.5 | **BCP:** 1 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-1 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e08-wave-execution/epic.yaml` for full specifications.
+1 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e08-wave-execution/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e09.okf.md
+++ b/specs/epics-wiki/e09.okf.md
@@ -27,4 +27,4 @@ references:
 **Epic:** e09 | **WSJF:** 2.0 | **BCP:** 11 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-6 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e09-self-evolution/epic.yaml` for full specifications.
+6 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e09-self-evolution/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e10.okf.md
+++ b/specs/epics-wiki/e10.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e10 | **WSJF:** 1.8 | **BCP:** 2 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e10-stack-profiles/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e10-stack-profiles/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e11.okf.md
+++ b/specs/epics-wiki/e11.okf.md
@@ -26,4 +26,4 @@ references:
 **Epic:** e11 | **WSJF:** 1.0 | **BCP:** 10 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-5 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e11-sustain-cleanup/epic.yaml` for full specifications.
+5 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e11-sustain-cleanup/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e12.okf.md
+++ b/specs/epics-wiki/e12.okf.md
@@ -27,4 +27,4 @@ references:
 **Epic:** e12 | **WSJF:** 0 | **BCP:** 8 | **Status:** done
 **Release:** unknown | **Tier:** extended
 
-6 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e12-pi-support/epic.yaml` for full specifications.
+6 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e12-pi-support/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e13.okf.md
+++ b/specs/epics-wiki/e13.okf.md
@@ -24,4 +24,4 @@ references:
 **Epic:** e13 | **WSJF:** 7.7 | **BCP:** 3 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-3 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e13-catalog-integrity/epic.yaml` for full specifications.
+3 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e13-catalog-integrity/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e14.okf.md
+++ b/specs/epics-wiki/e14.okf.md
@@ -24,4 +24,4 @@ references:
 **Epic:** e14 | **WSJF:** 6.0 | **BCP:** 3 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-3 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e14-release-hardening-quality/epic.yaml` for full specifications.
+3 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e14-release-hardening-quality/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e15.okf.md
+++ b/specs/epics-wiki/e15.okf.md
@@ -24,4 +24,4 @@ references:
 **Epic:** e15 | **WSJF:** 5.2 | **BCP:** 5 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-3 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e15-ci-pipeline-publishing/epic.yaml` for full specifications.
+3 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e15-ci-pipeline-publishing/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e16.okf.md
+++ b/specs/epics-wiki/e16.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e16 | **WSJF:** 5.2 | **BCP:** 5 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e16-deployment-pipeline/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e16-deployment-pipeline/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e17.okf.md
+++ b/specs/epics-wiki/e17.okf.md
@@ -22,4 +22,4 @@ references:
 **Epic:** e17 | **WSJF:** 5.0 | **BCP:** 3 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-1 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e17-data-contract-validation/epic.yaml` for full specifications.
+1 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e17-data-contract-validation/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e18.okf.md
+++ b/specs/epics-wiki/e18.okf.md
@@ -26,4 +26,4 @@ references:
 **Epic:** e18 | **WSJF:** 4.8 | **BCP:** 0 | **Status:** done
 **Release:** unknown | **Tier:** extended
 
-5 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e18-quality-gates-impact/epic.yaml` for full specifications.
+5 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e18-quality-gates-impact/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e19.okf.md
+++ b/specs/epics-wiki/e19.okf.md
@@ -22,4 +22,4 @@ references:
 **Epic:** e19 | **WSJF:** 4.7 | **BCP:** 0 | **Status:** done
 **Release:** unknown | **Tier:** extended
 
-1 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e19-quick-fix-fast-path/epic.yaml` for full specifications.
+1 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e19-quick-fix-fast-path/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e20.okf.md
+++ b/specs/epics-wiki/e20.okf.md
@@ -27,4 +27,4 @@ references:
 **Epic:** e20 | **WSJF:** 3.6 | **BCP:** 5 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-6 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e20-build-epic-ergonomics/epic.yaml` for full specifications.
+6 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e20-build-epic-ergonomics/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e21.okf.md
+++ b/specs/epics-wiki/e21.okf.md
@@ -25,4 +25,4 @@ references:
 **Epic:** e21 | **WSJF:** 2.9 | **BCP:** 0 | **Status:** done
 **Release:** unknown | **Tier:** extended
 
-4 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e21-mcp-discovery-tools/epic.yaml` for full specifications.
+4 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e21-mcp-discovery-tools/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e22.okf.md
+++ b/specs/epics-wiki/e22.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e22 | **WSJF:** 5.5 | **BCP:** 2 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e22-skill-catalog-ci-gate/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e22-skill-catalog-ci-gate/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e23.okf.md
+++ b/specs/epics-wiki/e23.okf.md
@@ -24,4 +24,4 @@ references:
 **Epic:** e23 | **WSJF:** 4.5 | **BCP:** 3 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-3 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e23-benchmark-infrastructure/epic.yaml` for full specifications.
+3 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e23-benchmark-infrastructure/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e24.okf.md
+++ b/specs/epics-wiki/e24.okf.md
@@ -24,4 +24,4 @@ references:
 **Epic:** e24 | **WSJF:** 4.0 | **BCP:** 3 | **Status:** done
 **Release:** v1.0.0 | **Tier:** specialized
 
-3 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e24-planning-context-capsule/epic.yaml` for full specifications.
+3 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e24-planning-context-capsule/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e25.okf.md
+++ b/specs/epics-wiki/e25.okf.md
@@ -27,4 +27,4 @@ references:
 **Epic:** e25 | **WSJF:** 3.0 | **BCP:** 0 | **Status:** done
 **Release:** unknown | **Tier:** extended
 
-6 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e25-migrate-spec-enhancements/epic.yaml` for full specifications.
+6 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e25-migrate-spec-enhancements/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e26.okf.md
+++ b/specs/epics-wiki/e26.okf.md
@@ -28,4 +28,4 @@ references:
 **Epic:** e26 | **WSJF:** 4.2 | **BCP:** 0 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-7 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e26-security-review/epic.yaml` for full specifications.
+7 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e26-security-review/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e27.okf.md
+++ b/specs/epics-wiki/e27.okf.md
@@ -22,4 +22,4 @@ references:
 **Epic:** e27 | **WSJF:** 2.0 | **BCP:** 0 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-1 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e27-specs-naming-convention/epic.yaml` for full specifications.
+1 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e27-specs-naming-convention/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e28.okf.md
+++ b/specs/epics-wiki/e28.okf.md
@@ -25,4 +25,4 @@ references:
 **Epic:** e28 | **WSJF:** 2.0 | **BCP:** 13 | **Status:** done
 **Release:** v2.6x "Traceability Gate | **Tier:** core
 
-4 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e28-sync-pipeline/epic.yaml` for full specifications.
+4 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e28-sync-pipeline/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e29.okf.md
+++ b/specs/epics-wiki/e29.okf.md
@@ -24,4 +24,4 @@ references:
 **Epic:** e29 | **WSJF:** 3.3   # (BV 5 + TC 2 + RR-OE 3) / JS 3 — see release-plan note | **BCP:** 0 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-3 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e29-skills-directory/epic.yaml` for full specifications.
+3 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e29-skills-directory/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e30.okf.md
+++ b/specs/epics-wiki/e30.okf.md
@@ -25,4 +25,4 @@ references:
 **Epic:** e30 | **WSJF:** 6.5 | **BCP:** 8 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-4 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e30-arch-quick-fixes/epic.yaml` for full specifications.
+4 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e30-arch-quick-fixes/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e31.okf.md
+++ b/specs/epics-wiki/e31.okf.md
@@ -28,4 +28,4 @@ references:
 **Epic:** e31 | **WSJF:** 9.5 | **BCP:** 11 | **Status:** done
 **Release:** v2.45.0 | **Tier:** specialized
 
-7 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e31-quality-guarantee/epic.yaml` for full specifications.
+7 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e31-quality-guarantee/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e32.okf.md
+++ b/specs/epics-wiki/e32.okf.md
@@ -28,4 +28,4 @@ references:
 **Epic:** e32 | **WSJF:** 4.00 | **BCP:** 13 | **Status:** done
 **Release:** v2.7x/v3.0 "Semantic Bridge" (leads) | **Tier:** specialized
 
-7 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e32-mcp-context-server/epic.yaml` for full specifications.
+7 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e32-mcp-context-server/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e33.okf.md
+++ b/specs/epics-wiki/e33.okf.md
@@ -26,4 +26,4 @@ references:
 **Epic:** e33 | **WSJF:** 2.8   # (BV 7 + TC 3 + RR-OE 4) / JS 5 — see release-plan note | **BCP:** 0 | **Status:** done
 **Release:** unknown | **Tier:** extended
 
-5 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e33-docs-website/epic.yaml` for full specifications.
+5 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e33-docs-website/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e34.okf.md
+++ b/specs/epics-wiki/e34.okf.md
@@ -25,4 +25,4 @@ references:
 **Epic:** e34 | **WSJF:** 2.75 | **BCP:** 10 | **Status:** done
 **Release:** v2.45.0 | **Tier:** specialized
 
-4 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e34-context-engineering/epic.yaml` for full specifications.
+4 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e34-context-engineering/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e35.okf.md
+++ b/specs/epics-wiki/e35.okf.md
@@ -31,4 +31,4 @@ references:
 **Epic:** e35 | **WSJF:** 3.0 | **BCP:** 20 | **Status:** done
 **Release:** v2.8x "Docs Polish | **Tier:** extended
 
-10 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e35-historical-refs/epic.yaml` for full specifications.
+10 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e35-historical-refs/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e36.okf.md
+++ b/specs/epics-wiki/e36.okf.md
@@ -26,4 +26,4 @@ references:
 **Epic:** e36 | **WSJF:** 1.4 | **BCP:** 12 | **Status:** done
 **Release:** v2.8x "Docs Polish | **Tier:** extended
 
-5 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e36-doc-dedup/epic.yaml` for full specifications.
+5 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e36-doc-dedup/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e37.okf.md
+++ b/specs/epics-wiki/e37.okf.md
@@ -37,4 +37,4 @@ references:
 **Epic:** e37 | **WSJF:** 7.0 | **BCP:** 45 | **Status:** done
 **Release:** v2.9x | **Tier:** extended
 
-16 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e37-reach/epic.yaml` for full specifications.
+16 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e37-reach/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e38.okf.md
+++ b/specs/epics-wiki/e38.okf.md
@@ -30,4 +30,4 @@ references:
 **Epic:** e38 | **WSJF:** 3.50 | **BCP:** 13 | **Status:** done
 **Release:** v2.45.0 | **Tier:** core
 
-9 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e38-traceability-gate/epic.yaml` for full specifications.
+9 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e38-traceability-gate/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e39.okf.md
+++ b/specs/epics-wiki/e39.okf.md
@@ -31,4 +31,4 @@ references:
 **Epic:** e39 | **WSJF:** 3.60 | **BCP:** 20 | **Status:** done
 **Release:** v2.7x/v3.0 "Semantic Bridge"  # corrected 2026-07-04 from stale v2.45.0 (BUG-2026-07-03-capsule-release-labels) | **Tier:** extended
 
-10 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e39-knowledge-graph/epic.yaml` for full specifications.
+10 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e39-knowledge-graph/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e40.okf.md
+++ b/specs/epics-wiki/e40.okf.md
@@ -29,4 +29,4 @@ references:
 **Epic:** e40 | **WSJF:** 3.2 | **BCP:** 18 | **Status:** done
 **Release:** v2.45.0 | **Tier:** core
 
-8 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e40-metrics-integrity/epic.yaml` for full specifications.
+8 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e40-metrics-integrity/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e41.okf.md
+++ b/specs/epics-wiki/e41.okf.md
@@ -33,4 +33,4 @@ references:
 **Epic:** e41 | **WSJF:** 3.75 | **BCP:** 10 | **Status:** done
 **Release:** v2.7x | **Tier:** core
 
-12 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e41-public-receipts/epic.yaml` for full specifications.
+12 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e41-public-receipts/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e42.okf.md
+++ b/specs/epics-wiki/e42.okf.md
@@ -25,4 +25,4 @@ references:
 **Epic:** e42 | **WSJF:** 1.8 | **BCP:** 10 | **Status:** done
 **Release:** v2.7x/v3.0 "Semantic Bridge | **Tier:** extended
 
-4 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e42-golden-stories/epic.yaml` for full specifications.
+4 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e42-golden-stories/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e43.okf.md
+++ b/specs/epics-wiki/e43.okf.md
@@ -30,4 +30,4 @@ references:
 **Epic:** e43 | **WSJF:** 2.5 | **BCP:** 11 | **Status:** done
 **Release:** v2.7x/v3.0  # pulled from v2.8x to ship site + receipts + worked example together | **Tier:** extended
 
-9 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e43-showcase-repo/epic.yaml` for full specifications.
+9 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e43-showcase-repo/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e44.okf.md
+++ b/specs/epics-wiki/e44.okf.md
@@ -27,4 +27,4 @@ references:
 **Epic:** e44 | **WSJF:** 3.75 | **BCP:** 14 | **Status:** done
 **Release:** v2.7x/v3.0 "Semantic Bridge"  # corrected 2026-07-04 from stale v2.45.0 (BUG-2026-07-03-capsule-release-labels) | **Tier:** core
 
-6 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e44-migrate-version/epic.yaml` for full specifications.
+6 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e44-migrate-version/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e45.okf.md
+++ b/specs/epics-wiki/e45.okf.md
@@ -62,4 +62,4 @@ references:
 **Epic:** e45 | **WSJF:** 5.0 | **BCP:** 45 | **Status:** done
 **Release:** v2.9x | **Tier:** core
 
-41 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e45-quality-core/epic.yaml` for full specifications.
+41 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e45-quality-core/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e46.okf.md
+++ b/specs/epics-wiki/e46.okf.md
@@ -25,4 +25,4 @@ references:
 **Epic:** e46 | **WSJF:** 3.4 | **BCP:** 16 | **Status:** done
 **Release:** v2.8x | **Tier:** core
 
-4 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e46-risk-based-verification/epic.yaml` for full specifications.
+4 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e46-risk-based-verification/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e47.okf.md
+++ b/specs/epics-wiki/e47.okf.md
@@ -25,4 +25,4 @@ references:
 **Epic:** e47 | **WSJF:** 4.3 | **BCP:** 9 | **Status:** done
 **Release:** v2.8x | **Tier:** extended
 
-4 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e47-cross-tool-distribution/epic.yaml` for full specifications.
+4 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e47-cross-tool-distribution/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e48.okf.md
+++ b/specs/epics-wiki/e48.okf.md
@@ -36,4 +36,4 @@ references:
 **Epic:** e48 | **WSJF:** 2.5 | **BCP:** 40 | **Status:** done
 **Release:** v2.9x | **Tier:** extended
 
-15 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e48-foundation/epic.yaml` for full specifications.
+15 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e48-foundation/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e51.okf.md
+++ b/specs/epics-wiki/e51.okf.md
@@ -26,4 +26,4 @@ references:
 **Epic:** e51 | **WSJF:** 7.0 | **BCP:** 12 | **Status:** done
 **Release:** v2.9x | **Tier:** specialized
 
-5 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e51-always-green-shift-left/epic.yaml` for full specifications.
+5 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e51-always-green-shift-left/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e53.okf.md
+++ b/specs/epics-wiki/e53.okf.md
@@ -25,4 +25,4 @@ references:
 **Epic:** e53 | **WSJF:** 8.0 | **BCP:** 9 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-4 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e53-establish-migration-baseline/epic.yaml` for full specifications.
+4 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e53-establish-migration-baseline/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e54.okf.md
+++ b/specs/epics-wiki/e54.okf.md
@@ -24,4 +24,4 @@ references:
 **Epic:** e54 | **WSJF:** 6.7 | **BCP:** 6 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-3 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e54-freeze-catalog-drift/epic.yaml` for full specifications.
+3 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e54-freeze-catalog-drift/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e55.okf.md
+++ b/specs/epics-wiki/e55.okf.md
@@ -24,4 +24,4 @@ references:
 **Epic:** e55 | **WSJF:** 6.0 | **BCP:** 0 | **Status:** scoped
 **Release:** unknown | **Tier:** specialized
 
-3 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e55-extract-constitution/epic.yaml` for full specifications.
+3 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/archive/e55-extract-constitution/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e60.okf.md
+++ b/specs/epics-wiki/e60.okf.md
@@ -22,4 +22,4 @@ references:
 **Epic:** e60 | **WSJF:** 9.0 | **BCP:** 3 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-1 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/e60-interactive-installer/epic.yaml` for full specifications.
+1 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/e60-interactive-installer/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e61.okf.md
+++ b/specs/epics-wiki/e61.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e61 | **WSJF:** 5.0 | **BCP:** 0 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/e61-integration-hermes/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/e61-integration-hermes/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e62.okf.md
+++ b/specs/epics-wiki/e62.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e62 | **WSJF:** 4.0 | **BCP:** 4 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/e62-integration-opencode/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/e62-integration-opencode/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e64.okf.md
+++ b/specs/epics-wiki/e64.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e64 | **WSJF:** 6.0 | **BCP:** 0 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/e64-integration-gemini/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/e64-integration-gemini/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e65.okf.md
+++ b/specs/epics-wiki/e65.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e65 | **WSJF:** 6.0 | **BCP:** 5 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/e65-integration-codex/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/e65-integration-codex/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e66.okf.md
+++ b/specs/epics-wiki/e66.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e66 | **WSJF:** 5.0 | **BCP:** 5 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/e66-integration-cline/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/e66-integration-cline/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e67.okf.md
+++ b/specs/epics-wiki/e67.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e67 | **WSJF:** 5.0 | **BCP:** 5 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/e67-integration-kilo/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/e67-integration-kilo/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e68.okf.md
+++ b/specs/epics-wiki/e68.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e68 | **WSJF:** 6.0 | **BCP:** 5 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/e68-integration-qwen-code/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/e68-integration-qwen-code/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e69.okf.md
+++ b/specs/epics-wiki/e69.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e69 | **WSJF:** 5.0 | **BCP:** 0 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/e69-integration-mimo-code/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/e69-integration-mimo-code/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e70.okf.md
+++ b/specs/epics-wiki/e70.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e70 | **WSJF:** 5.0 | **BCP:** 5 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/e70-integration-trae/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/e70-integration-trae/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e71.okf.md
+++ b/specs/epics-wiki/e71.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e71 | **WSJF:** 4.0 | **BCP:** 4 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/e71-integration-copilot/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/e71-integration-copilot/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e72.okf.md
+++ b/specs/epics-wiki/e72.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e72 | **WSJF:** 6.0 | **BCP:** 5 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/e72-integration-codebuddy/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/e72-integration-codebuddy/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e73.okf.md
+++ b/specs/epics-wiki/e73.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e73 | **WSJF:** 5.0 | **BCP:** 5 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/e73-integration-windsurf/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/e73-integration-windsurf/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e74.okf.md
+++ b/specs/epics-wiki/e74.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e74 | **WSJF:** 4.0 | **BCP:** 2 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/e74-integration-antigravity/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/e74-integration-antigravity/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e76.okf.md
+++ b/specs/epics-wiki/e76.okf.md
@@ -23,4 +23,4 @@ references:
 **Epic:** e76 | **WSJF:** 5.0 | **BCP:** 0 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-2 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/e76-integration-zcode/epic.yaml` for full specifications.
+2 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/e76-integration-zcode/epic.yaml` for full specifications.

--- a/specs/epics-wiki/e79.okf.md
+++ b/specs/epics-wiki/e79.okf.md
@@ -1,0 +1,28 @@
+---
+okf_kind: concept
+okf_version: "0.1"
+type: epic
+id: "e79"
+title: "Agentic Controlled English (STE-style instruction precision)"
+category: epic
+tier: specialized
+wsjf: 6.0
+bcps: 8
+status: scoped
+release: unknown
+codename: ""
+story_count: 4
+generator: scripts/generate-epics-wiki.sh
+references:
+    - e79s01
+    - e79s02
+    - e79s03
+    - e79s04
+---
+
+# Agentic Controlled English (STE-style instruction precision)
+
+**Epic:** e79 | **WSJF:** 6.0 | **BCP:** 8 | **Status:** scoped
+**Release:** unknown | **Tier:** specialized
+
+4 stories. See `/Users/danielvm/Developer/feat-agentic-ste/specs/epics/e79-agentic-ste/epic.yaml` for full specifications.

--- a/specs/epics/e79-agentic-ste/e79s01-agentic-ste-doc.md
+++ b/specs/epics/e79-agentic-ste/e79s01-agentic-ste-doc.md
@@ -1,6 +1,6 @@
 # e79s01 — AGENTIC-STE ruleset document
 
-**Epic:** e79 | **Story:** e79s01 | **Status:** todo | **BCPs:** 2
+**Epic:** e79 | **Story:** e79s01 | **Status:** done | **BCPs:** 2
 
 ## Goal
 

--- a/specs/epics/e79-agentic-ste/e79s01-tasks.yaml
+++ b/specs/epics/e79-agentic-ste/e79s01-tasks.yaml
@@ -1,7 +1,7 @@
 story_id: e79s01
 title: "AGENTIC-STE ruleset document"
 spec: e79s01-agentic-ste-doc.md
-status: todo
+status: done
 bcps: 2
 risk: P2
 depends_on: []
@@ -16,4 +16,4 @@ tasks:
       echo OK
     risk: P2
     security: none
-    status: todo
+    status: done

--- a/specs/epics/e79-agentic-ste/e79s02-tasks.yaml
+++ b/specs/epics/e79-agentic-ste/e79s02-tasks.yaml
@@ -1,7 +1,7 @@
 story_id: e79s02
 title: "Validator script + craft-skill HARD GATE"
 spec: e79s02-validator-craft-skill.md
-status: todo
+status: done
 bcps: 3
 risk: P2
 depends_on:
@@ -17,4 +17,4 @@ tasks:
       echo OK
     risk: P2
     security: none
-    status: todo
+    status: done

--- a/specs/epics/e79-agentic-ste/e79s02-validator-craft-skill.md
+++ b/specs/epics/e79-agentic-ste/e79s02-validator-craft-skill.md
@@ -1,6 +1,6 @@
 # e79s02 — Validator script + craft-skill HARD GATE
 
-**Epic:** e79 | **Story:** e79s02 | **Status:** todo | **BCPs:** 3
+**Epic:** e79 | **Story:** e79s02 | **Status:** done | **BCPs:** 3
 
 ## Goal
 

--- a/specs/epics/e79-agentic-ste/e79s03-seed-conventions.md
+++ b/specs/epics/e79-agentic-ste/e79s03-seed-conventions.md
@@ -1,6 +1,6 @@
 # e79s03 — seed-conventions applies Agentic STE
 
-**Status:** stub (intake)  
+**Status:** done  
 **Epic:** e79  
 **GitHub:** https://github.com/danielvm-git/bigpowers/issues/91  
 **Requirement delta:** ADDED

--- a/specs/epics/e79-agentic-ste/e79s03-tasks.yaml
+++ b/specs/epics/e79-agentic-ste/e79s03-tasks.yaml
@@ -1,7 +1,7 @@
 story_id: e79s03
 title: "seed-conventions applies ruleset"
 spec: e79s03-seed-conventions.md
-status: todo
+status: done
 bcps: 2
 risk: P2
 depends_on:
@@ -16,4 +16,4 @@ tasks:
       echo OK
     risk: P2
     security: none
-    status: todo
+    status: done

--- a/specs/epics/e79-agentic-ste/e79s04-stocktake-scanner.md
+++ b/specs/epics/e79-agentic-ste/e79s04-stocktake-scanner.md
@@ -1,6 +1,6 @@
 # e79s04 — stocktake-skills STE scanner
 
-**Status:** stub (intake)  
+**Status:** done  
 **Epic:** e79  
 **GitHub:** https://github.com/danielvm-git/bigpowers/issues/91  
 **Requirement delta:** ADDED

--- a/specs/epics/e79-agentic-ste/e79s04-tasks.yaml
+++ b/specs/epics/e79-agentic-ste/e79s04-tasks.yaml
@@ -1,7 +1,7 @@
 story_id: e79s04
 title: "stocktake-skills violation scanner"
 spec: e79s04-stocktake-scanner.md
-status: todo
+status: done
 bcps: 1
 risk: P2
 depends_on:
@@ -17,4 +17,4 @@ tasks:
       echo OK
     risk: P2
     security: none
-    status: todo
+    status: done

--- a/specs/epics/e79-agentic-ste/epic.yaml
+++ b/specs/epics/e79-agentic-ste/epic.yaml
@@ -16,7 +16,7 @@ source: >
 stories:
   - id: e79s01
     title: AGENTIC-STE ruleset document
-    status: todo
+    status: done
     bcps: 2
     description: >
       Commit docs/AGENTIC-STE.md with concrete numeric rules — word/sentence caps,
@@ -28,7 +28,7 @@ stories:
       - "story: e79s01"
   - id: e79s02
     title: Validator script + craft-skill HARD GATE
-    status: todo
+    status: done
     bcps: 3
     description: >
       Add scripts/validate-agentic-ste.sh and extend craft-skill HARD GATE table
@@ -42,7 +42,7 @@ stories:
       - "story: e79s02"
   - id: e79s03
     title: seed-conventions applies ruleset
-    status: todo
+    status: done
     bcps: 2
     description: >
       Extend seed-conventions to apply AGENTIC-STE rules when generating
@@ -54,7 +54,7 @@ stories:
       - "story: e79s03"
   - id: e79s04
     title: stocktake-skills violation scanner
-    status: todo
+    status: done
     bcps: 1
     description: >
       Extend stocktake-skills batch audit to flag hedge words and oversized

--- a/specs/traceability-matrix.json
+++ b/specs/traceability-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-24T19:53:42.385968+00:00",
+  "generated_at": "2026-07-25T05:28:09.653424+00:00",
   "matrix_version": "1.0",
   "stories": [
     {
@@ -37,6 +37,12 @@
         },
         {
           "file": "specs/wayfinder/doc-templates/tickets/T18-agents-and-conventions.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/e79s03-seed-conventions.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -114,7 +120,7 @@
           "method": "task_reference"
         }
       ],
-      "link_count": 17
+      "link_count": 18
     },
     {
       "id": "e37s02",
@@ -192,6 +198,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/epics/e79-agentic-ste/e79s03-seed-conventions.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": ".continue/rules/seed-conventions.md",
           "line": 0,
           "confidence": "medium",
@@ -222,7 +234,7 @@
           "method": "task_reference"
         }
       ],
-      "link_count": 9
+      "link_count": 10
     },
     {
       "id": "e37s04",
@@ -498,12 +510,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "website/src/content/docs/decisions/0007-agents-md-spine-context-derivatives.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/epics/archive/e37-reach/e37s08-tasks.yaml",
           "line": 0,
           "confidence": "low",
@@ -522,7 +528,7 @@
           "method": "task_reference"
         }
       ],
-      "link_count": 12
+      "link_count": 11
     },
     {
       "id": "e37s07",
@@ -918,6 +924,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/epics/e79-agentic-ste/e79s03-seed-conventions.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/epics/archive/e37-reach/e37s14-seed-codex-wiring.md",
           "line": 0,
           "confidence": "medium",
@@ -960,7 +972,7 @@
           "method": "task_reference"
         }
       ],
-      "link_count": 9
+      "link_count": 10
     },
     {
       "id": "e37s15",
@@ -1236,6 +1248,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/epics/e79-agentic-ste/e79s02-validator-craft-skill.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/epics/archive/e38-traceability-gate/e38s06-gate-trace-skill.md",
           "line": 0,
           "confidence": "medium",
@@ -1260,7 +1278,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 14
+      "link_count": 15
     },
     {
       "id": "e45s03",
@@ -2436,12 +2454,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "website/dist/pagefind/pagefind-worker.js",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "website/src/content/docs/guides/WORKFLOW-SOP-v2.md",
           "line": 0,
           "confidence": "medium",
@@ -2538,7 +2550,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 85
+      "link_count": 84
     },
     {
       "id": "e45s10",
@@ -2874,6 +2886,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/epics/e79-agentic-ste/e79s02-validator-craft-skill.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/epics/archive/e37-reach/e37s10-wave-b-skills-dir.md",
           "line": 0,
           "confidence": "medium",
@@ -2976,7 +2994,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 43
+      "link_count": 44
     },
     {
       "id": "e45s13",
@@ -3696,18 +3714,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190334.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-144556.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-175346.md",
           "line": 0,
           "confidence": "medium",
@@ -3720,49 +3726,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-102313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-103815.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163934.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202335.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145222.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165427.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-151538.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132836.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3780,31 +3744,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-155647.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181947.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212931.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-160106.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-180858.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3817,48 +3757,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-143153.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215320.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-132011.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-172717.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174039.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132651.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212830.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182718.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3877,18 +3775,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-122420.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-154721.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183547.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3930,12 +3816,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-160627.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-165137.md",
           "line": 0,
           "confidence": "medium",
@@ -3948,43 +3828,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-205519.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-131516.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101228.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-102150.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214411.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260622-001710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-165047.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3997,36 +3841,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-000102.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-131912.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-132538.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133327.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001605.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105239.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4050,55 +3864,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101847.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173628.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182629.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-161434.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154217.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-165703.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-143839.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163159.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260711-001225.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4116,31 +3888,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-185319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183644.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260629-132810.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001328.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4158,25 +3906,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-202226.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164609.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192340.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165651.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4194,43 +3924,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-160550.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-134603.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091641.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163954.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-210053.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190002.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-093104.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4243,24 +3937,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164251.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132615.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-172212.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-140513.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4290,31 +3966,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154135.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170532.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154323.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-082500.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101730.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4332,109 +3990,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-165007.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-205711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-182236.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-135136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-103737.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-093242.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-213042.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-134029.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164826.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-162400.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110426.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-223023.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-134126.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-162245.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-105652.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-114127.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-164053.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154055.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4458,25 +4020,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164801.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131809.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-175313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181604.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4500,37 +4044,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-110149.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-131715.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-133750.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-181656.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174414.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4542,19 +4056,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192541.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-233740.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173515.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4566,49 +4068,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190415.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192435.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-094025.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-161022.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-125910.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215656.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-135950.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092605.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4632,18 +4092,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154936.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132530.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174045.md",
           "line": 0,
           "confidence": "medium",
@@ -4662,31 +4110,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091938.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-133945.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174055.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001312.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110458.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4746,55 +4170,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105145.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-193609.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174351.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-154353.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-131211.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-130715.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182555.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-124641.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4812,31 +4194,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120114.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-234357.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110242.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-143756.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-235505.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4849,18 +4207,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-160732.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-145214.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-161026.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4884,12 +4230,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001100.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-150417.md",
           "line": 0,
           "confidence": "medium",
@@ -4908,19 +4248,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-151437.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-143504.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-185913.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4932,25 +4260,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-140559.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001518.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-184837.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4974,24 +4284,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-154541.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-105728.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-111510.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-180901.md",
           "line": 0,
           "confidence": "medium",
@@ -4999,24 +4291,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260702-133532.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145423.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-105643.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-141624.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5040,24 +4314,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181236.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163830.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092533.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174025.md",
           "line": 0,
           "confidence": "medium",
@@ -5070,55 +4326,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145349.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-164643.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-205433.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132944.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163746.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-091141.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184856.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-143844.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133446.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5136,42 +4344,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-182836.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202450.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194130.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-213831.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174245.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-005800.md",
           "line": 0,
           "confidence": "medium",
@@ -5179,12 +4351,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-173348.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-165006.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5202,25 +4368,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-005225.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-143007.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-171058.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-150742.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5233,12 +4381,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165618.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-130546.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5286,49 +4428,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-154637.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001919.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-144757.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-220941.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174117.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-093202.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110206.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120150.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5352,43 +4452,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131734.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182807.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173917.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-185210.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-101322.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165256.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192433.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5400,37 +4464,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105013.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-200110.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-114242.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001233.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-130623.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-162439.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5442,37 +4476,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002229.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-144202.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183102.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-133837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-233707.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212919.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5496,25 +4506,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164345.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120250.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165035.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-112952.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5532,42 +4524,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194053.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001439.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202651.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-165120.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-143840.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-000955.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-144557.md",
           "line": 0,
           "confidence": "medium",
@@ -5575,18 +4531,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174133.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115538.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-113034.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5604,12 +4548,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-161502.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170255.md",
           "line": 0,
           "confidence": "medium",
@@ -5617,42 +4555,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164704.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132813.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164342.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-154344.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-120815.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-164833.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154835.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5670,37 +4572,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-155747.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173218.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260626-204822.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202348.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-161543.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5718,12 +4596,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-113257.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-181044.md",
           "line": 0,
           "confidence": "medium",
@@ -5736,37 +4608,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-133458.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164823.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-180900.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-104009.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-163929.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5785,12 +4627,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-081735.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-154818.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5820,12 +4656,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170738.md",
           "line": 0,
           "confidence": "medium",
@@ -5845,12 +4675,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-153801.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194215.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5880,31 +4704,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084719.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132017.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-171157.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183350.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-150937.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -5928,18 +4728,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-110050.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001337.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260627-133613.md",
           "line": 0,
           "confidence": "medium",
@@ -5958,12 +4746,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-220404.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-085740.md",
           "line": 0,
           "confidence": "medium",
@@ -5976,37 +4758,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-193756.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163218.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163309.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-130821.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-160906.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-094142.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6024,19 +4776,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202442.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164036.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6060,55 +4800,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214125.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-164249.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132604.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-142359.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-163353.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132933.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-175550.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174408.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-163120.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6126,12 +4824,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182339.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165418.md",
           "line": 0,
           "confidence": "medium",
@@ -6144,13 +4836,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-155114.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133637.md",
+          "file": "specs/verifications/reports/audit-cleancode-20260725-021918.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6168,19 +4854,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-131140.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165111.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-144700.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6234,7 +4908,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202558.md",
+          "file": "specs/verifications/reports/audit-cleancode-20260725-022131.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6246,43 +4920,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-163657.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215213.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-160919.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-204345.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-153739.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175227.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6295,60 +4933,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260621-225313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164721.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-093336.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132207.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130940.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105058.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-163457.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084617.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084805.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174631.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6372,49 +4956,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002322.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-220022.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-135838.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-093012.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-152233.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-131617.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181159.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6432,12 +4974,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131350.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-083101.md",
           "line": 0,
           "confidence": "medium",
@@ -6450,31 +4986,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115557.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-114525.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-093128.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-221847.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-154451.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6486,73 +4998,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212552.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-161624.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181706.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-105035.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092013.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001702.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132130.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-163956.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001902.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-093246.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-204300.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6576,18 +5022,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132858.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165902.md",
           "line": 0,
           "confidence": "medium",
@@ -6600,25 +5034,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001029.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-172425.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145255.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-133730.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6630,73 +5046,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175929.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-172525.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133254.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184658.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164258.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-164418.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194009.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-092924.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260629-130359.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130821.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190539.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6714,37 +5070,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-163613.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-142458.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-005318.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-235409.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001952.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6762,37 +5088,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002154.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-171134.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260621-182630.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165733.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091717.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084911.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6816,43 +5112,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182346.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115503.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-101402.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260621-231038.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-123626.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184355.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-172751.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6864,37 +5124,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101633.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130900.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-103924.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101425.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-163837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175105.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6918,19 +5148,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-234704.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163238.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-172133.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6942,25 +5160,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214329.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-144506.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-210010.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173306.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6985,12 +5185,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-151341.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131314.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7068,7 +5262,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 582
+      "link_count": 278
     },
     {
       "id": "e45s19",
@@ -7165,7 +5359,7 @@
         },
         {
           "file": ".gemini/extensions/bigpowers/commands/prompts/seed-conventions.md",
-          "line": 106,
+          "line": 123,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -7177,7 +5371,7 @@
         },
         {
           "file": ".gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md",
-          "line": 108,
+          "line": 125,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -7189,7 +5383,7 @@
         },
         {
           "file": ".trae/skills/seed-conventions/SKILL.md",
-          "line": 107,
+          "line": 124,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -7201,7 +5395,7 @@
         },
         {
           "file": ".windsurf/rules/seed-conventions.md",
-          "line": 107,
+          "line": 124,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -7213,7 +5407,7 @@
         },
         {
           "file": ".agents/skills/seed-conventions/SKILL.md",
-          "line": 107,
+          "line": 124,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -7231,7 +5425,7 @@
         },
         {
           "file": ".kilocode/rules/seed-conventions.md",
-          "line": 107,
+          "line": 124,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -7243,7 +5437,7 @@
         },
         {
           "file": ".codex/skills/seed-conventions/SKILL.md",
-          "line": 107,
+          "line": 124,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -7267,7 +5461,7 @@
         },
         {
           "file": ".codebuddy/skills/seed-conventions/SKILL.md",
-          "line": 107,
+          "line": 124,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -7279,7 +5473,7 @@
         },
         {
           "file": ".zcode/skills/seed-conventions/SKILL.md",
-          "line": 107,
+          "line": 124,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -7291,7 +5485,7 @@
         },
         {
           "file": ".mimocode/skills/seed-conventions/SKILL.md",
-          "line": 107,
+          "line": 124,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -7303,7 +5497,7 @@
         },
         {
           "file": ".hermes/skills/seed-conventions/SKILL.md",
-          "line": 107,
+          "line": 124,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -7315,7 +5509,7 @@
         },
         {
           "file": ".pi/prompts/seed-conventions.md",
-          "line": 106,
+          "line": 123,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -7327,12 +5521,18 @@
         },
         {
           "file": ".pi/skills/seed-conventions/SKILL.md",
-          "line": 107,
+          "line": 124,
           "confidence": "high",
           "method": "explicit_tag"
         },
         {
           "file": "specs/skills-wiki/skills/seed-conventions.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/e79s03-seed-conventions.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7350,7 +5550,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 32
+      "link_count": 33
     },
     {
       "id": "e45s22",
@@ -8448,18 +6648,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190334.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-144556.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-175346.md",
           "line": 0,
           "confidence": "medium",
@@ -8472,49 +6660,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-102313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-103815.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163934.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202335.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145222.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165427.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-151538.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132836.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8532,31 +6678,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-155647.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181947.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212931.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-160106.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-180858.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8569,48 +6691,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-143153.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215320.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-132011.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-172717.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174039.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132651.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212830.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182718.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8629,18 +6709,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-122420.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-154721.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183547.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8682,12 +6750,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-160627.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-165137.md",
           "line": 0,
           "confidence": "medium",
@@ -8700,43 +6762,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-205519.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-131516.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101228.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-102150.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214411.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260622-001710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-165047.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8749,36 +6775,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-000102.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-131912.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-132538.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133327.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001605.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105239.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8802,55 +6798,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101847.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173628.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182629.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-161434.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154217.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-165703.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-143839.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163159.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260711-001225.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8868,31 +6822,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-185319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183644.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260629-132810.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001328.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8910,25 +6840,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-202226.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164609.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192340.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165651.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8946,43 +6858,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-160550.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-134603.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091641.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163954.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-210053.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190002.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-093104.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -8995,24 +6871,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164251.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132615.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-172212.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-140513.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9042,31 +6900,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154135.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170532.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154323.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-082500.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101730.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9084,109 +6924,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-165007.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-205711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-182236.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-135136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-103737.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-093242.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-213042.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-134029.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164826.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-162400.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110426.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-223023.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-134126.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-162245.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-105652.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-114127.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-164053.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154055.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9210,25 +6954,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164801.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131809.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-175313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181604.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9252,37 +6978,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-110149.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-131715.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-133750.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-181656.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174414.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9294,19 +6990,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192541.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-233740.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173515.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9318,49 +7002,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190415.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192435.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-094025.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-161022.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-125910.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215656.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-135950.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092605.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9384,18 +7026,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154936.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132530.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174045.md",
           "line": 0,
           "confidence": "medium",
@@ -9414,31 +7044,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091938.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-133945.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174055.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001312.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110458.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9498,55 +7104,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105145.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-193609.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174351.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-154353.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-131211.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-130715.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182555.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-124641.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9564,31 +7128,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120114.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-234357.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110242.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-143756.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-235505.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9601,18 +7141,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-160732.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-145214.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-161026.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9636,12 +7164,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001100.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-150417.md",
           "line": 0,
           "confidence": "medium",
@@ -9660,19 +7182,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-151437.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-143504.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-185913.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9684,25 +7194,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-140559.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001518.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-184837.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9726,24 +7218,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-154541.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-105728.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-111510.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-180901.md",
           "line": 0,
           "confidence": "medium",
@@ -9751,24 +7225,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260702-133532.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145423.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-105643.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-141624.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9792,24 +7248,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181236.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163830.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092533.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174025.md",
           "line": 0,
           "confidence": "medium",
@@ -9822,55 +7260,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145349.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-164643.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-205433.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132944.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163746.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-091141.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184856.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-143844.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133446.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9888,42 +7278,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-182836.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202450.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194130.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-213831.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174245.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-005800.md",
           "line": 0,
           "confidence": "medium",
@@ -9931,12 +7285,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-173348.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-165006.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9954,25 +7302,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-005225.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-143007.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-171058.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-150742.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -9985,12 +7315,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165618.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-130546.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10038,49 +7362,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-154637.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001919.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-144757.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-220941.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174117.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-093202.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110206.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120150.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10104,43 +7386,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131734.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182807.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173917.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-185210.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-101322.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165256.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192433.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10152,37 +7398,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105013.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-200110.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-114242.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001233.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-130623.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-162439.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10194,37 +7410,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002229.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-144202.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183102.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-133837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-233707.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212919.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10248,25 +7440,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164345.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120250.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165035.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-112952.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10284,42 +7458,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194053.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001439.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202651.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-165120.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-143840.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-000955.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-144557.md",
           "line": 0,
           "confidence": "medium",
@@ -10327,18 +7465,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174133.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115538.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-113034.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10356,12 +7482,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-161502.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170255.md",
           "line": 0,
           "confidence": "medium",
@@ -10369,42 +7489,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164704.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132813.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164342.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-154344.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-120815.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-164833.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154835.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10422,37 +7506,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-155747.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173218.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260626-204822.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202348.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-161543.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10470,12 +7530,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-113257.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-181044.md",
           "line": 0,
           "confidence": "medium",
@@ -10488,37 +7542,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-133458.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164823.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-180900.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-104009.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-163929.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10537,12 +7561,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-081735.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-154818.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10572,12 +7590,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170738.md",
           "line": 0,
           "confidence": "medium",
@@ -10597,12 +7609,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-153801.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194215.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10632,31 +7638,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084719.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132017.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-171157.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183350.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-150937.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10680,18 +7662,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-110050.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001337.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260627-133613.md",
           "line": 0,
           "confidence": "medium",
@@ -10710,12 +7680,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-220404.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-085740.md",
           "line": 0,
           "confidence": "medium",
@@ -10728,37 +7692,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-193756.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163218.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163309.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-130821.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-160906.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-094142.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10776,19 +7710,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202442.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164036.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10812,55 +7734,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214125.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-164249.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132604.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-142359.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-163353.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132933.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-175550.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174408.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-163120.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10878,12 +7758,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182339.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165418.md",
           "line": 0,
           "confidence": "medium",
@@ -10896,13 +7770,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-155114.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133637.md",
+          "file": "specs/verifications/reports/audit-cleancode-20260725-021918.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10920,19 +7788,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-131140.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165111.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-144700.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10986,7 +7842,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202558.md",
+          "file": "specs/verifications/reports/audit-cleancode-20260725-022131.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10998,43 +7854,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-163657.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215213.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-160919.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-204345.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-153739.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175227.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -11047,60 +7867,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260621-225313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164721.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-093336.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132207.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130940.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105058.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-163457.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084617.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084805.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174631.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -11124,49 +7890,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002322.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-220022.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-135838.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-093012.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-152233.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-131617.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181159.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -11184,12 +7908,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131350.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-083101.md",
           "line": 0,
           "confidence": "medium",
@@ -11202,31 +7920,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115557.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-114525.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-093128.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-221847.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-154451.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -11238,73 +7932,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212552.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-161624.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181706.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-105035.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092013.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001702.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132130.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-163956.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001902.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-093246.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-204300.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -11328,18 +7956,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132858.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165902.md",
           "line": 0,
           "confidence": "medium",
@@ -11352,25 +7968,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001029.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-172425.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145255.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-133730.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -11382,73 +7980,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175929.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-172525.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133254.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184658.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164258.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-164418.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194009.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-092924.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260629-130359.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130821.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190539.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -11466,37 +8004,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-163613.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-142458.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-005318.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-235409.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001952.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -11514,37 +8022,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002154.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-171134.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260621-182630.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165733.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091717.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084911.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -11568,43 +8046,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182346.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115503.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-101402.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260621-231038.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-123626.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184355.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-172751.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -11616,37 +8058,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101633.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130900.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-103924.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101425.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-163837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175105.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -11670,19 +8082,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-234704.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163238.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-172133.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -11694,25 +8094,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214329.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-144506.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-210010.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173306.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -11737,12 +8119,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-151341.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131314.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -11808,7 +8184,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 572
+      "link_count": 268
     },
     {
       "id": "e45s32",
@@ -12822,6 +9198,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/bugs/BUG-2026-07-25-land-branch-protected.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/bugs/BUG-2026-07-23-epics-wiki-empty-references.okf.md",
           "line": 0,
           "confidence": "medium",
@@ -12889,12 +9271,6 @@
         },
         {
           "file": ".continue/rules/maintain-wiki.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "website/src/content/docs/skills/maintain-wiki.mdx",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -13002,79 +9378,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-09.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-18.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/GOLDEN-2026-07-05.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-2026-07-06.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-07.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-23.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-24.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-13.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-23.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-07.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-21.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-06.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-18.okf.md",
+          "file": "specs/verifications/reports/GOLDEN-2026-07-25.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -13086,31 +9396,19 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-2026-07-09.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-13.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-11.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-24.okf.md",
+          "file": "specs/verifications/reports/audit-2026-07-25.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
           "file": "specs/bugs/BUG-2026-07-06-g06-migrate-version-golden.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/bugs/BUG-2026-07-25-land-branch-protected.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -13218,7 +9516,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 43
+      "link_count": 30
     },
     {
       "id": "e48s03",
@@ -13363,6 +9661,12 @@
         },
         {
           "file": "specs/bugs/BUG-2026-07-06-gate-trace-matrix-oversized.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/bugs/BUG-2026-07-25-land-branch-protected.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -13962,6 +10266,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/bugs/BUG-2026-07-25-land-branch-protected.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/bugs/BUG-2026-06-11T183000.md",
           "line": 0,
           "confidence": "medium",
@@ -14068,15 +10378,9 @@
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
-        },
-        {
-          "file": "bigpowers-showcase/specs/bugs/BUG-2026-07-05-race-condition.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
         }
       ],
-      "link_count": 141
+      "link_count": 142
     },
     {
       "id": "e48s04",
@@ -14232,79 +10536,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-09.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-18.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/GOLDEN-2026-07-05.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-2026-07-06.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-07.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-23.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-24.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-13.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-23.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-07.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-21.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-06.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-18.okf.md",
+          "file": "specs/verifications/reports/GOLDEN-2026-07-25.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -14316,25 +10554,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-2026-07-09.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-13.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-2026-07-11.okf.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/GOLDEN-2026-07-24.okf.md",
+          "file": "specs/verifications/reports/audit-2026-07-25.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -14383,6 +10603,12 @@
         },
         {
           "file": "specs/bugs/BUG-2026-07-03-validate-specs-no-real-parser.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/bugs/BUG-2026-07-25-land-branch-protected.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15144,6 +11370,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/epics-wiki/e79.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/epics-wiki/e67.okf.md",
           "line": 0,
           "confidence": "medium",
@@ -15264,7 +11496,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 182
+      "link_count": 170
     },
     {
       "id": "e48s06",
@@ -16141,7 +12373,7 @@
         },
         {
           "file": ".gemini/extensions/bigpowers/commands/prompts/seed-conventions.md",
-          "line": 105,
+          "line": 122,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -16153,7 +12385,7 @@
         },
         {
           "file": ".gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md",
-          "line": 107,
+          "line": 124,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -16165,7 +12397,7 @@
         },
         {
           "file": ".trae/skills/seed-conventions/SKILL.md",
-          "line": 106,
+          "line": 123,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -16177,7 +12409,7 @@
         },
         {
           "file": ".windsurf/rules/seed-conventions.md",
-          "line": 106,
+          "line": 123,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -16207,7 +12439,7 @@
         },
         {
           "file": ".agents/skills/seed-conventions/SKILL.md",
-          "line": 106,
+          "line": 123,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -16219,7 +12451,7 @@
         },
         {
           "file": ".kilocode/rules/seed-conventions.md",
-          "line": 106,
+          "line": 123,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -16231,7 +12463,7 @@
         },
         {
           "file": ".codex/skills/seed-conventions/SKILL.md",
-          "line": 106,
+          "line": 123,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -16255,7 +12487,7 @@
         },
         {
           "file": ".codebuddy/skills/seed-conventions/SKILL.md",
-          "line": 106,
+          "line": 123,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -16267,7 +12499,7 @@
         },
         {
           "file": ".zcode/skills/seed-conventions/SKILL.md",
-          "line": 106,
+          "line": 123,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -16279,7 +12511,7 @@
         },
         {
           "file": ".mimocode/skills/seed-conventions/SKILL.md",
-          "line": 106,
+          "line": 123,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -16291,7 +12523,7 @@
         },
         {
           "file": ".hermes/skills/seed-conventions/SKILL.md",
-          "line": 106,
+          "line": 123,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -16303,7 +12535,7 @@
         },
         {
           "file": ".pi/prompts/seed-conventions.md",
-          "line": 105,
+          "line": 122,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -16315,7 +12547,7 @@
         },
         {
           "file": ".pi/skills/seed-conventions/SKILL.md",
-          "line": 106,
+          "line": 123,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -16339,6 +12571,12 @@
         },
         {
           "file": "specs/verifications/steps/and-solo-git-profile-exists.sh",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/e79s03-seed-conventions.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16368,7 +12606,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 39
+      "link_count": 40
     },
     {
       "id": "e51s03",
@@ -16632,6 +12870,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/bugs/BUG-2026-07-25-land-branch-protected.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/bugs/BUG-2026-07-06-verify-work-runner-scripts-oversized.md",
           "line": 0,
           "confidence": "medium",
@@ -16639,6 +12883,12 @@
         },
         {
           "file": "specs/bugs/BUG-2026-07-06-verify-work-runner-scripts-oversized.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/bugs/BUG-2026-07-25-land-branch-protected.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16752,7 +13002,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 62
+      "link_count": 64
     },
     {
       "id": "e51s04",
@@ -16914,18 +13164,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190334.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-144556.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-175346.md",
           "line": 0,
           "confidence": "medium",
@@ -16938,49 +13176,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-102313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-103815.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163934.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202335.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145222.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165427.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-151538.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132836.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16998,31 +13194,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-155647.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181947.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212931.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-160106.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-180858.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17035,48 +13207,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-143153.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215320.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-132011.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-172717.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174039.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132651.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212830.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182718.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17095,18 +13225,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-122420.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-154721.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183547.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17148,12 +13266,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-160627.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-165137.md",
           "line": 0,
           "confidence": "medium",
@@ -17166,43 +13278,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-205519.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-131516.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101228.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-102150.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214411.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260622-001710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-165047.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17215,36 +13291,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-000102.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-131912.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-132538.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133327.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001605.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105239.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17268,55 +13314,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101847.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173628.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182629.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-161434.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154217.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-165703.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-143839.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163159.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260711-001225.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17334,31 +13338,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-185319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183644.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260629-132810.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001328.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17376,25 +13356,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-202226.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164609.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192340.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165651.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17412,43 +13374,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-160550.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-134603.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091641.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163954.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-210053.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190002.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-093104.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17461,24 +13387,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164251.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132615.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-172212.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-140513.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17508,31 +13416,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154135.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170532.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154323.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-082500.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101730.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17550,109 +13440,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-165007.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-205711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-182236.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-135136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-103737.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-093242.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-213042.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-134029.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164826.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-162400.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110426.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-223023.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-134126.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-162245.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-105652.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-114127.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-164053.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154055.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17676,25 +13470,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164801.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131809.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-175313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181604.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17718,37 +13494,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-110149.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-131715.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-133750.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-181656.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174414.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17760,19 +13506,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192541.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-233740.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173515.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17784,49 +13518,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190415.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192435.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-094025.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-161022.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-125910.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215656.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-135950.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092605.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17850,18 +13542,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154936.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132530.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174045.md",
           "line": 0,
           "confidence": "medium",
@@ -17880,31 +13560,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091938.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-133945.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174055.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001312.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110458.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17964,55 +13620,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105145.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-193609.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174351.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-154353.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-131211.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-130715.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182555.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-124641.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18030,31 +13644,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120114.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-234357.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110242.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-143756.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-235505.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18067,18 +13657,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-160732.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-145214.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-161026.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18102,12 +13680,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001100.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-150417.md",
           "line": 0,
           "confidence": "medium",
@@ -18126,19 +13698,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-151437.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-143504.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-185913.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18150,25 +13710,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-140559.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001518.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-184837.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18192,24 +13734,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-154541.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-105728.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-111510.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-180901.md",
           "line": 0,
           "confidence": "medium",
@@ -18217,24 +13741,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260702-133532.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145423.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-105643.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-141624.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18258,24 +13764,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181236.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163830.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092533.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174025.md",
           "line": 0,
           "confidence": "medium",
@@ -18288,55 +13776,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145349.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-164643.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-205433.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132944.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163746.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-091141.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184856.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-143844.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133446.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18354,42 +13794,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-182836.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202450.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194130.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-213831.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174245.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-005800.md",
           "line": 0,
           "confidence": "medium",
@@ -18397,12 +13801,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-173348.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-165006.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18420,25 +13818,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-005225.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-143007.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-171058.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-150742.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18451,12 +13831,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165618.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-130546.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18504,49 +13878,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-154637.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001919.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-144757.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-220941.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174117.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-093202.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-110206.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120150.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18570,43 +13902,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131734.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182807.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173917.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-185210.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-101322.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165256.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-192433.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18618,37 +13914,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105013.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-200110.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-114242.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001233.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-130623.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-162439.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18660,37 +13926,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002229.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-144202.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183102.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-133837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-233707.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212919.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18714,25 +13956,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164345.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120250.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165035.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-112952.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18750,42 +13974,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194053.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001439.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202651.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-165120.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-143840.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-000955.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-144557.md",
           "line": 0,
           "confidence": "medium",
@@ -18793,18 +13981,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-174133.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115538.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-113034.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18822,12 +13998,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-161502.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170255.md",
           "line": 0,
           "confidence": "medium",
@@ -18835,42 +14005,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164704.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132813.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164342.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-154344.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-120815.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-164833.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154835.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18888,37 +14022,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-155747.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173218.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260626-204822.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202348.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-161543.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -18936,12 +14046,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-113257.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-181044.md",
           "line": 0,
           "confidence": "medium",
@@ -18954,37 +14058,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-133458.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164823.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-180900.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-120136.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-104009.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-163929.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19003,12 +14077,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260704-081735.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-154818.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19038,12 +14106,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-170738.md",
           "line": 0,
           "confidence": "medium",
@@ -19063,12 +14125,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-153801.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194215.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19098,31 +14154,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084719.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-132017.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-171157.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-183350.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-150937.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19146,18 +14178,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-110050.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001337.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260627-133613.md",
           "line": 0,
           "confidence": "medium",
@@ -19176,12 +14196,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-220404.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-085740.md",
           "line": 0,
           "confidence": "medium",
@@ -19194,37 +14208,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-193756.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163218.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-163309.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-130821.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-160906.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-094142.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19242,19 +14226,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202442.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164319.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-164036.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19278,55 +14250,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214125.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-164249.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132604.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-142359.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-163353.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132933.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-175550.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174408.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-163120.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19344,12 +14274,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182339.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165418.md",
           "line": 0,
           "confidence": "medium",
@@ -19362,13 +14286,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-155114.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133637.md",
+          "file": "specs/verifications/reports/audit-cleancode-20260725-021918.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19386,19 +14304,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-131140.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165111.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-144700.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19452,7 +14358,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-202558.md",
+          "file": "specs/verifications/reports/audit-cleancode-20260725-022131.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19464,43 +14370,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-163657.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-215213.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-160919.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-204345.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212711.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-153739.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175227.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19513,60 +14383,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260621-225313.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164721.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-093336.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132207.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130940.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-105058.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-163457.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084617.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084805.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174631.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19590,49 +14406,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002322.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-220022.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-164429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-135838.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-093012.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260713-152233.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-131617.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181159.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19650,12 +14424,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131350.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-083101.md",
           "line": 0,
           "confidence": "medium",
@@ -19668,31 +14436,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115557.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-114525.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-093128.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-221847.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-154451.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19704,73 +14448,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-212552.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-161624.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-181706.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-105035.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-092013.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001702.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132130.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-163956.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001902.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260721-093246.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-204300.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19794,18 +14472,6 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-132858.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-174710.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-165902.md",
           "line": 0,
           "confidence": "medium",
@@ -19818,25 +14484,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-001029.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-172425.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-145255.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-133730.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19848,73 +14496,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-154759.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175929.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-172525.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-133254.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184658.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-164258.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-164418.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-194009.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260724-092924.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260629-130359.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130821.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-190539.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19932,37 +14520,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-163613.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173429.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-142458.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-005318.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-235409.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-001952.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19980,37 +14538,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260709-002154.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-171134.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260621-182630.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-165733.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-091717.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-084911.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -20034,43 +14562,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260705-182346.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-115503.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-101402.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260621-231038.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-123626.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-184355.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-172751.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -20082,37 +14574,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101633.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-130900.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-103924.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260707-101425.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260705-163837.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-175105.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -20136,19 +14598,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-234704.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-163238.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-172133.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -20160,25 +14610,7 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-214329.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
           "file": "specs/verifications/reports/audit-cleancode-20260704-144506.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260718-210010.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260706-173306.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -20203,12 +14635,6 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-151341.md",
-          "line": 0,
-          "confidence": "medium",
-          "method": "file_heuristic"
-        },
-        {
-          "file": "specs/verifications/reports/audit-cleancode-20260723-131314.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -20514,7 +14940,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 625
+      "link_count": 321
     },
     {
       "id": "e51s05",
@@ -21238,9 +15664,15 @@
           "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
+        },
+        {
+          "file": "docs/images/interactive-installer.png",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
         }
       ],
-      "link_count": 8
+      "link_count": 9
     },
     {
       "id": "e61s01",
@@ -23611,11 +18043,473 @@
         }
       ],
       "link_count": 16
+    },
+    {
+      "id": "e79s01",
+      "title": "AGENTIC-STE ruleset document",
+      "epic_id": "e79",
+      "epic_title": "Agentic Controlled English (STE-style instruction precision)",
+      "bcp": 0,
+      "wsjf": 6.0,
+      "status": "backlog",
+      "links": [
+        {
+          "file": "specs/epics/e79-agentic-ste/epic.yaml",
+          "line": 28,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/e79s01-tasks.yaml",
+          "line": 12,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "docs/AGENTIC-STE.md",
+          "line": 1,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/e79s01-agentic-ste-doc.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "scripts/validate-agentic-ste.sh",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/e79s02-tasks.yaml",
+          "line": 0,
+          "confidence": "low",
+          "method": "task_reference"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/e79s04-tasks.yaml",
+          "line": 0,
+          "confidence": "low",
+          "method": "task_reference"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/e79s03-tasks.yaml",
+          "line": 0,
+          "confidence": "low",
+          "method": "task_reference"
+        }
+      ],
+      "link_count": 8
+    },
+    {
+      "id": "e79s02",
+      "title": "Validator script + craft-skill HARD GATE",
+      "epic_id": "e79",
+      "epic_title": "Agentic Controlled English (STE-style instruction precision)",
+      "bcp": 0,
+      "wsjf": 6.0,
+      "status": "backlog",
+      "links": [
+        {
+          "file": "specs/epics/e79-agentic-ste/e79s02-tasks.yaml",
+          "line": 13,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/epic.yaml",
+          "line": 42,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "scripts/validate-agentic-ste.sh",
+          "line": 2,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "skills/craft-skill/SKILL.md",
+          "line": 3,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".windsurf/rules/craft-skill.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/skills-wiki/skills/craft-skill.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/adr/0005-hard-gate-mandate.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/steps/then-skills-should-include-bold-hard-gate-callout-blocks.sh",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/bugs/BUG-2026-07-06-craft-skill-sync-oversized.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/bugs/BUG-2026-07-06-craft-skill-sync-oversized.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/adr-wiki/0005-hard-gate-mandate.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/tech-architecture/PLAN-add-hard-gates.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/tech-architecture/HARD-GATES-REFERENCE.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/e79s02-validator-craft-skill.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/epics/archive/e38-traceability-gate/e38s06-gate-trace-skill.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": ".continue/rules/craft-skill.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "website/src/content/docs/decisions/0005-hard-gate-mandate.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "website/src/content/docs/skills/craft-skill.mdx",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": ".kilocode/rules/craft-skill.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "scripts/validate-skill-description.sh",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/e79s04-tasks.yaml",
+          "line": 0,
+          "confidence": "low",
+          "method": "task_reference"
+        }
+      ],
+      "link_count": 21
+    },
+    {
+      "id": "e79s03",
+      "title": "seed-conventions applies ruleset",
+      "epic_id": "e79",
+      "epic_title": "Agentic Controlled English (STE-style instruction precision)",
+      "bcp": 0,
+      "wsjf": 6.0,
+      "status": "backlog",
+      "links": [
+        {
+          "file": ".gemini/extensions/bigpowers/commands/prompts/seed-conventions.md",
+          "line": 11,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".gemini/extensions/bigpowers/skills/seed-conventions/SKILL.md",
+          "line": 13,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".trae/skills/seed-conventions/SKILL.md",
+          "line": 12,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".windsurf/rules/seed-conventions.md",
+          "line": 12,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/epic.yaml",
+          "line": 54,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/e79s03-tasks.yaml",
+          "line": 13,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".agents/skills/seed-conventions/SKILL.md",
+          "line": 12,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".kilocode/rules/seed-conventions.md",
+          "line": 12,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".codex/skills/seed-conventions/SKILL.md",
+          "line": 12,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "skills/seed-conventions/SKILL.md",
+          "line": 13,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".codebuddy/skills/seed-conventions/SKILL.md",
+          "line": 12,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".zcode/skills/seed-conventions/SKILL.md",
+          "line": 12,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".mimocode/skills/seed-conventions/SKILL.md",
+          "line": 12,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".hermes/skills/seed-conventions/SKILL.md",
+          "line": 12,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".pi/prompts/seed-conventions.md",
+          "line": 11,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".pi/skills/seed-conventions/SKILL.md",
+          "line": 12,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/skills-wiki/skills/seed-conventions.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/e79s03-seed-conventions.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": ".continue/rules/seed-conventions.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "website/src/content/docs/skills/seed-conventions.mdx",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        }
+      ],
+      "link_count": 20
+    },
+    {
+      "id": "e79s04",
+      "title": "stocktake-skills violation scanner",
+      "epic_id": "e79",
+      "epic_title": "Agentic Controlled English (STE-style instruction precision)",
+      "bcp": 0,
+      "wsjf": 6.0,
+      "status": "backlog",
+      "links": [
+        {
+          "file": ".gemini/extensions/bigpowers/commands/prompts/stocktake-skills.md",
+          "line": 8,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".gemini/extensions/bigpowers/skills/stocktake-skills/SKILL.md",
+          "line": 10,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".trae/skills/stocktake-skills/SKILL.md",
+          "line": 9,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".windsurf/rules/stocktake-skills.md",
+          "line": 9,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/epic.yaml",
+          "line": 66,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/e79s04-tasks.yaml",
+          "line": 14,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".agents/skills/stocktake-skills/SKILL.md",
+          "line": 9,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".kilocode/rules/stocktake-skills.md",
+          "line": 9,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".codex/skills/stocktake-skills/SKILL.md",
+          "line": 9,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "skills/stocktake-skills/SKILL.md",
+          "line": 12,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".codebuddy/skills/stocktake-skills/SKILL.md",
+          "line": 9,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".zcode/skills/stocktake-skills/SKILL.md",
+          "line": 9,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".mimocode/skills/stocktake-skills/SKILL.md",
+          "line": 9,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".hermes/skills/stocktake-skills/SKILL.md",
+          "line": 9,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".pi/prompts/stocktake-skills.md",
+          "line": 8,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".pi/skills/stocktake-skills/SKILL.md",
+          "line": 9,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/skills-wiki/skills/stocktake-skills.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/epics/e79-agentic-ste/e79s04-stocktake-scanner.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": ".continue/rules/stocktake-skills.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "website/src/content/docs/skills/stocktake-skills.mdx",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        }
+      ],
+      "link_count": 20
     }
   ],
   "summary": {
-    "total_stories": 112,
-    "tagged_stories": 102,
+    "total_stories": 116,
+    "tagged_stories": 106,
     "dark_stories": [],
     "dark_count": 0,
     "orphan_tags": [
@@ -23751,8 +18645,6 @@
       "e42s02",
       "e42s03",
       "e42s04",
-      "e43s01",
-      "e43s02",
       "e44s01",
       "e44s02",
       "e44s03",
@@ -23769,7 +18661,7 @@
       "e99s01",
       "e99s99"
     ],
-    "orphan_count": 149,
+    "orphan_count": 147,
     "stale_tags": [
       "e37s01",
       "e37s02",
@@ -23876,9 +18768,9 @@
     ],
     "stale_count": 102,
     "oracle_stats": {
-      "high": 720,
-      "medium": 2925,
-      "low": 66
+      "high": 759,
+      "medium": 2023,
+      "low": 70
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `docs/AGENTIC-STE.md` — 10 numeric rules for instructional prose (directive vocabulary, banned hedge modals, 20-word sentence cap, explicit `terse-mode` exclusion)
- Add `scripts/validate-agentic-ste.sh` with built-in fixture self-test; `--strict` for craft-skill gate, `--audit` for stocktake debt scan
- Extend `craft-skill`, `seed-conventions`, and `stocktake-skills` to enforce/audit Agentic STE at write time and catalog audit

Closes #91

## Test plan

- [x] `bash scripts/validate-agentic-ste.sh` — self-test PASS
- [x] `bash scripts/validate-agentic-ste.sh --strict skills/craft-skill/SKILL.md` — PASS
- [x] Preflight green in worktree (compliance + golden 12/12 + sync-skills + trace-stories)
- [ ] CI checks on PR


Made with [Cursor](https://cursor.com)