### PR TITLE
fix(verify): repair two gates that could not fail (#97, #98)

### DIFF
--- a/.codebuddy/skills/security-review/SKILL.md
+++ b/.codebuddy/skills/security-review/SKILL.md
@@ -58,6 +58,8 @@ Every **new detection rule** added to this skill MUST:
 |------|-----|------------------|------------------|
 | SQL injection | CWE-89 | `fixtures/CWE-89-sqli-positive.py` | `fixtures/CWE-89-sqli-negative.py` |
 | XSS (DOM) | CWE-79 | `fixtures/CWE-79-xss-positive.js` | `fixtures/CWE-79-xss-negative.js` |
+| Missing tenant scoping (IDOR) | CWE-639 | `fixtures/CWE-639-idor-positive.go` | `fixtures/CWE-639-idor-negative.go` |
+| Fail-open verify directive | CWE-754 | `fixtures/CWE-fail-open-verify-positive.sh` | `fixtures/CWE-fail-open-verify-negative.sh` |
 
 Before merging a new category, run both fixtures through the detection guidance and confirm positive flags / negative passes.
 
@@ -109,7 +111,7 @@ Each finding: **`File:Line` — Severity — Category**
 
 ## Verify
 
-→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && git rev-parse HEAD >/dev/null 2>&1`
+→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && bash scripts/verify-cwe-fixture-sync.sh >/dev/null && git rev-parse HEAD >/dev/null 2>&1`
 
 ---
 

--- a/.codebuddy/skills/smoke-test/SKILL.md
+++ b/.codebuddy/skills/smoke-test/SKILL.md
@@ -78,7 +78,7 @@ Part of **★ VERIFY ★**: `verify-work` → `validate-contracts` → `smoke-te
 
 ## Verify
 
-→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && grep -qv 'See \[REFERENCE.md\]' skills/smoke-test/SKILL.md && echo OK`
+→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && ! grep -q 'See \[REFERENCE.md\](REFERENCE.md)$' skills/smoke-test/SKILL.md && echo OK`
 
 ---
 

--- a/.codex/skills/security-review/SKILL.md
+++ b/.codex/skills/security-review/SKILL.md
@@ -58,6 +58,8 @@ Every **new detection rule** added to this skill MUST:
 |------|-----|------------------|------------------|
 | SQL injection | CWE-89 | `fixtures/CWE-89-sqli-positive.py` | `fixtures/CWE-89-sqli-negative.py` |
 | XSS (DOM) | CWE-79 | `fixtures/CWE-79-xss-positive.js` | `fixtures/CWE-79-xss-negative.js` |
+| Missing tenant scoping (IDOR) | CWE-639 | `fixtures/CWE-639-idor-positive.go` | `fixtures/CWE-639-idor-negative.go` |
+| Fail-open verify directive | CWE-754 | `fixtures/CWE-fail-open-verify-positive.sh` | `fixtures/CWE-fail-open-verify-negative.sh` |
 
 Before merging a new category, run both fixtures through the detection guidance and confirm positive flags / negative passes.
 
@@ -109,7 +111,7 @@ Each finding: **`File:Line` — Severity — Category**
 
 ## Verify
 
-→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && git rev-parse HEAD >/dev/null 2>&1`
+→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && bash scripts/verify-cwe-fixture-sync.sh >/dev/null && git rev-parse HEAD >/dev/null 2>&1`
 
 ---
 

--- a/.codex/skills/smoke-test/SKILL.md
+++ b/.codex/skills/smoke-test/SKILL.md
@@ -78,7 +78,7 @@ Part of **★ VERIFY ★**: `verify-work` → `validate-contracts` → `smoke-te
 
 ## Verify
 
-→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && grep -qv 'See \[REFERENCE.md\]' skills/smoke-test/SKILL.md && echo OK`
+→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && ! grep -q 'See \[REFERENCE.md\](REFERENCE.md)$' skills/smoke-test/SKILL.md && echo OK`
 
 ---
 

--- a/.cursor/rules/security-review.mdc
+++ b/.cursor/rules/security-review.mdc
@@ -57,6 +57,8 @@ Every **new detection rule** added to this skill MUST:
 |------|-----|------------------|------------------|
 | SQL injection | CWE-89 | `fixtures/CWE-89-sqli-positive.py` | `fixtures/CWE-89-sqli-negative.py` |
 | XSS (DOM) | CWE-79 | `fixtures/CWE-79-xss-positive.js` | `fixtures/CWE-79-xss-negative.js` |
+| Missing tenant scoping (IDOR) | CWE-639 | `fixtures/CWE-639-idor-positive.go` | `fixtures/CWE-639-idor-negative.go` |
+| Fail-open verify directive | CWE-754 | `fixtures/CWE-fail-open-verify-positive.sh` | `fixtures/CWE-fail-open-verify-negative.sh` |
 
 Before merging a new category, run both fixtures through the detection guidance and confirm positive flags / negative passes.
 
@@ -108,7 +110,7 @@ Each finding: **`File:Line` — Severity — Category**
 
 ## Verify
 
-→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && git rev-parse HEAD >/dev/null 2>&1`
+→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && bash scripts/verify-cwe-fixture-sync.sh >/dev/null && git rev-parse HEAD >/dev/null 2>&1`
 
 ---
 

--- a/.cursor/rules/smoke-test.mdc
+++ b/.cursor/rules/smoke-test.mdc
@@ -77,7 +77,7 @@ Part of **★ VERIFY ★**: `verify-work` → `validate-contracts` → `smoke-te
 
 ## Verify
 
-→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && grep -qv 'See \[REFERENCE.md\]' skills/smoke-test/SKILL.md && echo OK`
+→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && ! grep -q 'See \[REFERENCE.md\](REFERENCE.md)$' skills/smoke-test/SKILL.md && echo OK`
 
 ---
 

--- a/.gemini/extensions/bigpowers/commands/prompts/security-review.md
+++ b/.gemini/extensions/bigpowers/commands/prompts/security-review.md
@@ -57,6 +57,8 @@ Every **new detection rule** added to this skill MUST:
 |------|-----|------------------|------------------|
 | SQL injection | CWE-89 | `fixtures/CWE-89-sqli-positive.py` | `fixtures/CWE-89-sqli-negative.py` |
 | XSS (DOM) | CWE-79 | `fixtures/CWE-79-xss-positive.js` | `fixtures/CWE-79-xss-negative.js` |
+| Missing tenant scoping (IDOR) | CWE-639 | `fixtures/CWE-639-idor-positive.go` | `fixtures/CWE-639-idor-negative.go` |
+| Fail-open verify directive | CWE-754 | `fixtures/CWE-fail-open-verify-positive.sh` | `fixtures/CWE-fail-open-verify-negative.sh` |
 
 Before merging a new category, run both fixtures through the detection guidance and confirm positive flags / negative passes.
 
@@ -108,7 +110,7 @@ Each finding: **`File:Line` — Severity — Category**
 
 ## Verify
 
-→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && git rev-parse HEAD >/dev/null 2>&1`
+→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && bash scripts/verify-cwe-fixture-sync.sh >/dev/null && git rev-parse HEAD >/dev/null 2>&1`
 
 ---
 

--- a/.gemini/extensions/bigpowers/commands/prompts/smoke-test.md
+++ b/.gemini/extensions/bigpowers/commands/prompts/smoke-test.md
@@ -77,7 +77,7 @@ Part of **★ VERIFY ★**: `verify-work` → `validate-contracts` → `smoke-te
 
 ## Verify
 
-→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && grep -qv 'See \[REFERENCE.md\]' skills/smoke-test/SKILL.md && echo OK`
+→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && ! grep -q 'See \[REFERENCE.md\](REFERENCE.md)$' skills/smoke-test/SKILL.md && echo OK`
 
 ---
 

--- a/.gemini/extensions/bigpowers/skills/security-review/SKILL.md
+++ b/.gemini/extensions/bigpowers/skills/security-review/SKILL.md
@@ -59,6 +59,8 @@ Every **new detection rule** added to this skill MUST:
 |------|-----|------------------|------------------|
 | SQL injection | CWE-89 | `fixtures/CWE-89-sqli-positive.py` | `fixtures/CWE-89-sqli-negative.py` |
 | XSS (DOM) | CWE-79 | `fixtures/CWE-79-xss-positive.js` | `fixtures/CWE-79-xss-negative.js` |
+| Missing tenant scoping (IDOR) | CWE-639 | `fixtures/CWE-639-idor-positive.go` | `fixtures/CWE-639-idor-negative.go` |
+| Fail-open verify directive | CWE-754 | `fixtures/CWE-fail-open-verify-positive.sh` | `fixtures/CWE-fail-open-verify-negative.sh` |
 
 Before merging a new category, run both fixtures through the detection guidance and confirm positive flags / negative passes.
 
@@ -110,7 +112,7 @@ Each finding: **`File:Line` — Severity — Category**
 
 ## Verify
 
-→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && git rev-parse HEAD >/dev/null 2>&1`
+→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && bash scripts/verify-cwe-fixture-sync.sh >/dev/null && git rev-parse HEAD >/dev/null 2>&1`
 
 ---
 

--- a/.gemini/extensions/bigpowers/skills/smoke-test/SKILL.md
+++ b/.gemini/extensions/bigpowers/skills/smoke-test/SKILL.md
@@ -79,7 +79,7 @@ Part of **★ VERIFY ★**: `verify-work` → `validate-contracts` → `smoke-te
 
 ## Verify
 
-→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && grep -qv 'See \[REFERENCE.md\]' skills/smoke-test/SKILL.md && echo OK`
+→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && ! grep -q 'See \[REFERENCE.md\](REFERENCE.md)$' skills/smoke-test/SKILL.md && echo OK`
 
 ---
 

--- a/.kilocode/rules/security-review.md
+++ b/.kilocode/rules/security-review.md
@@ -58,6 +58,8 @@ Every **new detection rule** added to this skill MUST:
 |------|-----|------------------|------------------|
 | SQL injection | CWE-89 | `fixtures/CWE-89-sqli-positive.py` | `fixtures/CWE-89-sqli-negative.py` |
 | XSS (DOM) | CWE-79 | `fixtures/CWE-79-xss-positive.js` | `fixtures/CWE-79-xss-negative.js` |
+| Missing tenant scoping (IDOR) | CWE-639 | `fixtures/CWE-639-idor-positive.go` | `fixtures/CWE-639-idor-negative.go` |
+| Fail-open verify directive | CWE-754 | `fixtures/CWE-fail-open-verify-positive.sh` | `fixtures/CWE-fail-open-verify-negative.sh` |
 
 Before merging a new category, run both fixtures through the detection guidance and confirm positive flags / negative passes.
 
@@ -109,7 +111,7 @@ Each finding: **`File:Line` — Severity — Category**
 
 ## Verify
 
-→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && git rev-parse HEAD >/dev/null 2>&1`
+→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && bash scripts/verify-cwe-fixture-sync.sh >/dev/null && git rev-parse HEAD >/dev/null 2>&1`
 
 ---
 

--- a/.kilocode/rules/smoke-test.md
+++ b/.kilocode/rules/smoke-test.md
@@ -78,7 +78,7 @@ Part of **★ VERIFY ★**: `verify-work` → `validate-contracts` → `smoke-te
 
 ## Verify
 
-→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && grep -qv 'See \[REFERENCE.md\]' skills/smoke-test/SKILL.md && echo OK`
+→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && ! grep -q 'See \[REFERENCE.md\](REFERENCE.md)$' skills/smoke-test/SKILL.md && echo OK`
 
 ---
 

--- a/.pi/prompts/security-review.md
+++ b/.pi/prompts/security-review.md
@@ -57,6 +57,8 @@ Every **new detection rule** added to this skill MUST:
 |------|-----|------------------|------------------|
 | SQL injection | CWE-89 | `fixtures/CWE-89-sqli-positive.py` | `fixtures/CWE-89-sqli-negative.py` |
 | XSS (DOM) | CWE-79 | `fixtures/CWE-79-xss-positive.js` | `fixtures/CWE-79-xss-negative.js` |
+| Missing tenant scoping (IDOR) | CWE-639 | `fixtures/CWE-639-idor-positive.go` | `fixtures/CWE-639-idor-negative.go` |
+| Fail-open verify directive | CWE-754 | `fixtures/CWE-fail-open-verify-positive.sh` | `fixtures/CWE-fail-open-verify-negative.sh` |
 
 Before merging a new category, run both fixtures through the detection guidance and confirm positive flags / negative passes.
 
@@ -108,7 +110,7 @@ Each finding: **`File:Line` — Severity — Category**
 
 ## Verify
 
-→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && git rev-parse HEAD >/dev/null 2>&1`
+→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && bash scripts/verify-cwe-fixture-sync.sh >/dev/null && git rev-parse HEAD >/dev/null 2>&1`
 
 ---
 

--- a/.pi/prompts/smoke-test.md
+++ b/.pi/prompts/smoke-test.md
@@ -77,7 +77,7 @@ Part of **★ VERIFY ★**: `verify-work` → `validate-contracts` → `smoke-te
 
 ## Verify
 
-→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && grep -qv 'See \[REFERENCE.md\]' skills/smoke-test/SKILL.md && echo OK`
+→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && ! grep -q 'See \[REFERENCE.md\](REFERENCE.md)$' skills/smoke-test/SKILL.md && echo OK`
 
 ---
 

--- a/.pi/skills/security-review/SKILL.md
+++ b/.pi/skills/security-review/SKILL.md
@@ -58,6 +58,8 @@ Every **new detection rule** added to this skill MUST:
 |------|-----|------------------|------------------|
 | SQL injection | CWE-89 | `fixtures/CWE-89-sqli-positive.py` | `fixtures/CWE-89-sqli-negative.py` |
 | XSS (DOM) | CWE-79 | `fixtures/CWE-79-xss-positive.js` | `fixtures/CWE-79-xss-negative.js` |
+| Missing tenant scoping (IDOR) | CWE-639 | `fixtures/CWE-639-idor-positive.go` | `fixtures/CWE-639-idor-negative.go` |
+| Fail-open verify directive | CWE-754 | `fixtures/CWE-fail-open-verify-positive.sh` | `fixtures/CWE-fail-open-verify-negative.sh` |
 
 Before merging a new category, run both fixtures through the detection guidance and confirm positive flags / negative passes.
 
@@ -109,7 +111,7 @@ Each finding: **`File:Line` — Severity — Category**
 
 ## Verify
 
-→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && git rev-parse HEAD >/dev/null 2>&1`
+→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && bash scripts/verify-cwe-fixture-sync.sh >/dev/null && git rev-parse HEAD >/dev/null 2>&1`
 
 ---
 

--- a/.pi/skills/smoke-test/SKILL.md
+++ b/.pi/skills/smoke-test/SKILL.md
@@ -78,7 +78,7 @@ Part of **★ VERIFY ★**: `verify-work` → `validate-contracts` → `smoke-te
 
 ## Verify
 
-→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && grep -qv 'See \[REFERENCE.md\]' skills/smoke-test/SKILL.md && echo OK`
+→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && ! grep -q 'See \[REFERENCE.md\](REFERENCE.md)$' skills/smoke-test/SKILL.md && echo OK`
 
 ---
 

--- a/.trae/skills/security-review/SKILL.md
+++ b/.trae/skills/security-review/SKILL.md
@@ -58,6 +58,8 @@ Every **new detection rule** added to this skill MUST:
 |------|-----|------------------|------------------|
 | SQL injection | CWE-89 | `fixtures/CWE-89-sqli-positive.py` | `fixtures/CWE-89-sqli-negative.py` |
 | XSS (DOM) | CWE-79 | `fixtures/CWE-79-xss-positive.js` | `fixtures/CWE-79-xss-negative.js` |
+| Missing tenant scoping (IDOR) | CWE-639 | `fixtures/CWE-639-idor-positive.go` | `fixtures/CWE-639-idor-negative.go` |
+| Fail-open verify directive | CWE-754 | `fixtures/CWE-fail-open-verify-positive.sh` | `fixtures/CWE-fail-open-verify-negative.sh` |
 
 Before merging a new category, run both fixtures through the detection guidance and confirm positive flags / negative passes.
 
@@ -109,7 +111,7 @@ Each finding: **`File:Line` — Severity — Category**
 
 ## Verify
 
-→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && git rev-parse HEAD >/dev/null 2>&1`
+→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && bash scripts/verify-cwe-fixture-sync.sh >/dev/null && git rev-parse HEAD >/dev/null 2>&1`
 
 ---
 

--- a/.trae/skills/smoke-test/SKILL.md
+++ b/.trae/skills/smoke-test/SKILL.md
@@ -78,7 +78,7 @@ Part of **★ VERIFY ★**: `verify-work` → `validate-contracts` → `smoke-te
 
 ## Verify
 
-→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && grep -qv 'See \[REFERENCE.md\]' skills/smoke-test/SKILL.md && echo OK`
+→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && ! grep -q 'See \[REFERENCE.md\](REFERENCE.md)$' skills/smoke-test/SKILL.md && echo OK`
 
 ---
 

--- a/.windsurf/rules/security-review.md
+++ b/.windsurf/rules/security-review.md
@@ -58,6 +58,8 @@ Every **new detection rule** added to this skill MUST:
 |------|-----|------------------|------------------|
 | SQL injection | CWE-89 | `fixtures/CWE-89-sqli-positive.py` | `fixtures/CWE-89-sqli-negative.py` |
 | XSS (DOM) | CWE-79 | `fixtures/CWE-79-xss-positive.js` | `fixtures/CWE-79-xss-negative.js` |
+| Missing tenant scoping (IDOR) | CWE-639 | `fixtures/CWE-639-idor-positive.go` | `fixtures/CWE-639-idor-negative.go` |
+| Fail-open verify directive | CWE-754 | `fixtures/CWE-fail-open-verify-positive.sh` | `fixtures/CWE-fail-open-verify-negative.sh` |
 
 Before merging a new category, run both fixtures through the detection guidance and confirm positive flags / negative passes.
 
@@ -109,7 +111,7 @@ Each finding: **`File:Line` — Severity — Category**
 
 ## Verify
 
-→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && git rev-parse HEAD >/dev/null 2>&1`
+→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && bash scripts/verify-cwe-fixture-sync.sh >/dev/null && git rev-parse HEAD >/dev/null 2>&1`
 
 ---
 

--- a/.windsurf/rules/smoke-test.md
+++ b/.windsurf/rules/smoke-test.md
@@ -78,7 +78,7 @@ Part of **★ VERIFY ★**: `verify-work` → `validate-contracts` → `smoke-te
 
 ## Verify
 
-→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && grep -qv 'See \[REFERENCE.md\]' skills/smoke-test/SKILL.md && echo OK`
+→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && ! grep -q 'See \[REFERENCE.md\](REFERENCE.md)$' skills/smoke-test/SKILL.md && echo OK`
 
 ---
 

--- a/scripts/verify-cwe-fixture-sync.sh
+++ b/scripts/verify-cwe-fixture-sync.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# story: e80s05
+# Assert security-review's CWE rule table and its fixtures/ directory agree.
+#
+# e80s05 ("security-review fixture table growth") was marked done while the
+# fixtures directory gained a class the table never listed. Remembering to
+# update both is exactly the kind of discipline that decays, so this makes the
+# drift mechanical instead: every fixture class needs a table row, and every
+# table row needs both fixtures on disk.
+#
+# Usage:
+#   bash scripts/verify-cwe-fixture-sync.sh [--self-test]
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILL_MD="$REPO_ROOT/skills/security-review/SKILL.md"
+FIXTURES="$REPO_ROOT/skills/security-review/fixtures"
+
+fail=0
+note() { echo "  $1"; }
+
+check_sync() {
+  local skill_md="$1" fixtures="$2"
+  local rc=0
+
+  [ -f "$skill_md" ] || { echo "FAIL: missing $skill_md"; return 1; }
+  [ -d "$fixtures" ] || { echo "FAIL: missing $fixtures"; return 1; }
+
+  # Classes present on disk, derived from the -positive fixture filenames.
+  local disk_classes
+  disk_classes=$(find "$fixtures" -name '*-positive.*' -exec basename {} \; 2>/dev/null \
+    | sed 's/-positive\..*$//' | sort -u)
+
+  # Every disk class must appear in the rule table.
+  local c
+  for c in $disk_classes; do
+    if ! grep -q "$c" "$skill_md"; then
+      note "FAIL: fixture class '$c' has no row in the CWE rule table"
+      rc=1
+    fi
+  done
+
+  # Every fixture referenced by the table must exist, both polarities.
+  local ref
+  for ref in $(grep -oE 'fixtures/[A-Za-z0-9._-]+' "$skill_md" | sed 's|fixtures/||' | sort -u); do
+    if [ ! -f "$fixtures/$ref" ]; then
+      note "FAIL: table references fixtures/$ref which does not exist"
+      rc=1
+    fi
+  done
+
+  for c in $disk_classes; do
+    local pos neg
+    pos=$(find "$fixtures" -name "$c-positive.*" | head -1)
+    neg=$(find "$fixtures" -name "$c-negative.*" | head -1)
+    if [ -z "$pos" ] || [ -z "$neg" ]; then
+      note "FAIL: class '$c' needs BOTH a -positive and a -negative fixture"
+      rc=1
+    fi
+  done
+
+  return $rc
+}
+
+# --self-test proves this gate can fail: point it at a fixtures dir holding a
+# class the table does not list, and require a non-zero exit.
+if [ "${1:-}" = "--self-test" ]; then
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  mkdir -p "$tmp/fixtures"
+  printf '| Rule | CWE | Positive fixture | Negative fixture |\n' > "$tmp/SKILL.md"
+  : > "$tmp/fixtures/CWE-999-unlisted-positive.py"
+  : > "$tmp/fixtures/CWE-999-unlisted-negative.py"
+
+  if check_sync "$tmp/SKILL.md" "$tmp/fixtures" >/dev/null 2>&1; then
+    echo "FAIL: self-test — gate passed on an unlisted fixture class (it cannot fail)"
+    exit 1
+  fi
+  echo "PASS: self-test — gate rejects a fixture class missing from the table"
+  exit 0
+fi
+
+if check_sync "$SKILL_MD" "$FIXTURES"; then
+  echo "PASS: CWE rule table and fixtures/ are in sync"
+  exit 0
+fi
+echo "FAIL: security-review CWE table and fixtures/ have drifted"
+exit 1

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -303,7 +303,7 @@
     },
     "security-review": {
       "description": ">",
-      "sha256": "0265010d9bd22e27",
+      "sha256": "3d046f443689fc1e",
       "path": "skills/security-reviewSKILL.md"
     },
     "seed-conventions": {
@@ -333,7 +333,7 @@
     },
     "smoke-test": {
       "description": "\"Post-deploy health-check against a live URL. Validates HTTP status, response content, and critical endpoints. Runnable standalone OR as the final step of the deploy skill.\"",
-      "sha256": "f75e9e57d4003209",
+      "sha256": "050170d66ada581e",
       "path": "skills/smoke-testSKILL.md"
     },
     "spike-prototype": {

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -64,6 +64,8 @@ Every **new detection rule** added to this skill MUST:
 |------|-----|------------------|------------------|
 | SQL injection | CWE-89 | `fixtures/CWE-89-sqli-positive.py` | `fixtures/CWE-89-sqli-negative.py` |
 | XSS (DOM) | CWE-79 | `fixtures/CWE-79-xss-positive.js` | `fixtures/CWE-79-xss-negative.js` |
+| Missing tenant scoping (IDOR) | CWE-639 | `fixtures/CWE-639-idor-positive.go` | `fixtures/CWE-639-idor-negative.go` |
+| Fail-open verify directive | CWE-754 | `fixtures/CWE-fail-open-verify-positive.sh` | `fixtures/CWE-fail-open-verify-negative.sh` |
 
 Before merging a new category, run both fixtures through the detection guidance and confirm positive flags / negative passes.
 
@@ -115,4 +117,4 @@ Each finding: **`File:Line` — Severity — Category**
 
 ## Verify
 
-→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && git rev-parse HEAD >/dev/null 2>&1`
+→ verify: `test -d specs/security && test -f scripts/lib/parallel-review-worktrees.sh && bash scripts/verify-cwe-fixture-sync.sh >/dev/null && git rev-parse HEAD >/dev/null 2>&1`

--- a/skills/security-review/fixtures/CWE-639-idor-negative.go
+++ b/skills/security-review/fixtures/CWE-639-idor-negative.go
@@ -1,0 +1,48 @@
+// story: e80s05
+// Negative fixture: correctly scoped tenant query (must NOT be flagged).
+//
+// The org comes from the authenticated context, never from the request, and it
+// is part of the WHERE clause. A caller from another organization gets zero
+// rows rather than someone else's site.
+//
+// Note the retrofit trap this deliberately avoids: bigbase's BUG-2026-07-24T184443
+// added `org_id INTEGER NOT NULL DEFAULT 0`, which passed tests on new rows and
+// hid 8 of 9 production sites whose legacy rows defaulted to org 0. Scope on a
+// real, backfilled org_id — never a placeholder default.
+package fixtures
+
+import (
+	"database/sql"
+	"net/http"
+)
+
+func orgIDFromContext(r *http.Request) (string, bool) {
+	v, ok := r.Context().Value(ctxOrgID).(string)
+	return v, ok && v != ""
+}
+
+type ctxKey string
+
+const ctxOrgID ctxKey = "org_id"
+
+func handleGetSiteNegative(w http.ResponseWriter, r *http.Request, db *sql.DB) {
+	orgID, ok := orgIDFromContext(r)
+	if !ok {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	siteID := r.URL.Query().Get("site_id")
+
+	// SAFE: the tenant predicate is not optional and does not come from input.
+	row := db.QueryRow(
+		`SELECT id, name, domain FROM sites WHERE id = ? AND org_id = ?`,
+		siteID, orgID,
+	)
+
+	var id, name, domain string
+	if err := row.Scan(&id, &name, &domain); err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	_, _ = w.Write([]byte(name + " " + domain))
+}

--- a/skills/security-review/fixtures/CWE-639-idor-positive.go
+++ b/skills/security-review/fixtures/CWE-639-idor-positive.go
@@ -1,0 +1,29 @@
+// story: e80s05
+// Positive fixture: IDOR / missing tenant scoping (must be flagged).
+//
+// Modelled on the bigbase family (BUG-129/130/133/135/136/140/143): the
+// handler authenticates the caller, then trusts an ID from the request and
+// queries by that ID alone. Authentication is proven; authorization is not.
+// Nothing in the type system or a diff-scoped review makes this look wrong —
+// the bug is a predicate that was never written.
+package fixtures
+
+import (
+	"database/sql"
+	"net/http"
+)
+
+func handleGetSitePositive(w http.ResponseWriter, r *http.Request, db *sql.DB) {
+	siteID := r.URL.Query().Get("site_id")
+
+	// VULNERABLE: scoped by primary key only. Any authenticated caller from any
+	// organization can read any site by guessing or enumerating site_id.
+	row := db.QueryRow(`SELECT id, name, domain FROM sites WHERE id = ?`, siteID)
+
+	var id, name, domain string
+	if err := row.Scan(&id, &name, &domain); err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	_, _ = w.Write([]byte(name + " " + domain))
+}

--- a/skills/smoke-test/SKILL.md
+++ b/skills/smoke-test/SKILL.md
@@ -81,4 +81,4 @@ Part of **★ VERIFY ★**: `verify-work` → `validate-contracts` → `smoke-te
 
 ## Verify
 
-→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && grep -qv 'See \[REFERENCE.md\]' skills/smoke-test/SKILL.md && echo OK`
+→ verify: `test -x scripts/run-smoke.sh && grep -q 'run-smoke.sh' skills/smoke-test/SKILL.md && ! grep -q 'See \[REFERENCE.md\](REFERENCE.md)$' skills/smoke-test/SKILL.md && echo OK`

--- a/specs/TRACEABILITY_LATEST.md
+++ b/specs/TRACEABILITY_LATEST.md
@@ -1,6 +1,6 @@
 # Traceability Matrix
 
-**Generated:** 2026-07-26 00:06:29 UTC
+**Generated:** 2026-07-26 11:27:33 UTC
 **Total stories:** 121
 **Tagged stories:** 111
 **Dark stories:** 0
@@ -9,8 +9,8 @@
 
 ## Oracle Stats
 
-- **High** (explicit tag): 723
-- **Medium** (file heuristic): 3201
+- **High** (explicit tag): 726
+- **Medium** (file heuristic): 3215
 - **Low** (task reference): 79
 
 ## Story Coverage
@@ -50,7 +50,7 @@
 | e45s15 | release-branch / deploy: three-independent-facts verificatio | e45 | 2 | 5.0 | done | 19 |
 | e45s16 | CLAUDE.md rtk mandate: wire rtk-ai/rtk PreToolUse hook | e45 | 2 | 5.0 | done | 4 |
 | e45s17 | request-review: fan-out to parallel review subagents | e45 | 2 | 5.0 | done | 30 |
-| e45s18 | audit-code / security-review: worktree-isolated parallel che | e45 | 2 | 5.0 | done | 609 |
+| e45s18 | audit-code / security-review: worktree-isolated parallel che | e45 | 2 | 5.0 | done | 611 |
 | e45s19 | Context7: bounded retry cap and explicit fallback block | e45 | 2 | 5.0 | done | 8 |
 | e45s20 | Context7 / bts docs: wrap in ETag-revalidated fetch cache | e45 | 2 | 5.0 | done | 1 |
 | e45s21 | seed-conventions / AGENTS.md: self-installing fenced markers | e45 | 2 | 5.0 | done | 29 |
@@ -58,12 +58,12 @@
 | e45s23 | CLAUDE.md: live Learned User Preferences / Workspace Facts | e45 | 2 | 5.0 | done | 15 |
 | e45s24 | REFERENCE.md files: embedded line-range navigation guides | e45 | 2 | 5.0 | done | 2 |
 | e45s25 | CONVENTIONS.md risk tiers: compile to versioned, diffable ru | e45 | 4 | 5.0 | done | 5 |
-| e45s26 | security-review: CWE mapping + 2 positive/2 negative fixture | e45 | 2 | 5.0 | done | 21 |
+| e45s26 | security-review: CWE mapping + 2 positive/2 negative fixture | e45 | 2 | 5.0 | done | 22 |
 | e45s27 | loop / workflow: terminal-state taxonomy | e45 | 2 | 5.0 | done | 12 |
 | e45s28 | request-review: hard max-iteration cap | e45 | 2 | 5.0 | done | 16 |
-| e45s29 | requirements: ADDED/MODIFIED/REMOVED/RENAMED tags | e45 | 2 | 5.0 | done | 36 |
+| e45s29 | requirements: ADDED/MODIFIED/REMOVED/RENAMED tags | e45 | 2 | 5.0 | done | 38 |
 | e45s30 | subagent depth: formalize depth tiers | e45 | 2 | 5.0 | done | 24 |
-| e45s31 | audit-code / deepen-architecture: churn-based look-here-firs | e45 | 2 | 5.0 | done | 601 |
+| e45s31 | audit-code / deepen-architecture: churn-based look-here-firs | e45 | 2 | 5.0 | done | 603 |
 | e45s32 | gate-trace / release-branch: adversarial-review refute frami | e45 | 2 | 5.0 | done | 35 |
 | e45s33 | requirements: per-section approval state | e45 | 2 | 5.0 | done | 3 |
 | e45s34 | develop-tdd: snapshot-before-transition hardening | e45 | 2 | 5.0 | done | 7 |
@@ -75,10 +75,10 @@
 | e45s40 | verify-work: mandatory real-browser verification | e45 | 2 | 5.0 | done | 21 |
 | e45s41 | security-review: proven authorship SQL-safety doctrine | e45 | 2 | 5.0 | done | 16 |
 | e48s01 | Generate epics-wiki and adr-wiki as OKF concept bundles from | e48 | 2 | 2.5 | done | 34 |
-| e48s02 | Emit verification reports as OKF bundles from run-golden-sui | e48 | 2 | 2.5 | done | 46 |
+| e48s02 | Emit verification reports as OKF bundles from run-golden-sui | e48 | 2 | 2.5 | done | 48 |
 | e48s03 | OKF-ify bug-registry: specs/bugs/registry.yaml emits concept | e48 | 1 | 2.5 | done | 146 |
 | e48s04 | Create viz.html — interactive force-layout graph companion f | e48 | 2 | 2.5 | done | 12 |
-| e48s05 | Wire OKF validation into CI (sync-skills.yml) and document i | e48 | 1 | 2.5 | done | 188 |
+| e48s05 | Wire OKF validation into CI (sync-skills.yml) and document i | e48 | 1 | 2.5 | done | 190 |
 | e48s06 | Add tier: field (core/extended/specialized) to OKF wiki inde | e48 | 2 | 2.5 | done | 10 |
 | e48s07 | Create publish-to-wiki kernel tool | e48 | 3 | 2.5 | done | 2 |
 | e48s08 | Add GitHub Action Template for publish-wiki.yml [HARD GATE] | e48 | 1 | 2.5 | done | 8 |
@@ -92,7 +92,7 @@
 | e51s01 | CONVENTIONS — Always Green, Shift Left, Discovered Defects,  | e51 | 3 | 7.0 | done | 8 |
 | e51s02 | seed-conventions — Preflight default, solo-git default, embe | e51 | 3 | 7.0 | done | 36 |
 | e51s03 | kickoff-branch + verify-work — Preflight hard block and CI g | e51 | 2 | 7.0 | done | 63 |
-| e51s04 | audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log rou | e51 | 2 | 7.0 | done | 656 |
+| e51s04 | audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log rou | e51 | 2 | 7.0 | done | 659 |
 | e51s05 | CLAUDE.md — solo-default agent rules + bigpowers Preflight c | e51 | 2 | 7.0 | done | 7 |
 | e54s01 | Snapshot the current skill catalog as an immutable baseline | e54 | 2 | 6.7 | done | 9 |
 | e54s02 | Add a soft drift-detection gate for the freeze window | e54 | 3 | 6.7 | done | 14 |
@@ -133,11 +133,11 @@
 | e79s02 | Validator script + craft-skill HARD GATE | e79 | 0 | 6.0 | backlog | 21 |
 | e79s03 | seed-conventions applies ruleset | e79 | 0 | 6.0 | backlog | 18 |
 | e79s04 | stocktake-skills violation scanner | e79 | 0 | 6.0 | backlog | 18 |
-| e80s01 | Core verify skills → verify directives | e80 | 0 | 7.5 | backlog | 75 |
+| e80s01 | Core verify skills → verify directives | e80 | 0 | 7.5 | backlog | 76 |
 | e80s02 | smoke-test and validate-contracts real bodies | e80 | 0 | 7.5 | backlog | 30 |
 | e80s03 | develop-tdd RED commit isolation check | e80 | 0 | 7.5 | backlog | 10 |
-| e80s04 | generalize-fix phase in validate-fix | e80 | 0 | 7.5 | backlog | 34 |
-| e80s05 | security-review fixture table growth | e80 | 0 | 7.5 | backlog | 10 |
+| e80s04 | generalize-fix phase in validate-fix | e80 | 0 | 7.5 | backlog | 35 |
+| e80s05 | security-review fixture table growth | e80 | 0 | 7.5 | backlog | 11 |
 
 ## Orphan Tags (tag in code, no matching story)
 

--- a/specs/benchmarks/reports/GOLDEN-2026-07-26.yaml
+++ b/specs/benchmarks/reports/GOLDEN-2026-07-26.yaml
@@ -1,0 +1,68 @@
+timestamp: "2026-07-26T11:25:50Z"
+git_commit: "987cad23da5fd17ac01c7cb535424a72c2021e9a"
+suite: "golden-combined"
+mode: "daily"
+deterministic:
+  total: 12
+  passed: 12
+  failed: 0
+  skipped: 0
+  pass_rate: 1.00
+gates:
+  - name: compliance
+    exit_code: 0
+    duration_seconds: 76.12
+    status: pass
+  - name: g04-selftest
+    exit_code: 0
+    duration_seconds: .04
+    status: pass
+  - name: g06-migrate-version
+    exit_code: 0
+    duration_seconds: 8.52
+    status: pass
+  - name: g07-negative-path
+    exit_code: 0
+    duration_seconds: .07
+    status: pass
+  - name: g08-anti-vacuity
+    exit_code: 0
+    duration_seconds: .08
+    status: pass
+  - name: g09-yaml-roundtrip
+    exit_code: 0
+    duration_seconds: .10
+    status: pass
+  - name: g10-trace-anti-vacuity
+    exit_code: 0
+    duration_seconds: .09
+    status: pass
+  - name: g11-gitignore-venv
+    exit_code: 0
+    duration_seconds: .08
+    status: pass
+  - name: install-helpers
+    exit_code: 0
+    duration_seconds: .08
+    status: pass
+  - name: import-boundaries
+    exit_code: 0
+    duration_seconds: .30
+    status: pass
+  - name: skill-catalog
+    exit_code: 0
+    duration_seconds: 1.53
+    status: pass
+  - name: specs-parse
+    exit_code: 0
+    duration_seconds: .80
+    status: pass
+agent_stories:
+  total: 0
+  passed: 0
+  failed: 0
+  skipped: 0
+  flake_count: 0
+  pass_rate: n/a
+summary:
+  combined_verdict: "pass"

--- a/specs/codebase-wiki/e45s18.md
+++ b/specs/codebase-wiki/e45s18.md
@@ -232,6 +232,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260726-082552.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-172502.md
     line: 0
     confidence: medium
@@ -2196,6 +2200,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260726-082716.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-142458.md
     line: 0
     confidence: medium
@@ -2510,6 +2518,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260704-081618.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-162136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234209.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260726-082552.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132717.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260723-160627.md` (line 0, confidence: medium, method: file_heuristic)
@@ -3001,6 +3010,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260705-170757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-163613.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-173429.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260726-082716.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260725-003812.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260709-005318.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s26.md
+++ b/specs/codebase-wiki/e45s26.md
@@ -92,6 +92,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: skills/security-review/fixtures/CWE-639-idor-negative.go
+    line: 0
+    confidence: medium
+    method: file_heuristic
 ---
 
 # e45s26: security-review: CWE mapping + 2 positive/2 negative fixtures
@@ -123,3 +127,4 @@ links:
 - `.continue/rules/security-review.md` (line 0, confidence: medium, method: file_heuristic)
 - `website/src/content/docs/skills/security-review.mdx` (line 0, confidence: medium, method: file_heuristic)
 - `skills/security-review/fixtures/CWE-fail-open-verify-negative.sh` (line 0, confidence: medium, method: file_heuristic)
+- `skills/security-review/fixtures/CWE-639-idor-negative.go` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s29.md
+++ b/specs/codebase-wiki/e45s29.md
@@ -152,6 +152,14 @@ links:
     line: 7
     confidence: high
     method: explicit_tag
+  - file: .pi/prompts/change-request.md
+    line: 6
+    confidence: high
+    method: explicit_tag
+  - file: .pi/skills/change-request/SKILL.md
+    line: 7
+    confidence: high
+    method: explicit_tag
 ---
 
 # e45s29: requirements: ADDED/MODIFIED/REMOVED/RENAMED tags
@@ -198,3 +206,5 @@ links:
 - `.hermes/skills/plan-work/SKILL.md` (line 7, confidence: high, method: explicit_tag)
 - `.hermes/skills/change-request/SKILL.md` (line 7, confidence: high, method: explicit_tag)
 - `.hermes/skills/slice-tasks/SKILL.md` (line 7, confidence: high, method: explicit_tag)
+- `.pi/prompts/change-request.md` (line 6, confidence: high, method: explicit_tag)
+- `.pi/skills/change-request/SKILL.md` (line 7, confidence: high, method: explicit_tag)

--- a/specs/codebase-wiki/e45s31.md
+++ b/specs/codebase-wiki/e45s31.md
@@ -208,6 +208,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260726-082552.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-172502.md
     line: 0
     confidence: medium
@@ -2172,6 +2176,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260726-082716.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-142458.md
     line: 0
     confidence: medium
@@ -2472,6 +2480,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260704-081618.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-162136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234209.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260726-082552.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132717.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260723-160627.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2963,6 +2972,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260705-170757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-163613.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-173429.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260726-082716.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260725-003812.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260709-005318.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e48s02.md
+++ b/specs/codebase-wiki/e48s02.md
@@ -68,6 +68,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/audit-2026-07-26.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/GOLDEN-2026-07-13.okf.md
     line: 0
     confidence: medium
@@ -101,6 +105,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-2026-07-13.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/reports/GOLDEN-2026-07-26.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -217,6 +225,7 @@ links:
 - `specs/verifications/reports/GOLDEN-2026-07-23.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-24.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-25.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-2026-07-26.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-13.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-23.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-07.okf.md` (line 0, confidence: medium, method: file_heuristic)
@@ -226,6 +235,7 @@ links:
 - `specs/verifications/reports/audit-2026-07-05.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-09.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-13.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/GOLDEN-2026-07-26.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-25.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-11.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-24.okf.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e48s05.md
+++ b/specs/codebase-wiki/e48s05.md
@@ -80,6 +80,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/audit-2026-07-26.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/GOLDEN-2026-07-13.okf.md
     line: 0
     confidence: medium
@@ -113,6 +117,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-2026-07-13.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/reports/GOLDEN-2026-07-26.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -788,6 +796,7 @@ links:
 - `specs/verifications/reports/GOLDEN-2026-07-23.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-24.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-25.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-2026-07-26.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-13.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-23.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-07.okf.md` (line 0, confidence: medium, method: file_heuristic)
@@ -797,6 +806,7 @@ links:
 - `specs/verifications/reports/audit-2026-07-05.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-09.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-13.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/GOLDEN-2026-07-26.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-25.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-11.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-24.okf.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e51s04.md
+++ b/specs/codebase-wiki/e51s04.md
@@ -264,6 +264,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260726-082552.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-172502.md
     line: 0
     confidence: medium
@@ -2228,6 +2232,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260726-082716.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260703-142458.md
     line: 0
     confidence: medium
@@ -2628,6 +2636,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: scripts/verify-cwe-fixture-sync.sh
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: skills/validate-fix/REFERENCE-generalize-fix.md
     line: 0
     confidence: medium
@@ -2706,6 +2718,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260704-081618.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-162136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234209.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260726-082552.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132717.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260723-160627.md` (line 0, confidence: medium, method: file_heuristic)
@@ -3197,6 +3210,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260705-170757.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-163613.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-173429.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260726-082716.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-142458.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260725-003812.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260709-005318.md` (line 0, confidence: medium, method: file_heuristic)
@@ -3297,4 +3311,5 @@ links:
 - `.kilocode/rules/audit-code.md` (line 0, confidence: medium, method: file_heuristic)
 - `.kilocode/rules/investigate-bug.md` (line 0, confidence: medium, method: file_heuristic)
 - `scripts/audit-catalog.sh` (line 0, confidence: medium, method: file_heuristic)
+- `scripts/verify-cwe-fixture-sync.sh` (line 0, confidence: medium, method: file_heuristic)
 - `skills/validate-fix/REFERENCE-generalize-fix.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e80s01.md
+++ b/specs/codebase-wiki/e80s01.md
@@ -276,6 +276,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: scripts/verify-cwe-fixture-sync.sh
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: scripts/run-skill-verify.sh
     line: 0
     confidence: medium
@@ -385,6 +389,7 @@ links:
 - `scripts/hermes-verify-e39s02.sh` (line 0, confidence: medium, method: file_heuristic)
 - `scripts/verify-generalize-sweep.sh` (line 0, confidence: medium, method: file_heuristic)
 - `scripts/verify-install.sh` (line 0, confidence: medium, method: file_heuristic)
+- `scripts/verify-cwe-fixture-sync.sh` (line 0, confidence: medium, method: file_heuristic)
 - `scripts/run-skill-verify.sh` (line 0, confidence: medium, method: file_heuristic)
 - `skills/align-grid/scripts/verify_grid.js` (line 0, confidence: medium, method: file_heuristic)
 - `skills/security-review/fixtures/CWE-fail-open-verify-negative.sh` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e80s04.md
+++ b/specs/codebase-wiki/e80s04.md
@@ -132,6 +132,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: scripts/verify-cwe-fixture-sync.sh
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: skills/validate-fix/REFERENCE-generalize-fix.md
     line: 0
     confidence: medium
@@ -185,6 +189,7 @@ links:
 - `.kilocode/rules/quick-fix.md` (line 0, confidence: medium, method: file_heuristic)
 - `.kilocode/rules/validate-fix.md` (line 0, confidence: medium, method: file_heuristic)
 - `.kilocode/rules/fix-bug.md` (line 0, confidence: medium, method: file_heuristic)
+- `scripts/verify-cwe-fixture-sync.sh` (line 0, confidence: medium, method: file_heuristic)
 - `skills/validate-fix/REFERENCE-generalize-fix.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/e80-verify-arc-hardening/e80s05-tasks.yaml` (line 0, confidence: low, method: task_reference)
 - `specs/epics/e80-verify-arc-hardening/e80s04-tasks.yaml` (line 0, confidence: low, method: task_reference)

--- a/specs/codebase-wiki/e80s05.md
+++ b/specs/codebase-wiki/e80s05.md
@@ -12,6 +12,10 @@ links:
     line: 99
     confidence: high
     method: explicit_tag
+  - file: scripts/verify-cwe-fixture-sync.sh
+    line: 2
+    confidence: high
+    method: explicit_tag
   - file: skills/security-review/fixtures/CWE-fail-open-verify-negative.sh
     line: 2
     confidence: high
@@ -59,6 +63,7 @@ links:
 ## Implemented In
 
 - `specs/epics/e80-verify-arc-hardening/epic.yaml` (line 99, confidence: high, method: explicit_tag)
+- `scripts/verify-cwe-fixture-sync.sh` (line 2, confidence: high, method: explicit_tag)
 - `skills/security-review/fixtures/CWE-fail-open-verify-negative.sh` (line 2, confidence: high, method: explicit_tag)
 - `skills/security-review/fixtures/CWE-fail-open-verify-positive.sh` (line 2, confidence: high, method: explicit_tag)
 - `.windsurf/rules/security-review.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/index.md
+++ b/specs/codebase-wiki/index.md
@@ -1,6 +1,6 @@
 ---
 type: Index
-generated_at: 2026-07-26T00:06:29.937569+00:00
+generated_at: 2026-07-26T11:27:33.981347+00:00
 total_concepts: 121
 ---
 
@@ -43,7 +43,7 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e45s15](./e45s15.md) | release-branch / deploy: three-independent-facts verificatio | high | 19 |
 | [e45s16](./e45s16.md) | CLAUDE.md rtk mandate: wire rtk-ai/rtk PreToolUse hook | high | 4 |
 | [e45s17](./e45s17.md) | request-review: fan-out to parallel review subagents | high | 30 |
-| [e45s18](./e45s18.md) | audit-code / security-review: worktree-isolated parallel che | high | 609 |
+| [e45s18](./e45s18.md) | audit-code / security-review: worktree-isolated parallel che | high | 611 |
 | [e45s19](./e45s19.md) | Context7: bounded retry cap and explicit fallback block | high | 8 |
 | [e45s20](./e45s20.md) | Context7 / bts docs: wrap in ETag-revalidated fetch cache | high | 1 |
 | [e45s21](./e45s21.md) | seed-conventions / AGENTS.md: self-installing fenced markers | high | 29 |
@@ -51,12 +51,12 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e45s23](./e45s23.md) | CLAUDE.md: live Learned User Preferences / Workspace Facts | high | 15 |
 | [e45s24](./e45s24.md) | REFERENCE.md files: embedded line-range navigation guides | medium | 2 |
 | [e45s25](./e45s25.md) | CONVENTIONS.md risk tiers: compile to versioned, diffable ru | high | 5 |
-| [e45s26](./e45s26.md) | security-review: CWE mapping + 2 positive/2 negative fixture | high | 21 |
+| [e45s26](./e45s26.md) | security-review: CWE mapping + 2 positive/2 negative fixture | high | 22 |
 | [e45s27](./e45s27.md) | loop / workflow: terminal-state taxonomy | high | 12 |
 | [e45s28](./e45s28.md) | request-review: hard max-iteration cap | high | 16 |
-| [e45s29](./e45s29.md) | requirements: ADDED/MODIFIED/REMOVED/RENAMED tags | high | 36 |
+| [e45s29](./e45s29.md) | requirements: ADDED/MODIFIED/REMOVED/RENAMED tags | high | 38 |
 | [e45s30](./e45s30.md) | subagent depth: formalize depth tiers | high | 24 |
-| [e45s31](./e45s31.md) | audit-code / deepen-architecture: churn-based look-here-firs | high | 601 |
+| [e45s31](./e45s31.md) | audit-code / deepen-architecture: churn-based look-here-firs | high | 603 |
 | [e45s32](./e45s32.md) | gate-trace / release-branch: adversarial-review refute frami | high | 35 |
 | [e45s33](./e45s33.md) | requirements: per-section approval state | high | 3 |
 | [e45s34](./e45s34.md) | develop-tdd: snapshot-before-transition hardening | high | 7 |
@@ -68,10 +68,10 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e45s40](./e45s40.md) | verify-work: mandatory real-browser verification | high | 21 |
 | [e45s41](./e45s41.md) | security-review: proven authorship SQL-safety doctrine | high | 16 |
 | [e48s01](./e48s01.md) | Generate epics-wiki and adr-wiki as OKF concept bundles from | high | 34 |
-| [e48s02](./e48s02.md) | Emit verification reports as OKF bundles from run-golden-sui | medium | 46 |
+| [e48s02](./e48s02.md) | Emit verification reports as OKF bundles from run-golden-sui | medium | 48 |
 | [e48s03](./e48s03.md) | OKF-ify bug-registry: specs/bugs/registry.yaml emits concept | high | 146 |
 | [e48s04](./e48s04.md) | Create viz.html — interactive force-layout graph companion f | medium | 12 |
-| [e48s05](./e48s05.md) | Wire OKF validation into CI (sync-skills.yml) and document i | medium | 188 |
+| [e48s05](./e48s05.md) | Wire OKF validation into CI (sync-skills.yml) and document i | medium | 190 |
 | [e48s06](./e48s06.md) | Add tier: field (core/extended/specialized) to OKF wiki inde | medium | 10 |
 | [e48s07](./e48s07.md) | Create publish-to-wiki kernel tool | high | 2 |
 | [e48s08](./e48s08.md) | Add GitHub Action Template for publish-wiki.yml [HARD GATE] | high | 8 |
@@ -85,7 +85,7 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e51s01](./e51s01.md) | CONVENTIONS — Always Green, Shift Left, Discovered Defects,  | high | 8 |
 | [e51s02](./e51s02.md) | seed-conventions — Preflight default, solo-git default, embe | high | 36 |
 | [e51s03](./e51s03.md) | kickoff-branch + verify-work — Preflight hard block and CI g | high | 63 |
-| [e51s04](./e51s04.md) | audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log rou | high | 656 |
+| [e51s04](./e51s04.md) | audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log rou | high | 659 |
 | [e51s05](./e51s05.md) | CLAUDE.md — solo-default agent rules + bigpowers Preflight c | high | 7 |
 | [e54s01](./e54s01.md) | Snapshot the current skill catalog as an immutable baseline | high | 9 |
 | [e54s02](./e54s02.md) | Add a soft drift-detection gate for the freeze window | high | 14 |
@@ -126,8 +126,8 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e79s02](./e79s02.md) | Validator script + craft-skill HARD GATE | high | 21 |
 | [e79s03](./e79s03.md) | seed-conventions applies ruleset | high | 18 |
 | [e79s04](./e79s04.md) | stocktake-skills violation scanner | high | 18 |
-| [e80s01](./e80s01.md) | Core verify skills → verify directives | high | 75 |
+| [e80s01](./e80s01.md) | Core verify skills → verify directives | high | 76 |
 | [e80s02](./e80s02.md) | smoke-test and validate-contracts real bodies | high | 30 |
 | [e80s03](./e80s03.md) | develop-tdd RED commit isolation check | high | 10 |
-| [e80s04](./e80s04.md) | generalize-fix phase in validate-fix | high | 34 |
-| [e80s05](./e80s05.md) | security-review fixture table growth | high | 10 |
+| [e80s04](./e80s04.md) | generalize-fix phase in validate-fix | high | 35 |
+| [e80s05](./e80s05.md) | security-review fixture table growth | high | 11 |

--- a/specs/traceability-matrix.json
+++ b/specs/traceability-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-26T00:06:29.923874+00:00",
+  "generated_at": "2026-07-26T11:27:33.968779+00:00",
   "matrix_version": "1.0",
   "stories": [
     {
@@ -3882,6 +3882,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/audit-cleancode-20260726-082552.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-172502.md",
           "line": 0,
           "confidence": "medium",
@@ -6828,6 +6834,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/audit-cleancode-20260726-082716.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-142458.md",
           "line": 0,
           "confidence": "medium",
@@ -7200,7 +7212,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 609
+      "link_count": 611
     },
     {
       "id": "e45s19",
@@ -7798,9 +7810,15 @@
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
+        },
+        {
+          "file": "skills/security-review/fixtures/CWE-639-idor-negative.go",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
         }
       ],
-      "link_count": 21
+      "link_count": 22
     },
     {
       "id": "e45s27",
@@ -8218,9 +8236,21 @@
           "line": 7,
           "confidence": "high",
           "method": "explicit_tag"
+        },
+        {
+          "file": ".pi/prompts/change-request.md",
+          "line": 6,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": ".pi/skills/change-request/SKILL.md",
+          "line": 7,
+          "confidence": "high",
+          "method": "explicit_tag"
         }
       ],
-      "link_count": 36
+      "link_count": 38
     },
     {
       "id": "e45s30",
@@ -8683,6 +8713,12 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260703-234209.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/reports/audit-cleancode-20260726-082552.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -11634,6 +11670,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/audit-cleancode-20260726-082716.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-142458.md",
           "line": 0,
           "confidence": "medium",
@@ -11994,7 +12036,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 601
+      "link_count": 603
     },
     {
       "id": "e45s32",
@@ -13188,6 +13230,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/audit-2026-07-26.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/GOLDEN-2026-07-13.okf.md",
           "line": 0,
           "confidence": "medium",
@@ -13237,6 +13285,12 @@
         },
         {
           "file": "specs/verifications/reports/audit-2026-07-13.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/reports/GOLDEN-2026-07-26.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -13374,7 +13428,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 46
+      "link_count": 48
     },
     {
       "id": "e48s03",
@@ -14466,6 +14520,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/audit-2026-07-26.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/GOLDEN-2026-07-13.okf.md",
           "line": 0,
           "confidence": "medium",
@@ -14515,6 +14575,12 @@
         },
         {
           "file": "specs/verifications/reports/audit-2026-07-13.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/reports/GOLDEN-2026-07-26.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15486,7 +15552,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 188
+      "link_count": 190
     },
     {
       "id": "e48s06",
@@ -17364,6 +17430,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/audit-cleancode-20260726-082552.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-172502.md",
           "line": 0,
           "confidence": "medium",
@@ -20310,6 +20382,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/audit-cleancode-20260726-082716.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/audit-cleancode-20260703-142458.md",
           "line": 0,
           "confidence": "medium",
@@ -20910,13 +20988,19 @@
           "method": "file_heuristic"
         },
         {
+          "file": "scripts/verify-cwe-fixture-sync.sh",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "skills/validate-fix/REFERENCE-generalize-fix.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
         }
       ],
-      "link_count": 656
+      "link_count": 659
     },
     {
       "id": "e51s05",
@@ -24870,6 +24954,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "scripts/verify-cwe-fixture-sync.sh",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "scripts/run-skill-verify.sh",
           "line": 0,
           "confidence": "medium",
@@ -24918,7 +25008,7 @@
           "method": "task_reference"
         }
       ],
-      "link_count": 75
+      "link_count": 76
     },
     {
       "id": "e80s02",
@@ -25380,6 +25470,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "scripts/verify-cwe-fixture-sync.sh",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "skills/validate-fix/REFERENCE-generalize-fix.md",
           "line": 0,
           "confidence": "medium",
@@ -25398,7 +25494,7 @@
           "method": "task_reference"
         }
       ],
-      "link_count": 34
+      "link_count": 35
     },
     {
       "id": "e80s05",
@@ -25412,6 +25508,12 @@
         {
           "file": "specs/epics/e80-verify-arc-hardening/epic.yaml",
           "line": 99,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "scripts/verify-cwe-fixture-sync.sh",
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -25470,7 +25572,7 @@
           "method": "task_reference"
         }
       ],
-      "link_count": 10
+      "link_count": 11
     }
   ],
   "summary": {
@@ -25736,8 +25838,8 @@
     ],
     "stale_count": 102,
     "oracle_stats": {
-      "high": 723,
-      "medium": 3201,
+      "high": 726,
+      "medium": 3215,
       "low": 79
     }
   }


### PR DESCRIPTION
Audit of epic e80 (which marked #97 and #98 done while both issues stayed open). **Most of e80 holds** — credit where due:

- all six core verify skills now carry directives backed by real `--self-test` scripts
- `smoke-test` and `validate-contracts` have bodies instead of `See REFERENCE.md` stubs
- the arc reads `verify-work → validate-contracts → smoke-test → run-evals → audit-code`, with both skills reclassified from **Build** to **Verify**
- `verify-tdd-red-commit.sh --self-test` genuinely builds a temp repo, makes a RED test-only commit, and asserts it fails in isolation

Two things did not hold, and both are the same failure mode this epic existed to remove.

## 1. `smoke-test`'s guard could not fail

```
grep -qv 'See \[REFERENCE.md\]' skills/smoke-test/SKILL.md
```

`grep -qv` exits 0 whenever *any* line does not match — true of every non-empty file. Proven:

```
$ printf 'line one\nSee [REFERENCE.md](REFERENCE.md)\n' > /tmp/stub.md
$ grep -qv 'See \[REFERENCE.md\]' /tmp/stub.md ; echo $?
0        # passes although the stub IS present
```

And end to end — appending a stub line to the real skill still gave `PASS: skills/smoke-test`. Replaced with `! grep -q`, which now correctly `FAIL`s on that same input and passes once restored.

## 2. e80s05 was marked done without doing it

The CWE rule table still had exactly the two rows the original audit flagged (SQLi, XSS), while `fixtures/` had meanwhile gained `CWE-fail-open-verify` that the table never listed. Nothing compared the two.

Adding the missing row alone would just reset the clock, so the drift is now mechanical:

- **`scripts/verify-cwe-fixture-sync.sh`** — every fixture class needs a table row, every referenced fixture must exist, every class needs both polarities. `--self-test` points it at an unlisted class and requires a non-zero exit.
- Wired into `security-review`'s verify directive, so the skill fails when its own rule table drifts from its fixtures. Proven: hiding one fixture flips it to `FAIL`, restoring it flips back.
- Added the missing `CWE-fail-open-verify` row.
- Added **CWE-639 (missing tenant scoping / IDOR)** with Go fixtures.

CWE-639 is the substantive addition: **11+ bigbase bugs, carrying most of the criticals**, and `security-review` had no rule for it. The negative fixture documents the retrofit trap specifically — `org_id INTEGER NOT NULL DEFAULT 0` passes tests on new rows and orphans legacy ones, which is how BUG-136's fix became BUG-2026-07-24T184443 and hid 8 of 9 production sites.

## Verification

```
compliance                 0
run-verification-gates     0    12/12 passed
trace-stories --strict     0
sync-skills                0
skill-verify   bash 3.2 -> 61 PASS, 0 FAIL, 34 SKIP   exit 0
skill-verify   bash 5.3 -> 61 PASS, 0 FAIL, 34 SKIP   exit 0
```

Both repaired gates were proven to fail before being trusted, per the same discipline as #103.

## Scope note

The 34 remaining `SKIP`s (skills with no directive) are unchanged. #97's named complaint — the six *verification* skills — is resolved; the long tail is held from growing by the SKIP ratchet added in #103. Worth tracking separately rather than pretending this PR closes it.