### PR TITLE
fix(skills): pi no longer drops 16 skills — story tags above frontmatter delimiter (BUG-2026-08-06, issue #108)

### DIFF
--- a/scripts/lib/skill-common.sh
+++ b/scripts/lib/skill-common.sh
@@ -48,6 +48,9 @@ parse_frontmatter() {
     fi
     [ "$in_block" -ne 1 ] && continue
 
+    # Skip comment lines (e.g. # story: tags inside the frontmatter block)
+    [[ "$line" == \#* || "$line" == \<\!--* ]] && continue
+
     case "$line" in
       name:*)
         name="${line#name: }"
@@ -76,6 +79,8 @@ parse_frontmatter() {
       continue
     fi
     [ "$continued" -eq 0 ] && continue
+    # Skip comment lines (e.g. # story: tags inside the frontmatter block)
+    [[ "$line" == \#* || "$line" == \<\!--* ]] && continue
     # If next field starts (unindented key:), stop
     [[ "$line" =~ ^[a-zA-Z_]+: ]] && break
     desc="$desc $line"
@@ -103,7 +108,7 @@ parse_frontmatter_okf() {
   _PF_NAME=$(awk '/^---/{f++} f==1 && /^name:/{print; exit}' "$file" | sed 's/^name:[[:space:]]*//')
   _PF_MODEL=$(awk '/^---/{f++} f==1 && /^model:/{print; exit}' "$file" | sed 's/^model:[[:space:]]*//')
   _PF_EFFORT=$(awk '/^---/{f++} f==1 && /^effort:/{print; exit}' "$file" | sed 's/^effort:[[:space:]]*//')
-  _PF_DESCRIPTION=$(awk '/^---/{f++; next} f==1 && /^description:/{p=1; sub(/^description:[[:space:]]*/,""); print; next} f==1 && p && /^[a-z]+:/{exit} f==1 && p{print}' "$file" \
+  _PF_DESCRIPTION=$(awk '/^---/{f++; next} f==1 && /^description:/{p=1; sub(/^description:[[:space:]]*/,""); print; next} f==1 && p && /^[a-z]+:/{exit} f==1 && p && !/^[[:space:]]*#/ && !/^[[:space:]]*<!--/{print}' "$file" \
     | tr -d '\n' \
     | sed -E 's/[[:space:]]+/ /g')
 

--- a/scripts/validate-skill-yaml.py
+++ b/scripts/validate-skill-yaml.py
@@ -1,5 +1,21 @@
 #!/usr/bin/env python3
-"""Validate YAML frontmatter in all .pi/skills/*/SKILL.md files."""
+"""Validate YAML frontmatter in SKILL.md files (sources + generated .pi/skills).
+
+Rules per file (sources and generated copies alike):
+
+  R1  file must start with the frontmatter delimiter '---' at byte 0.
+      pi (dist/utils/frontmatter.js) and the Agent Skills spec require the
+      opening delimiter to be the first characters of the file. Story tags
+      (`# story:` / `<!-- story: -->`) must live INSIDE the frontmatter block
+      as YAML comments, or below the closing delimiter — never above it,
+      or pi drops the skill as "description is required".
+      (story: BUG-2026-08-06-pi-drops-skills-frontmatter)
+  R2  frontmatter must parse as YAML (PyYAML or bundled simple_yaml).
+  R3  description must not embed 'model: sonnet' as literal text.
+
+Exits 1 on any failure. Called by the sync-skills.sh post-generation guard
+and by scripts/test-setup-no-pyyaml.sh.
+"""
 import glob
 import sys
 import os
@@ -17,64 +33,99 @@ except ModuleNotFoundError:
     from simple_yaml import parse_simple_yaml
     _load_yaml = parse_simple_yaml
 
-SKILLS_DIR = ".pi/skills"
-files = sorted(glob.glob(f"{SKILLS_DIR}/*/SKILL.md"))
+# Source of truth (skills/*/SKILL.md) and the pi-distributed copy (.pi/skills).
+SKILL_ROOTS = ["skills", ".pi/skills"]
 
-parse_failures = []
-semantic_failures = []
-passed = []
 
-for path in files:
-    skill_name = os.path.basename(os.path.dirname(path))
-    with open(path) as f:
-        content = f.read()
+def validate_tree(root):
+    """Return (passed, delimiter_failures, parse_failures, semantic_failures)."""
+    files = sorted(glob.glob(os.path.join(root, "*/SKILL.md")))
+    parse_failures = []
+    semantic_failures = []
+    delimiter_failures = []
+    passed = []
 
-    parts = content.split("---", 2)
-    if len(parts) < 3:
-        parse_failures.append((skill_name, "missing frontmatter delimiters"))
-        continue
+    for path in files:
+        skill_name = os.path.basename(os.path.dirname(path))
+        with open(path) as f:
+            content = f.read()
 
-    frontmatter = parts[1]
+        # R1 — pi's frontmatter gate: opening delimiter must be at byte 0.
+        if not content.startswith("---"):
+            delimiter_failures.append((skill_name, "file must start with '---' (story tags belong inside the frontmatter block or below it)"))
+            continue
 
-    try:
-        data = _load_yaml(frontmatter)
-    except Exception as e:
-        parse_failures.append((skill_name, str(e).split("\n")[0]))
-        continue
+        parts = content.split("---", 2)
+        if len(parts) < 3:
+            parse_failures.append((skill_name, "missing frontmatter delimiters"))
+            continue
 
-    if data is None:
-        parse_failures.append((skill_name, "empty frontmatter"))
-        continue
+        frontmatter = parts[1]
 
-    # Semantic check: model hint embedded in description
-    desc = data.get("description", "")
-    if desc and "model: sonnet" in desc:
-        semantic_failures.append(skill_name)
+        try:
+            data = _load_yaml(frontmatter)
+        except Exception as e:
+            parse_failures.append((skill_name, str(e).split("\n")[0]))
+            continue
 
-    passed.append(skill_name)
+        if data is None:
+            parse_failures.append((skill_name, "empty frontmatter"))
+            continue
 
-# Report
-print(f"Total SKILL.md files: {len(files)}")
-print(f"Parse OK: {len(passed)}")
-print(f"Parse FAIL: {len(parse_failures)}")
-print(f"Semantic issues (model in desc): {len(semantic_failures)}")
+        # R3 — semantic check: model hint embedded in description
+        desc = data.get("description", "")
+        if desc and "model: sonnet" in desc:
+            semantic_failures.append(skill_name)
+
+        passed.append(skill_name)
+
+    return passed, delimiter_failures, parse_failures, semantic_failures
+
+
+all_passed = []
+all_delimiter = []
+all_parse = []
+all_semantic = []
+
+for root in SKILL_ROOTS:
+    passed, delimiter_failures, parse_failures, semantic_failures = validate_tree(root)
+    all_passed += passed
+    all_delimiter += delimiter_failures
+    all_parse += parse_failures
+    all_semantic += semantic_failures
+    total = len(passed) + len(delimiter_failures) + len(parse_failures) + len(semantic_failures)
+    print(f"[{root}] SKILL.md files: {total} — parse OK: {len(passed)}")
+
+print()
+print(f"Total SKILL.md files: {len(all_passed) + len(all_delimiter) + len(all_parse) + len(all_semantic)}")
+print(f"Parse OK: {len(all_passed)}")
+print(f"Delimiter FAIL (must start with '---'): {len(all_delimiter)}")
+print(f"Parse FAIL: {len(all_parse)}")
+print(f"Semantic issues (model in desc): {len(all_semantic)}")
 print()
 
-if parse_failures:
-    print("=== PARSE FAILURES ===")
-    for name, err in parse_failures:
+if all_delimiter:
+    print("=== DELIMITER FAILURES (file does not start with '---') ===")
+    for name, err in all_delimiter:
         print(f"  {name}: {err}")
     print()
 
-if semantic_failures:
+if all_parse:
+    print("=== PARSE FAILURES ===")
+    for name, err in all_parse:
+        print(f"  {name}: {err}")
+    print()
+
+if all_semantic:
     print("=== SEMANTIC ISSUES (model embedded in description) ===")
-    for name in sorted(semantic_failures):
+    for name in sorted(all_semantic):
         print(f"  {name}")
     print()
 
-if parse_failures or semantic_failures:
-    print(f"FAIL: {len(parse_failures)} parse + {len(semantic_failures)} semantic issues")
+if all_delimiter or all_parse or all_semantic:
+    n = len(all_delimiter) + len(all_parse) + len(all_semantic)
+    print(f"FAIL: {n} issues ({len(all_delimiter)} delimiter + {len(all_parse)} parse + {len(all_semantic)} semantic)")
     sys.exit(1)
 else:
-    print("PASS: all SKILL.md YAML frontmatter valid")
+    print("PASS: all SKILL.md YAML frontmatter valid (sources + .pi/skills)")
     sys.exit(0)

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -13,7 +13,7 @@
     },
     "audit-code": {
       "description": "Self-review checklist for the coding agent to run before dispatching a reviewer. Checks CONVENTIONS.md compliance, Boy Scout Rule, test coverage, types, and SOLID. Produces a pass/fail checklist. Use before request-review, before committing, or when user asks for a code quality check.",
-      "sha256": "b0342883680fee6c",
+      "sha256": "6c37decb8b323a18",
       "path": "skills/audit-codeSKILL.md"
     },
     "audit-plan": {
@@ -48,12 +48,12 @@
     },
     "craft-skill": {
       "description": "Create new bigpowers skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill for the bigpowers lifecycle.",
-      "sha256": "f3b08c24979f1857",
+      "sha256": "b1d4efb0dcecb204",
       "path": "skills/craft-skillSKILL.md"
     },
     "deepen-architecture": {
       "description": "Find deepening opportunities in a codebase, informed by the domain language in specs/tech-architecture/tech-stack.md and the decisions in specs/adr/. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable.",
-      "sha256": "da2760c0cb49a3e4",
+      "sha256": "ee41e4524031fee3",
       "path": "skills/deepen-architectureSKILL.md"
     },
     "define-language": {
@@ -73,7 +73,7 @@
     },
     "deploy": {
       "description": "\"Build → verify artifact → deploy → wait → smoke deployment pipeline. Platform-agnostic (MCP or CLI), with configurable timeout, retry with exponential backoff, and integrated health-check. The deploy half of CI/CD: run after build to push to production.\"",
-      "sha256": "ddfcbfbfc464c620",
+      "sha256": "d355906aff894cfc",
       "path": "skills/deploySKILL.md"
     },
     "design-interface": {
@@ -83,7 +83,7 @@
     },
     "develop-tdd": {
       "description": "Test-driven development with red-green-refactor loop using vertical slices. Use for features (epic tasks) or bugs (specs/bugs/BUG-*.md).",
-      "sha256": "8b3934e2291b863d",
+      "sha256": "433c1315e6604899",
       "path": "skills/develop-tddSKILL.md"
     },
     "diagnose-root": {
@@ -93,7 +93,7 @@
     },
     "diagnose-stall": {
       "description": "Diagnose why agent orchestration stopped producing progress — silent stalls in /loop, dispatch-agents, or execute-plan. Use when work appears hung, no output for several minutes, or a subagent never returned.",
-      "sha256": "c0fe87349399c112",
+      "sha256": "983d5a3a922af07d",
       "path": "skills/diagnose-stallSKILL.md"
     },
     "dispatch-agents": {
@@ -113,7 +113,7 @@
     },
     "enforce-first": {
       "description": "Apply the F.I.R.S.T test quality rubric (per CONVENTIONS.md §Tests) to a test suite or individual tests. Use when develop-tdd is writing tests, when test quality needs to be checked, or when user mentions F.I.R.S.T or \"test quality\".",
-      "sha256": "1ec1183ee6377917",
+      "sha256": "567d0efaa59d1262",
       "path": "skills/enforce-firstSKILL.md"
     },
     "evolve-skill": {
@@ -138,12 +138,12 @@
     },
     "fix-bug": {
       "description": "Bug fix orchestrator — active_flow fix_bug; reads specs/bugs/BUG-*.md; chains investigate-bug, develop-tdd, validate-fix. Use when user reports a defect.",
-      "sha256": "8e9e5922211b7e3b",
+      "sha256": "575a3ce60745c5c3",
       "path": "skills/fix-bugSKILL.md"
     },
     "gate-trace": {
       "description": "\"Deterministic traceability quality gate — reads coverage matrix + blind-spot data, applies decision rules with oracle confidence downgrade, emits PASS/CONCERNS/FAIL/WAIVED verdict. Use before release-branch to gate merges on traceability.\"",
-      "sha256": "87e0c49ff90ec34c",
+      "sha256": "097c31ec960861ce",
       "path": "skills/gate-traceSKILL.md"
     },
     "generate-allure-report": {
@@ -238,7 +238,7 @@
     },
     "plan-work": {
       "description": "\"PLANNING SPINE STEP 3 of 3 — Plan the work: write detailed implementation tasks into the active epic capsule (specs/epics/eNN-slug/). Produces countable-story-format .md specs and runnable -tasks.yaml files. Use after slice-tasks (step 2). Not a substitute for scope-work (step 1) or slice-tasks (step 2).\"",
-      "sha256": "32c2bcaf16cb4ad2",
+      "sha256": "0558f03399e6b93f",
       "path": "skills/plan-workSKILL.md"
     },
     "publish-package": {
@@ -248,7 +248,7 @@
     },
     "quick-fix": {
       "description": "\"Streamlined fast-path for trivial data-only fixes — no TDD, no branching ceremony. Collapses 6 skills into 2 for changes that are purely data with no logic risk. Aborts with fallback to investigate-bug if guardrails trigger.\"",
-      "sha256": "6a1b70cb1530c428",
+      "sha256": "5631a3980b214748",
       "path": "skills/quick-fixSKILL.md"
     },
     "release-branch": {
@@ -258,7 +258,7 @@
     },
     "request-review": {
       "description": "Dispatch a fresh reviewer agent with a clean context to critique the code after audit-code passes. The reviewer has no shared state with the coding agent and gives a genuine second opinion. Use after audit-code passes, before committing, or when user wants an independent code review.",
-      "sha256": "f362641a467c3000",
+      "sha256": "f395a14585b78aaf",
       "path": "skills/request-reviewSKILL.md"
     },
     "research-first": {
@@ -283,7 +283,7 @@
     },
     "run-evals": {
       "description": "Eval-Driven Development — define capability and regression evals before building; code graders use verify commands, model graders use explicit rubrics; log pass@k. Use before develop-tdd on new features, or when measuring agent capability over runs.",
-      "sha256": "d20ba2bece1b1c72",
+      "sha256": "7bc7cfd24a41d9e3",
       "path": "skills/run-evalsSKILL.md"
     },
     "run-planning": {
@@ -338,7 +338,7 @@
     },
     "smoke-test": {
       "description": "\"Post-deploy health-check against a live URL. Validates HTTP status, response content, and critical endpoints. Runnable standalone OR as the final step of the deploy skill.\"",
-      "sha256": "050170d66ada581e",
+      "sha256": "407669c94dee6b53",
       "path": "skills/smoke-testSKILL.md"
     },
     "spike-prototype": {
@@ -373,12 +373,12 @@
     },
     "validate-contracts": {
       "description": "\"Assert data shape consistency across system boundaries — live API responses against JSON Schema, key-set comparison across layers, data shape validation for migrations and exports. Catches silent data corruption before deploy.\"",
-      "sha256": "d93c9ae2953ac457",
+      "sha256": "6541a7f72b3f0493",
       "path": "skills/validate-contractsSKILL.md"
     },
     "validate-fix": {
       "description": "Prove a fix works before declaring done — re-run the failing test, run the full suite, typecheck, lint, and harden against recurrence. Use after implementing a bug fix, when user says \"is this fixed?\", or before closing an investigation.",
-      "sha256": "f94972af3fd48e3e",
+      "sha256": "d7fac868ccbf5dbe",
       "path": "skills/validate-fixSKILL.md"
     },
     "verify-work": {

--- a/skills/audit-code/SKILL.md
+++ b/skills/audit-code/SKILL.md
@@ -1,7 +1,7 @@
+---
 # story: e51s04
 # story: e45s18
 # story: e45s31
----
 name: audit-code
 model: haiku
 effort: standard

--- a/skills/craft-skill/SKILL.md
+++ b/skills/craft-skill/SKILL.md
@@ -1,7 +1,7 @@
-# story: e45s02
-<!-- story: e45s12 -->
-<!-- story: e79s02 -->
 ---
+# story: e45s02
+# story: e45s12
+# story: e79s02
 name: craft-skill
 model: sonnet
 effort: standard

--- a/skills/deepen-architecture/SKILL.md
+++ b/skills/deepen-architecture/SKILL.md
@@ -1,6 +1,6 @@
-# story: e45s31
-<!-- story: e45s14 -->
 ---
+# story: e45s31
+# story: e45s14
 name: deepen-architecture
 model: sonnet
 effort: standard

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -1,5 +1,5 @@
-<!-- story: e45s15 -->
 ---
+# story: e45s15
 name: deploy
 description: "Build → verify artifact → deploy → wait → smoke deployment pipeline. Platform-agnostic (MCP or CLI), with configurable timeout, retry with exponential backoff, and integrated health-check. The deploy half of CI/CD: run after build to push to production."
 model: sonnet

--- a/skills/develop-tdd/SKILL.md
+++ b/skills/develop-tdd/SKILL.md
@@ -1,10 +1,10 @@
+---
 # story: e80s01
 # story: e80s03
 # story: e51s04
 # story: e45s06
 # story: e45s08
 # story: e45s34
----
 name: develop-tdd
 model: sonnet
 effort: standard

--- a/skills/diagnose-stall/SKILL.md
+++ b/skills/diagnose-stall/SKILL.md
@@ -1,5 +1,5 @@
-# story: e45s38
 ---
+# story: e45s38
 name: diagnose-stall
 model: haiku
 effort: light

--- a/skills/enforce-first/SKILL.md
+++ b/skills/enforce-first/SKILL.md
@@ -1,5 +1,5 @@
-# story: e80s01
 ---
+# story: e80s01
 name: enforce-first
 model: haiku
 effort: standard

--- a/skills/fix-bug/SKILL.md
+++ b/skills/fix-bug/SKILL.md
@@ -1,5 +1,5 @@
-# story: e51s04
 ---
+# story: e51s04
 name: fix-bug
 model: sonnet
 effort: standard

--- a/skills/gate-trace/SKILL.md
+++ b/skills/gate-trace/SKILL.md
@@ -1,6 +1,6 @@
+---
 # story: e80s01
 # story: e45s05
----
 name: gate-trace
 description: "Deterministic traceability quality gate — reads coverage matrix + blind-spot data, applies decision rules with oracle confidence downgrade, emits PASS/CONCERNS/FAIL/WAIVED verdict. Use before release-branch to gate merges on traceability."
 # story: e38s06

--- a/skills/plan-work/SKILL.md
+++ b/skills/plan-work/SKILL.md
@@ -1,9 +1,9 @@
+---
 # story: e45s04
 # story: e45s06
 # story: e45s09
 # story: e45s33
 # story: e45s35
----
 name: plan-work
 model: opus
 effort: standard

--- a/skills/quick-fix/SKILL.md
+++ b/skills/quick-fix/SKILL.md
@@ -1,5 +1,5 @@
-# story: e51s04
 ---
+# story: e51s04
 name: quick-fix
 description: "Streamlined fast-path for trivial data-only fixes — no TDD, no branching ceremony. Collapses 6 skills into 2 for changes that are purely data with no logic risk. Aborts with fallback to investigate-bug if guardrails trigger."
 model: sonnet

--- a/skills/request-review/SKILL.md
+++ b/skills/request-review/SKILL.md
@@ -1,7 +1,7 @@
-# story: e45s07
-<!-- story: e45s07 -->
-<!-- story: e45s17 -->
 ---
+# story: e45s07
+# story: e45s07
+# story: e45s17
 name: request-review
 model: opus
 effort: standard

--- a/skills/run-evals/SKILL.md
+++ b/skills/run-evals/SKILL.md
@@ -1,5 +1,5 @@
-# story: e45s37
 ---
+# story: e45s37
 name: run-evals
 description: Eval-Driven Development — define capability and regression evals before building; code graders use verify commands, model graders use explicit rubrics; log pass@k. Use before develop-tdd on new features, or when measuring agent capability over runs.
 model: sonnet

--- a/skills/smoke-test/SKILL.md
+++ b/skills/smoke-test/SKILL.md
@@ -1,5 +1,5 @@
-# story: e80s02
 ---
+# story: e80s02
 name: smoke-test
 phase: verify
 description: "Post-deploy health-check against a live URL. Validates HTTP status, response content, and critical endpoints. Runnable standalone OR as the final step of the deploy skill."

--- a/skills/validate-contracts/SKILL.md
+++ b/skills/validate-contracts/SKILL.md
@@ -1,5 +1,5 @@
-# story: e80s02
 ---
+# story: e80s02
 name: validate-contracts
 phase: verify
 description: "Assert data shape consistency across system boundaries — live API responses against JSON Schema, key-set comparison across layers, data shape validation for migrations and exports. Catches silent data corruption before deploy."

--- a/skills/validate-fix/SKILL.md
+++ b/skills/validate-fix/SKILL.md
@@ -1,7 +1,7 @@
+---
 # story: e80s01
 # story: e80s04
 # story: e45s08
----
 name: validate-fix
 model: haiku
 effort: standard

--- a/specs/TRACEABILITY_LATEST.md
+++ b/specs/TRACEABILITY_LATEST.md
@@ -1,16 +1,16 @@
 # Traceability Matrix
 
-**Generated:** 2026-08-05 16:09:57 UTC
+**Generated:** 2026-08-06 15:57:11 UTC
 **Total stories:** 126
 **Tagged stories:** 116
 **Dark stories:** 0
 **Orphan tags:** 145
-**Stale tags:** 115
+**Stale tags:** 116
 
 ## Oracle Stats
 
-- **High** (explicit tag): 907
-- **Medium** (file heuristic): 3497
+- **High** (explicit tag): 908
+- **Medium** (file heuristic): 3525
 - **Low** (task reference): 79
 
 ## Story Coverage
@@ -41,16 +41,16 @@
 | e45s06 | tasks.yaml: literal failing→passing task ledger | e45 | 2 | 5.0 | done | 2 |
 | e45s07 | request-review: dual-blind AND-gate review (Santa Method) | e45 | 2 | 5.0 | done | 38 |
 | e45s08 | develop-tdd / validate-fix: two-commit red/green regression  | e45 | 2 | 5.0 | done | 14 |
-| e45s09 | verify-work / plan-work: Pre-Implementation and Validation g | e45 | 2 | 5.0 | done | 88 |
+| e45s09 | verify-work / plan-work: Pre-Implementation and Validation g | e45 | 2 | 5.0 | done | 89 |
 | e45s10 | docs/references: auto-regenerate from source-of-truth docs v | e45 | 2 | 5.0 | done | 7 |
 | e45s11 | orchestration / dispatch-agents: typed message protocol + 3- | e45 | 2 | 5.0 | done | 21 |
-| e45s12 | stocktake-skills / craft-skill: code-enforced validator + au | e45 | 2 | 5.0 | done | 46 |
+| e45s12 | stocktake-skills / craft-skill: code-enforced validator + au | e45 | 2 | 5.0 | done | 47 |
 | e45s13 | verify-work: one-test-minimum terminal-verdict rule | e45 | 2 | 5.0 | done | 29 |
 | e45s14 | deepen-architecture: declared import-boundary allowlist enfo | e45 | 2 | 5.0 | done | 8 |
 | e45s15 | release-branch / deploy: three-independent-facts verificatio | e45 | 2 | 5.0 | done | 25 |
 | e45s16 | CLAUDE.md rtk mandate: wire rtk-ai/rtk PreToolUse hook | e45 | 2 | 5.0 | done | 4 |
 | e45s17 | request-review: fan-out to parallel review subagents | e45 | 2 | 5.0 | done | 30 |
-| e45s18 | audit-code / security-review: worktree-isolated parallel che | e45 | 2 | 5.0 | done | 682 |
+| e45s18 | audit-code / security-review: worktree-isolated parallel che | e45 | 2 | 5.0 | done | 688 |
 | e45s19 | Context7: bounded retry cap and explicit fallback block | e45 | 2 | 5.0 | done | 8 |
 | e45s20 | Context7 / bts docs: wrap in ETag-revalidated fetch cache | e45 | 2 | 5.0 | done | 1 |
 | e45s21 | seed-conventions / AGENTS.md: self-installing fenced markers | e45 | 2 | 5.0 | done | 41 |
@@ -63,7 +63,7 @@
 | e45s28 | request-review: hard max-iteration cap | e45 | 2 | 5.0 | done | 22 |
 | e45s29 | requirements: ADDED/MODIFIED/REMOVED/RENAMED tags | e45 | 2 | 5.0 | done | 54 |
 | e45s30 | subagent depth: formalize depth tiers | e45 | 2 | 5.0 | done | 36 |
-| e45s31 | audit-code / deepen-architecture: churn-based look-here-firs | e45 | 2 | 5.0 | done | 668 |
+| e45s31 | audit-code / deepen-architecture: churn-based look-here-firs | e45 | 2 | 5.0 | done | 674 |
 | e45s32 | gate-trace / release-branch: adversarial-review refute frami | e45 | 2 | 5.0 | done | 41 |
 | e45s33 | requirements: per-section approval state | e45 | 2 | 5.0 | done | 3 |
 | e45s34 | develop-tdd: snapshot-before-transition hardening | e45 | 2 | 5.0 | done | 7 |
@@ -75,10 +75,10 @@
 | e45s40 | verify-work: mandatory real-browser verification | e45 | 2 | 5.0 | done | 27 |
 | e45s41 | security-review: proven authorship SQL-safety doctrine | e45 | 2 | 5.0 | done | 22 |
 | e48s01 | Generate epics-wiki and adr-wiki as OKF concept bundles from | e48 | 2 | 2.5 | done | 34 |
-| e48s02 | Emit verification reports as OKF bundles from run-golden-sui | e48 | 2 | 2.5 | done | 56 |
-| e48s03 | OKF-ify bug-registry: specs/bugs/registry.yaml emits concept | e48 | 1 | 2.5 | done | 157 |
+| e48s02 | Emit verification reports as OKF bundles from run-golden-sui | e48 | 2 | 2.5 | done | 58 |
+| e48s03 | OKF-ify bug-registry: specs/bugs/registry.yaml emits concept | e48 | 1 | 2.5 | done | 160 |
 | e48s04 | Create viz.html — interactive force-layout graph companion f | e48 | 2 | 2.5 | done | 12 |
-| e48s05 | Wire OKF validation into CI (sync-skills.yml) and document i | e48 | 1 | 2.5 | done | 204 |
+| e48s05 | Wire OKF validation into CI (sync-skills.yml) and document i | e48 | 1 | 2.5 | done | 207 |
 | e48s06 | Add tier: field (core/extended/specialized) to OKF wiki inde | e48 | 2 | 2.5 | done | 10 |
 | e48s07 | Create publish-to-wiki kernel tool | e48 | 3 | 2.5 | done | 2 |
 | e48s08 | Add GitHub Action Template for publish-wiki.yml [HARD GATE] | e48 | 1 | 2.5 | done | 8 |
@@ -92,7 +92,7 @@
 | e51s01 | CONVENTIONS — Always Green, Shift Left, Discovered Defects,  | e51 | 3 | 7.0 | done | 8 |
 | e51s02 | seed-conventions — Preflight default, solo-git default, embe | e51 | 3 | 7.0 | done | 48 |
 | e51s03 | kickoff-branch + verify-work — Preflight hard block and CI g | e51 | 2 | 7.0 | done | 74 |
-| e51s04 | audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log rou | e51 | 2 | 7.0 | done | 722 |
+| e51s04 | audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log rou | e51 | 2 | 7.0 | done | 728 |
 | e51s05 | CLAUDE.md — solo-default agent rules + bigpowers Preflight c | e51 | 2 | 7.0 | done | 7 |
 | e53s01 | Commit the untracked GOLDEN baseline | e53 | 1 | 8.0 | done | 12 |
 | e53s02 | Build the tombstone-alias mechanism | e53 | 3 | 8.0 | done | 7 |
@@ -142,7 +142,7 @@
 | e80s03 | develop-tdd RED commit isolation check | e80 | 0 | 7.5 | done | 10 |
 | e80s04 | generalize-fix phase in validate-fix | e80 | 0 | 7.5 | done | 32 |
 | e80s05 | security-review fixture table growth | e80 | 0 | 7.5 | done | 11 |
-| e81s01 | AGENTS.md template Token Economy section + reference doc | e81 | 0 | 4.5 | backlog | 8 |
+| e81s01 | AGENTS.md template Token Economy section + reference doc | e81 | 0 | 4.5 | done | 9 |
 
 ## Orphan Tags (tag in code, no matching story)
 
@@ -409,3 +409,4 @@
 - `e80s03`
 - `e80s04`
 - `e80s05`
+- `e81s01`

--- a/specs/benchmarks/reports/GOLDEN-2026-08-06.yaml
+++ b/specs/benchmarks/reports/GOLDEN-2026-08-06.yaml
@@ -1,0 +1,172 @@
+timestamp: "2026-08-06T15:53:16Z"
+git_commit: "7087aa5714476be9a6cffd369df541d99356f8d6"
+suite: "golden-combined"
+mode: "daily"
+deterministic:
+  total: 38
+  passed: 38
+  failed: 0
+  skipped: 0
+  pass_rate: 1.00
+gates:
+  - name: compliance
+    exit_code: 0
+    duration_seconds: 92.43
+    status: pass
+  - name: g04-selftest
+    exit_code: 0
+    duration_seconds: .04
+    status: pass
+  - name: g06-migrate-version
+    exit_code: 0
+    duration_seconds: 8.62
+    status: pass
+  - name: g07-negative-path
+    exit_code: 0
+    duration_seconds: .06
+    status: pass
+  - name: g08-anti-vacuity
+    exit_code: 0
+    duration_seconds: .12
+    status: pass
+  - name: g09-yaml-roundtrip
+    exit_code: 0
+    duration_seconds: .12
+    status: pass
+  - name: g10-trace-anti-vacuity
+    exit_code: 0
+    duration_seconds: .09
+    status: pass
+  - name: g11-gitignore-venv
+    exit_code: 0
+    duration_seconds: .08
+    status: pass
+  - name: g12-status-selftest
+    exit_code: 0
+    duration_seconds: .57
+    status: pass
+  - name: g12-status-consistency
+    exit_code: 0
+    duration_seconds: .21
+    status: pass
+  - name: g15-compliance-runner-selftest
+    exit_code: 0
+    duration_seconds: .04
+    status: pass
+  - name: g15-compliance-runner
+    exit_code: 0
+    duration_seconds: .10
+    status: pass
+  - name: g13-script-orphans-selftest
+    exit_code: 0
+    duration_seconds: 51.62
+    status: pass
+  - name: g13-script-orphans
+    exit_code: 0
+    duration_seconds: 50.50
+    status: pass
+  - name: workflow-diagrams-fresh
+    exit_code: 0
+    duration_seconds: .12
+    status: pass
+  - name: reference-nav-fresh
+    exit_code: 0
+    duration_seconds: .05
+    status: pass
+  - name: g14-adapter-dispatch-selftest
+    exit_code: 0
+    duration_seconds: .10
+    status: pass
+  - name: g14-adapter-dispatch
+    exit_code: 0
+    duration_seconds: .06
+    status: pass
+  - name: g16-spec-version-gap-selftest
+    exit_code: 0
+    duration_seconds: .21
+    status: pass
+  - name: g16-spec-version-gap
+    exit_code: 0
+    duration_seconds: .09
+    status: pass
+  - name: target-contracts
+    exit_code: 0
+    duration_seconds: .18
+    status: pass
+  - name: install-hub
+    exit_code: 0
+    duration_seconds: 7.24
+    status: pass
+  - name: adapter-render
+    exit_code: 0
+    duration_seconds: 3.22
+    status: pass
+  - name: adapters
+    exit_code: 0
+    duration_seconds: 2.38
+    status: pass
+  - name: tombstone-mechanism
+    exit_code: 0
+    duration_seconds: 1.71
+    status: pass
+  - name: trace-strict
+    exit_code: 0
+    duration_seconds: 14.38
+    status: pass
+  - name: trace-matrix-size
+    exit_code: 0
+    duration_seconds: .02
+    status: pass
+  - name: setup-no-pyyaml
+    exit_code: 0
+    duration_seconds: 2.09
+    status: pass
+  - name: install-distribute-only
+    exit_code: 0
+    duration_seconds: 44.48
+    status: pass
+  - name: completeness-critic-scope
+    exit_code: 0
+    duration_seconds: .17
+    status: pass
+  - name: epics-wiki-zero-stories
+    exit_code: 0
+    duration_seconds: 2.81
+    status: pass
+  - name: golden-g11-worktree-venv
+    exit_code: 0
+    duration_seconds: .11
+    status: pass
+  - name: install-helpers
+    exit_code: 0
+    duration_seconds: .05
+    status: pass
+  - name: import-boundaries
+    exit_code: 0
+    duration_seconds: .23
+    status: pass
+  - name: skill-catalog
+    exit_code: 0
+    duration_seconds: 1.66
+    status: pass
+  - name: specs-parse
+    exit_code: 0
+    duration_seconds: .82
+    status: pass
+  - name: story-verify-selftest
+    exit_code: 0
+    duration_seconds: .16
+    status: pass
+  - name: story-verify
+    exit_code: 0
+    duration_seconds: 218.17
+    status: pass
+agent_stories:
+  total: 0
+  passed: 0
+  failed: 0
+  skipped: 0
+  flake_count: 0
+  pass_rate: n/a
+summary:
+  combined_verdict: "pass"

--- a/specs/bugs/BUG-2026-08-06-pi-drops-skills-frontmatter.md
+++ b/specs/bugs/BUG-2026-08-06-pi-drops-skills-frontmatter.md
@@ -1,0 +1,79 @@
+---
+bug_id: BUG-2026-08-06-pi-drops-skills-frontmatter
+status: open
+severity: high
+scope: skills / install
+title: "pi drops 16 skills as 'description is required' — story tags before frontmatter delimiter break parsing"
+---
+
+# BUG-2026-08-06: pi drops 16 skills as "description is required"
+
+## Problem
+
+- **Actual**: pi (v0.82.0, reproducible on current source) reports `description is required` at startup for exactly 16 skills: audit-code, craft-skill, deepen-architecture, deploy, develop-tdd, diagnose-stall, enforce-first, fix-bug, gate-trace, plan-work, quick-fix, request-review, run-evals, smoke-test, validate-contracts, validate-fix. The skills are silently dropped from the `~/.pi/agent/skills/` source of truth (warnings only — no hard failure).
+- **Expected**: All 81 skill sources load with their descriptions; zero startup warnings.
+- **Reproduce**: Start pi in a bigpowers checkout, or point pi at a fresh `bash scripts/install.sh` (pi target symlinks `~/.pi/agent/skills/<name>` → `skills/<name>` source). The startup banner lists the 16 files under `description is required`. Reporter's original report: https://github.com/danielvm-git/bigpowers/issues/108.
+
+**Security impact: NONE** — no exploit path identified; the defect only drops skill metadata from an agent's prompt context.
+
+## Root Cause Analysis
+
+### Reproduce
+
+Start pi in the bigpowers repo → banner shows `description is required` for the 16 files above. Programmatic reproduction (mirror of pi's parser): for each `skills/*/SKILL.md`, if the file does not start with the two characters `---`, pi returns an empty frontmatter object and rejects the skill. 16 of 81 sources fail this check; the other 65 pass.
+
+### Isolate
+
+Pi's frontmatter extractor has a strict gate: the opening delimiter `---` must be the **first characters of the file** (`startsWith("---")`); otherwise no frontmatter is returned at all. Source skills carry `# story: eNNsYY` / `<!-- story: ... -->` traceability tags on the lines *above* the opening `---`, which trips the gate. Every failing skill shares exactly this shape; no other frontmatter field is involved.
+
+### Hypothesize
+
+Confirmed by reading pi's source (`src/utils/frontmatter.ts` in the opensrc-fetched 0.84.0 tree; identical logic in the installed v0.82.0 `dist/utils/frontmatter.js`): comment lines before `---` ⇒ `yamlString: null` ⇒ `frontmatter: {}` ⇒ `description` undefined ⇒ "description is required" ⇒ skill rejected. The Agent Skills spec also mandates frontmatter at the first line, so pi's behavior is correct — the defect is in the skill sources.
+
+Contributing factors:
+
+1. **Inconsistent tag placement convention**: 65 sources place story tags after the frontmatter (or omit them); the 16 affected place them before it. No rule in CONVENTIONS.md pins tag position (traceability only requires ≥1 `story: eNNsNN` tag per story anywhere in a file).
+2. **Validation gap**: `scripts/validate-skill-yaml.py` validates only the generated `.pi/skills/` copies, never the `skills/*/SKILL.md` sources, and never checks the "starts with `---`" rule. The generator (`srp-engine.py`) strips the leading comment lines when rendering `.pi/skills/`, so repo-local pi sessions load the clean generated copies and the defect is masked — but every external install (npm `setup` → symlinks to source) hits it.
+3. **Stray artifact**: a malformed `SKILL.md` (empty `name:` and `description: ""`) sits at the root of `.agents/skills/`, producing an extra `description is required` warning.
+
+**Risk level**: High — on machines with only the npm install (no repo checkout) the 16 skills do not load at all; everywhere else it is warning noise plus duplicate skill entries across sources.
+
+## TDD Fix Plan
+
+### Preparation
+
+1. **RED**: Extend `scripts/validate-skill-yaml.py` to also scan source `skills/*/SKILL.md`, asserting (a) each file starts with `---` at byte 0 and (b) frontmatter parses. Currently 16 failures.
+   **GREEN**: Add the source-scan path with the `startsWith("---")` assertion; report 16 failures, exit 1.
+   **verify**: `python3 scripts/validate-skill-yaml.py` → 16 failures; `bash scripts/sync-skills.sh` guard fails on the new gate.
+
+### Fix — normalize tag placement (16 files)
+
+2. **RED**: All 16 source files fail the "starts with `---`" assertion.
+   **GREEN**: For each of the 16, move the leading `# story:` / `<!-- story: -->` lines **inside the frontmatter block** immediately after the opening `---`, converted to `# story:` YAML comments (YAML comments are ignored by pi's parser, PyYAML, and the bundled fallback `simple_yaml.py`). The generator re-renders frontmatter from extracted fields, so generated artifacts (`./.pi/skills/`, `.cursor/rules/`, `.gemini/`) stay byte-identical — no golden drift. `trace-stories.sh` greps the whole tree, so traceability is unaffected.
+   **verify**: `python3 scripts/validate-skill-yaml.py` → 0 failures, exit 0; `bash scripts/sync-skills.sh` guard passes; generated `.pi/skills/` diffs empty.
+
+3. **RED**: Remove the stray root `.agents/skills/SKILL.md` (empty name/description template) — or the gate must flag it.
+   **GREEN**: Delete the stray file; keep the source scan rule that flags empty `description` (already enforced for generated copies).
+   **verify**: `python3 scripts/validate-skill-yaml.py` → no `.agents` diagnostics.
+
+### Hardening
+
+4. **RED**: The new source-frontmatter gate must survive future edits.
+   **GREEN**: Wire the extended validator into the `sync-skills.sh` post-generation guard and the verification gates (`bash scripts/run-verification-gates.sh`), so any future SKILL.md with tags above `---` fails CI with a message pointing at the delimiter rule.
+   **verify**: `npm run compliance && bash scripts/run-verification-gates.sh` green; introduce a synthetic tag-above-`---` file → gate fails.
+
+**REFACTOR**: Optionally add a one-line note to CONVENTIONS.md (§ skills) that story tags must live inside the frontmatter block or below it — never above the opening `---`.
+
+## Acceptance Criteria
+
+- [ ] All 81 source `skills/*/SKILL.md` files start with `---` at byte 0
+- [ ] `validate-skill-yaml.py` scans sources and generated copies; 0 failures
+- [ ] pi startup shows zero `description is required` warnings for the 16 skills
+- [ ] Generated artifacts unchanged (no `.pi/skills/` / `.cursor/` / `.gemini/` churn)
+- [ ] `trace-stories.sh --strict` still passes (tag position independence)
+- [ ] Stray `.agents/skills/SKILL.md` removed or valid
+- [ ] Regression gate wired into sync-skills.sh + verification gates
+
+## Resolution
+
+<!-- filled in by validate-fix -->

--- a/specs/bugs/registry.yaml
+++ b/specs/bugs/registry.yaml
@@ -470,3 +470,9 @@ bugs:
     scope: validate-agentic-ste
     title: "validate-agentic-ste.sh counts markdown bold (**) as every file in cwd — false FAIL on valid prose"
     file: bugs/BUG-2026-08-05-ste-glob-wordcount.md
+  - id: BUG-2026-08-06-pi-drops-skills-frontmatter
+    status: open
+    severity: high
+    scope: skills / install
+    title: "pi drops 16 skills as 'description is required' — story tags before frontmatter delimiter break parsing"
+    file: bugs/BUG-2026-08-06-pi-drops-skills-frontmatter.md

--- a/specs/codebase-wiki/e45s02.md
+++ b/specs/codebase-wiki/e45s02.md
@@ -37,7 +37,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/craft-skill/SKILL.md
-    line: 1
+    line: 2
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/craft-skill.md
@@ -97,7 +97,7 @@ links:
 - `scripts/lib/audit-compliance-runner.sh` (line 2, confidence: high, method: explicit_tag)
 - `scripts/lib/audit-compliance-report.sh` (line 2, confidence: high, method: explicit_tag)
 - `scripts/validate-skill-description.sh` (line 2, confidence: high, method: explicit_tag)
-- `skills/craft-skill/SKILL.md` (line 1, confidence: high, method: explicit_tag)
+- `skills/craft-skill/SKILL.md` (line 2, confidence: high, method: explicit_tag)
 - `.windsurf/rules/craft-skill.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/craft-skill.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/then-skills-should-include-bold-hard-gate-callout-blocks.sh` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s04.md
+++ b/specs/codebase-wiki/e45s04.md
@@ -17,7 +17,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/plan-work/SKILL.md
-    line: 1
+    line: 2
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/slice-tasks.md
@@ -88,7 +88,7 @@ links:
 
 - `scripts/generate-viz-graph.sh` (line 2, confidence: high, method: explicit_tag)
 - `scripts/lib/plan-consistency-check.sh` (line 2, confidence: high, method: explicit_tag)
-- `skills/plan-work/SKILL.md` (line 1, confidence: high, method: explicit_tag)
+- `skills/plan-work/SKILL.md` (line 2, confidence: high, method: explicit_tag)
 - `.windsurf/rules/slice-tasks.md` (line 0, confidence: medium, method: file_heuristic)
 - `.windsurf/rules/plan-work.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/slice-tasks.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s05.md
+++ b/specs/codebase-wiki/e45s05.md
@@ -61,7 +61,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/gate-trace/SKILL.md
-    line: 2
+    line: 3
     confidence: high
     method: explicit_tag
   - file: .codebuddy/skills/verify-work/SKILL.md
@@ -211,7 +211,7 @@ links:
 - `scripts/lib/completeness-critic.sh` (line 2, confidence: high, method: explicit_tag)
 - `.cline/skills/verify-work/SKILL.md` (line 9, confidence: high, method: explicit_tag)
 - `skills/verify-work/SKILL.md` (line 10, confidence: high, method: explicit_tag)
-- `skills/gate-trace/SKILL.md` (line 2, confidence: high, method: explicit_tag)
+- `skills/gate-trace/SKILL.md` (line 3, confidence: high, method: explicit_tag)
 - `.codebuddy/skills/verify-work/SKILL.md` (line 9, confidence: high, method: explicit_tag)
 - `.zcode/skills/verify-work/SKILL.md` (line 9, confidence: high, method: explicit_tag)
 - `.mimocode/skills/verify-work/SKILL.md` (line 9, confidence: high, method: explicit_tag)

--- a/specs/codebase-wiki/e45s06.md
+++ b/specs/codebase-wiki/e45s06.md
@@ -9,11 +9,11 @@ coverage_status: covered
 confidence: high
 links:
   - file: skills/plan-work/SKILL.md
-    line: 2
+    line: 3
     confidence: high
     method: explicit_tag
   - file: skills/develop-tdd/SKILL.md
-    line: 4
+    line: 5
     confidence: high
     method: explicit_tag
 ---
@@ -26,5 +26,5 @@ links:
 
 ## Implemented In
 
-- `skills/plan-work/SKILL.md` (line 2, confidence: high, method: explicit_tag)
-- `skills/develop-tdd/SKILL.md` (line 4, confidence: high, method: explicit_tag)
+- `skills/plan-work/SKILL.md` (line 3, confidence: high, method: explicit_tag)
+- `skills/develop-tdd/SKILL.md` (line 5, confidence: high, method: explicit_tag)

--- a/specs/codebase-wiki/e45s07.md
+++ b/specs/codebase-wiki/e45s07.md
@@ -9,11 +9,11 @@ coverage_status: covered
 confidence: high
 links:
   - file: skills/request-review/SKILL.md
-    line: 1
+    line: 2
     confidence: high
     method: explicit_tag
   - file: skills/request-review/SKILL.md
-    line: 2
+    line: 3
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/security-review.md
@@ -170,8 +170,8 @@ links:
 
 ## Implemented In
 
-- `skills/request-review/SKILL.md` (line 1, confidence: high, method: explicit_tag)
 - `skills/request-review/SKILL.md` (line 2, confidence: high, method: explicit_tag)
+- `skills/request-review/SKILL.md` (line 3, confidence: high, method: explicit_tag)
 - `.windsurf/rules/security-review.md` (line 0, confidence: medium, method: file_heuristic)
 - `.windsurf/rules/request-review.md` (line 0, confidence: medium, method: file_heuristic)
 - `.windsurf/rules/respond-review.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s08.md
+++ b/specs/codebase-wiki/e45s08.md
@@ -9,11 +9,11 @@ coverage_status: covered
 confidence: high
 links:
   - file: skills/validate-fix/SKILL.md
-    line: 3
+    line: 4
     confidence: high
     method: explicit_tag
   - file: skills/develop-tdd/SKILL.md
-    line: 5
+    line: 6
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/develop-tdd.md
@@ -74,8 +74,8 @@ links:
 
 ## Implemented In
 
-- `skills/validate-fix/SKILL.md` (line 3, confidence: high, method: explicit_tag)
-- `skills/develop-tdd/SKILL.md` (line 5, confidence: high, method: explicit_tag)
+- `skills/validate-fix/SKILL.md` (line 4, confidence: high, method: explicit_tag)
+- `skills/develop-tdd/SKILL.md` (line 6, confidence: high, method: explicit_tag)
 - `.windsurf/rules/develop-tdd.md` (line 0, confidence: medium, method: file_heuristic)
 - `.windsurf/rules/validate-fix.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/develop-tdd.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s09.md
+++ b/specs/codebase-wiki/e45s09.md
@@ -53,7 +53,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/plan-work/SKILL.md
-    line: 3
+    line: 4
     confidence: high
     method: explicit_tag
   - file: skills/verify-work/SKILL.md
@@ -84,6 +84,10 @@ links:
     line: 10
     confidence: high
     method: explicit_tag
+  - file: GSD_WORKFLOW_ANALYSIS_VS_BIGPOWERS.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: .windsurf/rules/scope-work.md
     line: 0
     confidence: medium
@@ -381,7 +385,7 @@ links:
 - `.kilocode/rules/verify-work.md` (line 10, confidence: high, method: explicit_tag)
 - `.codex/skills/verify-work/SKILL.md` (line 10, confidence: high, method: explicit_tag)
 - `.cline/skills/verify-work/SKILL.md` (line 10, confidence: high, method: explicit_tag)
-- `skills/plan-work/SKILL.md` (line 3, confidence: high, method: explicit_tag)
+- `skills/plan-work/SKILL.md` (line 4, confidence: high, method: explicit_tag)
 - `skills/verify-work/SKILL.md` (line 11, confidence: high, method: explicit_tag)
 - `.codebuddy/skills/verify-work/SKILL.md` (line 10, confidence: high, method: explicit_tag)
 - `.zcode/skills/verify-work/SKILL.md` (line 10, confidence: high, method: explicit_tag)
@@ -389,6 +393,7 @@ links:
 - `.hermes/skills/verify-work/SKILL.md` (line 10, confidence: high, method: explicit_tag)
 - `.pi/prompts/verify-work.md` (line 9, confidence: high, method: explicit_tag)
 - `.pi/skills/verify-work/SKILL.md` (line 10, confidence: high, method: explicit_tag)
+- `GSD_WORKFLOW_ANALYSIS_VS_BIGPOWERS.md` (line 0, confidence: medium, method: file_heuristic)
 - `.windsurf/rules/scope-work.md` (line 0, confidence: medium, method: file_heuristic)
 - `.windsurf/rules/plan-work.md` (line 0, confidence: medium, method: file_heuristic)
 - `.windsurf/rules/compose-workflow.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s12.md
+++ b/specs/codebase-wiki/e45s12.md
@@ -57,7 +57,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/craft-skill/SKILL.md
-    line: 2
+    line: 3
     confidence: high
     method: explicit_tag
   - file: skills/stocktake-skills/SKILL.md
@@ -121,6 +121,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/bugs/BUG-2026-07-06-craft-skill-sync-oversized.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/bugs/BUG-2026-08-06-pi-drops-skills-frontmatter.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -214,7 +218,7 @@ links:
 - `.codex/skills/stocktake-skills/SKILL.md` (line 8, confidence: high, method: explicit_tag)
 - `scripts/validate-skill-catalog.sh` (line 2, confidence: high, method: explicit_tag)
 - `.cline/skills/stocktake-skills/SKILL.md` (line 8, confidence: high, method: explicit_tag)
-- `skills/craft-skill/SKILL.md` (line 2, confidence: high, method: explicit_tag)
+- `skills/craft-skill/SKILL.md` (line 3, confidence: high, method: explicit_tag)
 - `skills/stocktake-skills/SKILL.md` (line 11, confidence: high, method: explicit_tag)
 - `.codebuddy/skills/stocktake-skills/SKILL.md` (line 8, confidence: high, method: explicit_tag)
 - `.zcode/skills/stocktake-skills/SKILL.md` (line 8, confidence: high, method: explicit_tag)
@@ -231,6 +235,7 @@ links:
 - `specs/skills-wiki/skills/craft-skill.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/steps/then-skills-should-include-bold-hard-gate-callout-blocks.sh` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-craft-skill-sync-oversized.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/bugs/BUG-2026-08-06-pi-drops-skills-frontmatter.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-craft-skill-sync-oversized.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/e79-agentic-ste/e79s02-validator-craft-skill.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/archive/e37-reach/e37s10-wave-b-skills-dir.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s14.md
+++ b/specs/codebase-wiki/e45s14.md
@@ -13,7 +13,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/deepen-architecture/SKILL.md
-    line: 2
+    line: 3
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/deepen-architecture.md
@@ -51,7 +51,7 @@ links:
 ## Implemented In
 
 - `scripts/check-import-boundaries.sh` (line 2, confidence: high, method: explicit_tag)
-- `skills/deepen-architecture/SKILL.md` (line 2, confidence: high, method: explicit_tag)
+- `skills/deepen-architecture/SKILL.md` (line 3, confidence: high, method: explicit_tag)
 - `.windsurf/rules/deepen-architecture.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/DEEPEN-ARCHITECTURE-REVIEW.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/deepen-architecture.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s15.md
+++ b/specs/codebase-wiki/e45s15.md
@@ -53,7 +53,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/deploy/SKILL.md
-    line: 1
+    line: 2
     confidence: high
     method: explicit_tag
   - file: skills/release-branch/SKILL.md
@@ -129,7 +129,7 @@ links:
 - `.kilocode/rules/release-branch.md` (line 8, confidence: high, method: explicit_tag)
 - `.codex/skills/release-branch/SKILL.md` (line 8, confidence: high, method: explicit_tag)
 - `.cline/skills/release-branch/SKILL.md` (line 8, confidence: high, method: explicit_tag)
-- `skills/deploy/SKILL.md` (line 1, confidence: high, method: explicit_tag)
+- `skills/deploy/SKILL.md` (line 2, confidence: high, method: explicit_tag)
 - `skills/release-branch/SKILL.md` (line 10, confidence: high, method: explicit_tag)
 - `.codebuddy/skills/release-branch/SKILL.md` (line 8, confidence: high, method: explicit_tag)
 - `.zcode/skills/release-branch/SKILL.md` (line 8, confidence: high, method: explicit_tag)

--- a/specs/codebase-wiki/e45s17.md
+++ b/specs/codebase-wiki/e45s17.md
@@ -9,7 +9,7 @@ coverage_status: covered
 confidence: high
 links:
   - file: skills/request-review/SKILL.md
-    line: 3
+    line: 4
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/security-review.md
@@ -138,7 +138,7 @@ links:
 
 ## Implemented In
 
-- `skills/request-review/SKILL.md` (line 3, confidence: high, method: explicit_tag)
+- `skills/request-review/SKILL.md` (line 4, confidence: high, method: explicit_tag)
 - `.windsurf/rules/security-review.md` (line 0, confidence: medium, method: file_heuristic)
 - `.windsurf/rules/request-review.md` (line 0, confidence: medium, method: file_heuristic)
 - `.windsurf/rules/respond-review.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s18.md
+++ b/specs/codebase-wiki/e45s18.md
@@ -61,7 +61,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/audit-code/SKILL.md
-    line: 2
+    line: 3
     confidence: high
     method: explicit_tag
   - file: .codebuddy/skills/security-review/SKILL.md
@@ -269,6 +269,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260726-082552.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-124253.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -620,6 +624,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-125318.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260727-131841.md
     line: 0
     confidence: medium
@@ -937,6 +945,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260728-113556.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-123246.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1732,6 +1744,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-122059.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-200055.md
     line: 0
     confidence: medium
@@ -1857,6 +1873,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-223359.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-122400.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2324,6 +2344,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-122231.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260706-132858.md
     line: 0
     confidence: medium
@@ -2759,7 +2783,7 @@ links:
 - `scripts/lib/parallel-review-worktrees.sh` (line 2, confidence: high, method: explicit_tag)
 - `.cline/skills/security-review/SKILL.md` (line 8, confidence: high, method: explicit_tag)
 - `skills/security-review/SKILL.md` (line 14, confidence: high, method: explicit_tag)
-- `skills/audit-code/SKILL.md` (line 2, confidence: high, method: explicit_tag)
+- `skills/audit-code/SKILL.md` (line 3, confidence: high, method: explicit_tag)
 - `.codebuddy/skills/security-review/SKILL.md` (line 8, confidence: high, method: explicit_tag)
 - `.zcode/skills/security-review/SKILL.md` (line 8, confidence: high, method: explicit_tag)
 - `.mimocode/skills/security-review/SKILL.md` (line 8, confidence: high, method: explicit_tag)
@@ -2812,6 +2836,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260703-162136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234209.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260726-082552.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-124253.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132717.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260723-160627.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2899,6 +2924,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260724-093242.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-213042.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260707-134029.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-125318.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260727-131841.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260707-164826.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260723-162400.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2979,6 +3005,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260707-124641.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260725-201905.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260728-113556.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-123246.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260726-184010.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-083430.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080042.md` (line 0, confidence: medium, method: file_heuristic)
@@ -3177,6 +3204,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260704-161735.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005423.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130845.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-122059.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200055.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-173837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170738.md` (line 0, confidence: medium, method: file_heuristic)
@@ -3209,6 +3237,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260706-220404.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-085740.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223359.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-122400.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-193756.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260723-163218.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260723-163309.md` (line 0, confidence: medium, method: file_heuristic)
@@ -3325,6 +3354,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260703-173033.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164050.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260726-190959.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-122231.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-132858.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-174710.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165902.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s31.md
+++ b/specs/codebase-wiki/e45s31.md
@@ -13,11 +13,11 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/deepen-architecture/SKILL.md
-    line: 1
+    line: 2
     confidence: high
     method: explicit_tag
   - file: skills/audit-code/SKILL.md
-    line: 3
+    line: 4
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/audit-code.md
@@ -221,6 +221,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260726-082552.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-124253.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -572,6 +576,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-125318.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260727-131841.md
     line: 0
     confidence: medium
@@ -889,6 +897,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260728-113556.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-123246.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1684,6 +1696,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-122059.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-200055.md
     line: 0
     confidence: medium
@@ -1809,6 +1825,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-223359.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-122400.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2276,6 +2296,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-122231.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260706-132858.md
     line: 0
     confidence: medium
@@ -2691,8 +2715,8 @@ links:
 ## Implemented In
 
 - `scripts/bp-churn-rank.sh` (line 2, confidence: high, method: explicit_tag)
-- `skills/deepen-architecture/SKILL.md` (line 1, confidence: high, method: explicit_tag)
-- `skills/audit-code/SKILL.md` (line 3, confidence: high, method: explicit_tag)
+- `skills/deepen-architecture/SKILL.md` (line 2, confidence: high, method: explicit_tag)
+- `skills/audit-code/SKILL.md` (line 4, confidence: high, method: explicit_tag)
 - `.windsurf/rules/audit-code.md` (line 0, confidence: medium, method: file_heuristic)
 - `.windsurf/rules/deepen-architecture.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/DEEPEN-ARCHITECTURE-REVIEW.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2744,6 +2768,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260703-162136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234209.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260726-082552.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-124253.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132717.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260723-160627.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2831,6 +2856,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260724-093242.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-213042.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260707-134029.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-125318.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260727-131841.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260707-164826.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260723-162400.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2911,6 +2937,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260707-124641.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260725-201905.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260728-113556.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-123246.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260726-184010.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-083430.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080042.md` (line 0, confidence: medium, method: file_heuristic)
@@ -3109,6 +3136,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260704-161735.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005423.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130845.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-122059.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200055.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-173837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170738.md` (line 0, confidence: medium, method: file_heuristic)
@@ -3141,6 +3169,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260706-220404.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-085740.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223359.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-122400.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-193756.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260723-163218.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260723-163309.md` (line 0, confidence: medium, method: file_heuristic)
@@ -3257,6 +3286,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260703-173033.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164050.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260726-190959.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-122231.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-132858.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-174710.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165902.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s33.md
+++ b/specs/codebase-wiki/e45s33.md
@@ -17,7 +17,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/plan-work/SKILL.md
-    line: 4
+    line: 5
     confidence: high
     method: explicit_tag
 ---
@@ -32,4 +32,4 @@ links:
 
 - `website/src/content/docs/guides/countable-story-format.md` (line 6, confidence: high, method: explicit_tag)
 - `docs/countable-story-format.md` (line 3, confidence: high, method: explicit_tag)
-- `skills/plan-work/SKILL.md` (line 4, confidence: high, method: explicit_tag)
+- `skills/plan-work/SKILL.md` (line 5, confidence: high, method: explicit_tag)

--- a/specs/codebase-wiki/e45s34.md
+++ b/specs/codebase-wiki/e45s34.md
@@ -9,7 +9,7 @@ coverage_status: covered
 confidence: high
 links:
   - file: skills/develop-tdd/SKILL.md
-    line: 6
+    line: 7
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/develop-tdd.md
@@ -46,7 +46,7 @@ links:
 
 ## Implemented In
 
-- `skills/develop-tdd/SKILL.md` (line 6, confidence: high, method: explicit_tag)
+- `skills/develop-tdd/SKILL.md` (line 7, confidence: high, method: explicit_tag)
 - `.windsurf/rules/develop-tdd.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/develop-tdd.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/benchmarks/develop-tdd.yaml` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s35.md
+++ b/specs/codebase-wiki/e45s35.md
@@ -9,7 +9,7 @@ coverage_status: covered
 confidence: high
 links:
   - file: skills/plan-work/SKILL.md
-    line: 5
+    line: 6
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/plan-work.md
@@ -46,7 +46,7 @@ links:
 
 ## Implemented In
 
-- `skills/plan-work/SKILL.md` (line 5, confidence: high, method: explicit_tag)
+- `skills/plan-work/SKILL.md` (line 6, confidence: high, method: explicit_tag)
 - `.windsurf/rules/plan-work.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/plan-work.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/archive/e26-security-review/e26s03-plan-work-release.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s37.md
+++ b/specs/codebase-wiki/e45s37.md
@@ -9,7 +9,7 @@ coverage_status: covered
 confidence: high
 links:
   - file: skills/run-evals/SKILL.md
-    line: 1
+    line: 2
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/run-evals.md
@@ -50,7 +50,7 @@ links:
 
 ## Implemented In
 
-- `skills/run-evals/SKILL.md` (line 1, confidence: high, method: explicit_tag)
+- `skills/run-evals/SKILL.md` (line 2, confidence: high, method: explicit_tag)
 - `.windsurf/rules/run-evals.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/run-evals.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-run-evals-golden-suite-oversized.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e45s38.md
+++ b/specs/codebase-wiki/e45s38.md
@@ -53,7 +53,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/diagnose-stall/SKILL.md
-    line: 1
+    line: 2
     confidence: high
     method: explicit_tag
   - file: skills/dispatch-agents/SKILL.md
@@ -113,7 +113,7 @@ links:
 - `.kilocode/rules/dispatch-agents.md` (line 8, confidence: high, method: explicit_tag)
 - `.codex/skills/dispatch-agents/SKILL.md` (line 8, confidence: high, method: explicit_tag)
 - `.cline/skills/dispatch-agents/SKILL.md` (line 8, confidence: high, method: explicit_tag)
-- `skills/diagnose-stall/SKILL.md` (line 1, confidence: high, method: explicit_tag)
+- `skills/diagnose-stall/SKILL.md` (line 2, confidence: high, method: explicit_tag)
 - `skills/dispatch-agents/SKILL.md` (line 9, confidence: high, method: explicit_tag)
 - `.codebuddy/skills/dispatch-agents/SKILL.md` (line 8, confidence: high, method: explicit_tag)
 - `.zcode/skills/dispatch-agents/SKILL.md` (line 8, confidence: high, method: explicit_tag)

--- a/specs/codebase-wiki/e48s02.md
+++ b/specs/codebase-wiki/e48s02.md
@@ -56,6 +56,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/GOLDEN-2026-08-06.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/GOLDEN-2026-07-07.okf.md
     line: 0
     confidence: medium
@@ -97,6 +101,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-2026-07-07.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/reports/audit-2026-08-06.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -254,6 +262,7 @@ links:
 - `specs/verifications/reports/GOLDEN-2026-07-05.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-06.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-30.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/GOLDEN-2026-08-06.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-07.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-08-05.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-23.okf.md` (line 0, confidence: medium, method: file_heuristic)
@@ -265,6 +274,7 @@ links:
 - `specs/verifications/reports/audit-2026-07-23.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-08-05.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-07.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-2026-08-06.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-21.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-06.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-18.okf.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e48s03.md
+++ b/specs/codebase-wiki/e48s03.md
@@ -164,6 +164,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/bugs/BUG-2026-08-06-pi-drops-skills-frontmatter.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/bugs/BUG-001.okf.md
     line: 0
     confidence: medium
@@ -237,6 +241,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/bugs/BUG-2026-07-02T103911.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/bugs/BUG-2026-08-05-cycle-time-toolchain.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -468,6 +476,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/bugs/BUG-2026-08-05-cycle-time-toolchain.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/bugs/BUG-2026-07-03-validate-specs-no-real-parser.md
     line: 0
     confidence: medium
@@ -685,6 +697,7 @@ links:
 - `specs/bugs/BUG-2026-07-03-version-mirror-drift.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-25-anti-vacuity-ci.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-plan-release-gap-logic-boolean.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/bugs/BUG-2026-08-06-pi-drops-skills-frontmatter.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-001.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-24-installer-spinner-freezes-during-sync.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-23-epics-wiki-empty-references.okf.md` (line 0, confidence: medium, method: file_heuristic)
@@ -704,6 +717,7 @@ links:
 - `specs/bugs/BUG-2026-07-06-migrate-spec-migration-logic-violations.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-26-null-skill-adapters-install-nothing.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-02T103911.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/bugs/BUG-2026-08-05-cycle-time-toolchain.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-03-install-docs-stale.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-04-tautological-verify.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-18-skill-index-phase-table-drift.okf.md` (line 0, confidence: medium, method: file_heuristic)
@@ -761,6 +775,7 @@ links:
 - `specs/bugs/BUG-2026-07-18-setup-pyyaml-missing.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-verify-work-runner-scripts-oversized.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-evolve-skill-sync-oversized.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/bugs/BUG-2026-08-05-cycle-time-toolchain.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-03-validate-specs-no-real-parser.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-03-codebase-wiki-venv-pollution.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-03-venv-not-gitignored.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e48s05.md
+++ b/specs/codebase-wiki/e48s05.md
@@ -68,6 +68,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/GOLDEN-2026-08-06.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/GOLDEN-2026-07-07.okf.md
     line: 0
     confidence: medium
@@ -109,6 +113,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-2026-07-07.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/reports/audit-2026-08-06.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -397,6 +405,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/bugs/BUG-2026-07-06-verify-work-runner-scripts-oversized.okf.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/bugs/BUG-2026-08-05-cycle-time-toolchain.okf.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -849,6 +861,7 @@ links:
 - `specs/verifications/reports/GOLDEN-2026-07-05.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-06.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-30.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/GOLDEN-2026-08-06.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-07.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-08-05.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-23.okf.md` (line 0, confidence: medium, method: file_heuristic)
@@ -860,6 +873,7 @@ links:
 - `specs/verifications/reports/audit-2026-07-23.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-08-05.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-07.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-2026-08-06.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-2026-07-21.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-06.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/GOLDEN-2026-07-18.okf.md` (line 0, confidence: medium, method: file_heuristic)
@@ -932,6 +946,7 @@ links:
 - `specs/bugs/BUG-2026-07-06T134600.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-18-setup-pyyaml-missing.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-verify-work-runner-scripts-oversized.okf.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/bugs/BUG-2026-08-05-cycle-time-toolchain.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-03-codebase-wiki-venv-pollution.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-06-audit-code-auditor-oversized.okf.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/bugs/BUG-2026-07-07-compliance-cross-module-sourcing.okf.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e51s04.md
+++ b/specs/codebase-wiki/e51s04.md
@@ -29,19 +29,19 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/fix-bug/SKILL.md
-    line: 1
+    line: 2
     confidence: high
     method: explicit_tag
   - file: skills/quick-fix/SKILL.md
-    line: 1
+    line: 2
     confidence: high
     method: explicit_tag
   - file: skills/develop-tdd/SKILL.md
-    line: 3
+    line: 4
     confidence: high
     method: explicit_tag
   - file: skills/audit-code/SKILL.md
-    line: 1
+    line: 2
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/develop-tdd.md
@@ -269,6 +269,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260726-082552.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-124253.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -620,6 +624,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-125318.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260727-131841.md
     line: 0
     confidence: medium
@@ -937,6 +945,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260728-113556.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-123246.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -1732,6 +1744,10 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-122059.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-200055.md
     line: 0
     confidence: medium
@@ -1857,6 +1873,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260702-223359.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-122400.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2321,6 +2341,10 @@ links:
     confidence: medium
     method: file_heuristic
   - file: specs/verifications/reports/audit-cleancode-20260726-190959.md
+    line: 0
+    confidence: medium
+    method: file_heuristic
+  - file: specs/verifications/reports/audit-cleancode-20260806-122231.md
     line: 0
     confidence: medium
     method: file_heuristic
@@ -2911,10 +2935,10 @@ links:
 - `specs/epics/archive/e51-always-green-shift-left/e51s04-tasks.yaml` (line 34, confidence: high, method: explicit_tag)
 - `scripts/golden-g12-status-consistency.sh` (line 2, confidence: high, method: explicit_tag)
 - `.github/workflows/golden-suite.yml` (line 1, confidence: high, method: explicit_tag)
-- `skills/fix-bug/SKILL.md` (line 1, confidence: high, method: explicit_tag)
-- `skills/quick-fix/SKILL.md` (line 1, confidence: high, method: explicit_tag)
-- `skills/develop-tdd/SKILL.md` (line 3, confidence: high, method: explicit_tag)
-- `skills/audit-code/SKILL.md` (line 1, confidence: high, method: explicit_tag)
+- `skills/fix-bug/SKILL.md` (line 2, confidence: high, method: explicit_tag)
+- `skills/quick-fix/SKILL.md` (line 2, confidence: high, method: explicit_tag)
+- `skills/develop-tdd/SKILL.md` (line 4, confidence: high, method: explicit_tag)
+- `skills/audit-code/SKILL.md` (line 2, confidence: high, method: explicit_tag)
 - `.windsurf/rules/develop-tdd.md` (line 0, confidence: medium, method: file_heuristic)
 - `.windsurf/rules/quick-fix.md` (line 0, confidence: medium, method: file_heuristic)
 - `.windsurf/rules/validate-fix.md` (line 0, confidence: medium, method: file_heuristic)
@@ -2972,6 +2996,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260703-162136.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-234209.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260726-082552.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-124253.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-172502.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260629-132717.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260723-160627.md` (line 0, confidence: medium, method: file_heuristic)
@@ -3059,6 +3084,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260724-093242.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-213042.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260707-134029.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-125318.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260727-131841.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260707-164826.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260723-162400.md` (line 0, confidence: medium, method: file_heuristic)
@@ -3139,6 +3165,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260707-124641.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260725-201905.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260728-113556.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-123246.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260726-184010.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-083430.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-080042.md` (line 0, confidence: medium, method: file_heuristic)
@@ -3337,6 +3364,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260704-161735.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-005423.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260703-130845.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-122059.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-200055.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-173837.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-170738.md` (line 0, confidence: medium, method: file_heuristic)
@@ -3369,6 +3397,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260706-220404.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260704-085740.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260702-223359.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-122400.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-193756.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260723-163218.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260723-163309.md` (line 0, confidence: medium, method: file_heuristic)
@@ -3485,6 +3514,7 @@ links:
 - `specs/verifications/reports/audit-cleancode-20260703-173033.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-164050.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260726-190959.md` (line 0, confidence: medium, method: file_heuristic)
+- `specs/verifications/reports/audit-cleancode-20260806-122231.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-132858.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260706-174710.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/reports/audit-cleancode-20260705-165902.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e53s02.md
+++ b/specs/codebase-wiki/e53s02.md
@@ -28,11 +28,11 @@ links:
     line: 0
     confidence: medium
     method: file_heuristic
-  - file: specs/epics/e81-agents-code-economy/e81s01-tasks.yaml
+  - file: specs/epics/archive/e53-establish-migration-baseline/e53s02-tasks.yaml
     line: 0
     confidence: low
     method: task_reference
-  - file: specs/epics/archive/e53-establish-migration-baseline/e53s02-tasks.yaml
+  - file: specs/epics/archive/e81-agents-code-economy/e81s01-tasks.yaml
     line: 0
     confidence: low
     method: task_reference
@@ -51,5 +51,5 @@ links:
 - `scripts/tombstone-skill.sh` (line 2, confidence: high, method: explicit_tag)
 - `specs/conventions-wiki/tombstone-aliases-e53s02.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/epics/archive/e53-establish-migration-baseline/e53s02-tombstone-alias-mechanism.md` (line 0, confidence: medium, method: file_heuristic)
-- `specs/epics/e81-agents-code-economy/e81s01-tasks.yaml` (line 0, confidence: low, method: task_reference)
 - `specs/epics/archive/e53-establish-migration-baseline/e53s02-tasks.yaml` (line 0, confidence: low, method: task_reference)
+- `specs/epics/archive/e81-agents-code-economy/e81s01-tasks.yaml` (line 0, confidence: low, method: task_reference)

--- a/specs/codebase-wiki/e79s02.md
+++ b/specs/codebase-wiki/e79s02.md
@@ -21,7 +21,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/craft-skill/SKILL.md
-    line: 3
+    line: 4
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/craft-skill.md
@@ -105,7 +105,7 @@ links:
 - `specs/epics/e79-agentic-ste/e79s02-tasks.yaml` (line 13, confidence: high, method: explicit_tag)
 - `specs/epics/e79-agentic-ste/epic.yaml` (line 42, confidence: high, method: explicit_tag)
 - `scripts/validate-agentic-ste.sh` (line 2, confidence: high, method: explicit_tag)
-- `skills/craft-skill/SKILL.md` (line 3, confidence: high, method: explicit_tag)
+- `skills/craft-skill/SKILL.md` (line 4, confidence: high, method: explicit_tag)
 - `.windsurf/rules/craft-skill.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/craft-skill.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/adr/0005-hard-gate-mandate.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e80s01.md
+++ b/specs/codebase-wiki/e80s01.md
@@ -33,19 +33,19 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/enforce-first/SKILL.md
-    line: 1
+    line: 2
     confidence: high
     method: explicit_tag
   - file: skills/validate-fix/SKILL.md
-    line: 1
+    line: 2
     confidence: high
     method: explicit_tag
   - file: skills/gate-trace/SKILL.md
-    line: 1
+    line: 2
     confidence: high
     method: explicit_tag
   - file: skills/develop-tdd/SKILL.md
-    line: 1
+    line: 2
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/verify-work.md
@@ -348,10 +348,10 @@ links:
 - `specs/epics/e80-verify-arc-hardening/epic.yaml` (line 37, confidence: high, method: explicit_tag)
 - `scripts/verify-tdd-red-commit.sh` (line 2, confidence: high, method: explicit_tag)
 - `scripts/run-gate-trace-verify.sh` (line 2, confidence: high, method: explicit_tag)
-- `skills/enforce-first/SKILL.md` (line 1, confidence: high, method: explicit_tag)
-- `skills/validate-fix/SKILL.md` (line 1, confidence: high, method: explicit_tag)
-- `skills/gate-trace/SKILL.md` (line 1, confidence: high, method: explicit_tag)
-- `skills/develop-tdd/SKILL.md` (line 1, confidence: high, method: explicit_tag)
+- `skills/enforce-first/SKILL.md` (line 2, confidence: high, method: explicit_tag)
+- `skills/validate-fix/SKILL.md` (line 2, confidence: high, method: explicit_tag)
+- `skills/gate-trace/SKILL.md` (line 2, confidence: high, method: explicit_tag)
+- `skills/develop-tdd/SKILL.md` (line 2, confidence: high, method: explicit_tag)
 - `.windsurf/rules/verify-work.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/verify-work.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/verifications/e18s02-verify.yaml` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e80s02.md
+++ b/specs/codebase-wiki/e80s02.md
@@ -21,11 +21,11 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/smoke-test/SKILL.md
-    line: 1
+    line: 2
     confidence: high
     method: explicit_tag
   - file: skills/validate-contracts/SKILL.md
-    line: 1
+    line: 2
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/validate-contracts.md
@@ -149,8 +149,8 @@ links:
 - `specs/bugs/BUG-2026-07-26-planning-sot-drift.md` (line 23, confidence: high, method: explicit_tag)
 - `specs/epics/e80-verify-arc-hardening/epic.yaml` (line 56, confidence: high, method: explicit_tag)
 - `scripts/validate-contracts.sh` (line 2, confidence: high, method: explicit_tag)
-- `skills/smoke-test/SKILL.md` (line 1, confidence: high, method: explicit_tag)
-- `skills/validate-contracts/SKILL.md` (line 1, confidence: high, method: explicit_tag)
+- `skills/smoke-test/SKILL.md` (line 2, confidence: high, method: explicit_tag)
+- `skills/validate-contracts/SKILL.md` (line 2, confidence: high, method: explicit_tag)
 - `.windsurf/rules/validate-contracts.md` (line 0, confidence: medium, method: file_heuristic)
 - `.windsurf/rules/smoke-test.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/validate-contracts.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e80s03.md
+++ b/specs/codebase-wiki/e80s03.md
@@ -13,7 +13,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/develop-tdd/SKILL.md
-    line: 2
+    line: 3
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/develop-tdd.md
@@ -59,7 +59,7 @@ links:
 ## Implemented In
 
 - `specs/epics/e80-verify-arc-hardening/epic.yaml` (line 69, confidence: high, method: explicit_tag)
-- `skills/develop-tdd/SKILL.md` (line 2, confidence: high, method: explicit_tag)
+- `skills/develop-tdd/SKILL.md` (line 3, confidence: high, method: explicit_tag)
 - `.windsurf/rules/develop-tdd.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/skills-wiki/skills/develop-tdd.md` (line 0, confidence: medium, method: file_heuristic)
 - `specs/benchmarks/develop-tdd.yaml` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e80s04.md
+++ b/specs/codebase-wiki/e80s04.md
@@ -17,7 +17,7 @@ links:
     confidence: high
     method: explicit_tag
   - file: skills/validate-fix/SKILL.md
-    line: 2
+    line: 3
     confidence: high
     method: explicit_tag
   - file: .windsurf/rules/quick-fix.md
@@ -148,7 +148,7 @@ links:
 
 - `specs/epics/e80-verify-arc-hardening/epic.yaml` (line 82, confidence: high, method: explicit_tag)
 - `scripts/verify-generalize-sweep.sh` (line 2, confidence: high, method: explicit_tag)
-- `skills/validate-fix/SKILL.md` (line 2, confidence: high, method: explicit_tag)
+- `skills/validate-fix/SKILL.md` (line 3, confidence: high, method: explicit_tag)
 - `.windsurf/rules/quick-fix.md` (line 0, confidence: medium, method: file_heuristic)
 - `.windsurf/rules/validate-fix.md` (line 0, confidence: medium, method: file_heuristic)
 - `.windsurf/rules/fix-bug.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/e81s01.md
+++ b/specs/codebase-wiki/e81s01.md
@@ -4,23 +4,27 @@ id: e81s01
 epic: e81
 bcps: 0
 wsjf: 4.5
-implementation_status: backlog
+implementation_status: done
 coverage_status: covered
 confidence: high
 links:
-  - file: specs/epics/e81-agents-code-economy/e81s01-tasks.yaml
+  - file: specs/verifications/AUDIT-e81-e81s01.md
     line: 11
     confidence: high
     method: explicit_tag
-  - file: specs/epics/e81-agents-code-economy/e81s01-tasks.yaml
+  - file: specs/epics/archive/e81-agents-code-economy/e81s01-tasks.yaml
+    line: 11
+    confidence: high
+    method: explicit_tag
+  - file: specs/epics/archive/e81-agents-code-economy/e81s01-tasks.yaml
     line: 25
     confidence: high
     method: explicit_tag
-  - file: specs/epics/e81-agents-code-economy/epic.yaml
+  - file: specs/epics/archive/e81-agents-code-economy/epic.yaml
     line: 1
     confidence: high
     method: explicit_tag
-  - file: specs/epics/e81-agents-code-economy/epic.yaml
+  - file: specs/epics/archive/e81-agents-code-economy/epic.yaml
     line: 40
     confidence: high
     method: explicit_tag
@@ -45,15 +49,16 @@ links:
 # e81s01: AGENTS.md template Token Economy section + reference doc
 
 **Epic:** e81 — Agent code economy — 8-rules knowledge distillation
-**Status:** backlog
+**Status:** done
 **BCP:** 0 | **WSJF:** 4.5
 
 ## Implemented In
 
-- `specs/epics/e81-agents-code-economy/e81s01-tasks.yaml` (line 11, confidence: high, method: explicit_tag)
-- `specs/epics/e81-agents-code-economy/e81s01-tasks.yaml` (line 25, confidence: high, method: explicit_tag)
-- `specs/epics/e81-agents-code-economy/epic.yaml` (line 1, confidence: high, method: explicit_tag)
-- `specs/epics/e81-agents-code-economy/epic.yaml` (line 40, confidence: high, method: explicit_tag)
+- `specs/verifications/AUDIT-e81-e81s01.md` (line 11, confidence: high, method: explicit_tag)
+- `specs/epics/archive/e81-agents-code-economy/e81s01-tasks.yaml` (line 11, confidence: high, method: explicit_tag)
+- `specs/epics/archive/e81-agents-code-economy/e81s01-tasks.yaml` (line 25, confidence: high, method: explicit_tag)
+- `specs/epics/archive/e81-agents-code-economy/epic.yaml` (line 1, confidence: high, method: explicit_tag)
+- `specs/epics/archive/e81-agents-code-economy/epic.yaml` (line 40, confidence: high, method: explicit_tag)
 - `docs/references/agents-code-economy.md` (line 3, confidence: high, method: explicit_tag)
 - `docs/templates/AGENTS.md` (line 3, confidence: high, method: explicit_tag)
 - `specs/conventions-wiki/docs-references-ssot-sync-e45s10.md` (line 0, confidence: medium, method: file_heuristic)

--- a/specs/codebase-wiki/index.md
+++ b/specs/codebase-wiki/index.md
@@ -1,6 +1,6 @@
 ---
 type: Index
-generated_at: 2026-08-05T16:09:57.955320+00:00
+generated_at: 2026-08-06T15:57:11.278228+00:00
 total_concepts: 126
 ---
 
@@ -34,16 +34,16 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e45s06](./e45s06.md) | tasks.yaml: literal failing→passing task ledger | high | 2 |
 | [e45s07](./e45s07.md) | request-review: dual-blind AND-gate review (Santa Method) | high | 38 |
 | [e45s08](./e45s08.md) | develop-tdd / validate-fix: two-commit red/green regression  | high | 14 |
-| [e45s09](./e45s09.md) | verify-work / plan-work: Pre-Implementation and Validation g | high | 88 |
+| [e45s09](./e45s09.md) | verify-work / plan-work: Pre-Implementation and Validation g | high | 89 |
 | [e45s10](./e45s10.md) | docs/references: auto-regenerate from source-of-truth docs v | high | 7 |
 | [e45s11](./e45s11.md) | orchestration / dispatch-agents: typed message protocol + 3- | high | 21 |
-| [e45s12](./e45s12.md) | stocktake-skills / craft-skill: code-enforced validator + au | high | 46 |
+| [e45s12](./e45s12.md) | stocktake-skills / craft-skill: code-enforced validator + au | high | 47 |
 | [e45s13](./e45s13.md) | verify-work: one-test-minimum terminal-verdict rule | high | 29 |
 | [e45s14](./e45s14.md) | deepen-architecture: declared import-boundary allowlist enfo | high | 8 |
 | [e45s15](./e45s15.md) | release-branch / deploy: three-independent-facts verificatio | high | 25 |
 | [e45s16](./e45s16.md) | CLAUDE.md rtk mandate: wire rtk-ai/rtk PreToolUse hook | high | 4 |
 | [e45s17](./e45s17.md) | request-review: fan-out to parallel review subagents | high | 30 |
-| [e45s18](./e45s18.md) | audit-code / security-review: worktree-isolated parallel che | high | 682 |
+| [e45s18](./e45s18.md) | audit-code / security-review: worktree-isolated parallel che | high | 688 |
 | [e45s19](./e45s19.md) | Context7: bounded retry cap and explicit fallback block | high | 8 |
 | [e45s20](./e45s20.md) | Context7 / bts docs: wrap in ETag-revalidated fetch cache | high | 1 |
 | [e45s21](./e45s21.md) | seed-conventions / AGENTS.md: self-installing fenced markers | high | 41 |
@@ -56,7 +56,7 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e45s28](./e45s28.md) | request-review: hard max-iteration cap | high | 22 |
 | [e45s29](./e45s29.md) | requirements: ADDED/MODIFIED/REMOVED/RENAMED tags | high | 54 |
 | [e45s30](./e45s30.md) | subagent depth: formalize depth tiers | high | 36 |
-| [e45s31](./e45s31.md) | audit-code / deepen-architecture: churn-based look-here-firs | high | 668 |
+| [e45s31](./e45s31.md) | audit-code / deepen-architecture: churn-based look-here-firs | high | 674 |
 | [e45s32](./e45s32.md) | gate-trace / release-branch: adversarial-review refute frami | high | 41 |
 | [e45s33](./e45s33.md) | requirements: per-section approval state | high | 3 |
 | [e45s34](./e45s34.md) | develop-tdd: snapshot-before-transition hardening | high | 7 |
@@ -68,10 +68,10 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e45s40](./e45s40.md) | verify-work: mandatory real-browser verification | high | 27 |
 | [e45s41](./e45s41.md) | security-review: proven authorship SQL-safety doctrine | high | 22 |
 | [e48s01](./e48s01.md) | Generate epics-wiki and adr-wiki as OKF concept bundles from | high | 34 |
-| [e48s02](./e48s02.md) | Emit verification reports as OKF bundles from run-golden-sui | medium | 56 |
-| [e48s03](./e48s03.md) | OKF-ify bug-registry: specs/bugs/registry.yaml emits concept | high | 157 |
+| [e48s02](./e48s02.md) | Emit verification reports as OKF bundles from run-golden-sui | medium | 58 |
+| [e48s03](./e48s03.md) | OKF-ify bug-registry: specs/bugs/registry.yaml emits concept | high | 160 |
 | [e48s04](./e48s04.md) | Create viz.html — interactive force-layout graph companion f | medium | 12 |
-| [e48s05](./e48s05.md) | Wire OKF validation into CI (sync-skills.yml) and document i | medium | 204 |
+| [e48s05](./e48s05.md) | Wire OKF validation into CI (sync-skills.yml) and document i | medium | 207 |
 | [e48s06](./e48s06.md) | Add tier: field (core/extended/specialized) to OKF wiki inde | medium | 10 |
 | [e48s07](./e48s07.md) | Create publish-to-wiki kernel tool | high | 2 |
 | [e48s08](./e48s08.md) | Add GitHub Action Template for publish-wiki.yml [HARD GATE] | high | 8 |
@@ -85,7 +85,7 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e51s01](./e51s01.md) | CONVENTIONS — Always Green, Shift Left, Discovered Defects,  | high | 8 |
 | [e51s02](./e51s02.md) | seed-conventions — Preflight default, solo-git default, embe | high | 48 |
 | [e51s03](./e51s03.md) | kickoff-branch + verify-work — Preflight hard block and CI g | high | 74 |
-| [e51s04](./e51s04.md) | audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log rou | high | 722 |
+| [e51s04](./e51s04.md) | audit-code, develop-tdd, quick-fix, fix-bug — fix-or-log rou | high | 728 |
 | [e51s05](./e51s05.md) | CLAUDE.md — solo-default agent rules + bigpowers Preflight c | high | 7 |
 | [e53s01](./e53s01.md) | Commit the untracked GOLDEN baseline | high | 12 |
 | [e53s02](./e53s02.md) | Build the tombstone-alias mechanism | high | 7 |
@@ -135,4 +135,4 @@ Auto-generated OKF bundle from trace-stories.sh.
 | [e80s03](./e80s03.md) | develop-tdd RED commit isolation check | high | 10 |
 | [e80s04](./e80s04.md) | generalize-fix phase in validate-fix | high | 32 |
 | [e80s05](./e80s05.md) | security-review fixture table growth | high | 11 |
-| [e81s01](./e81s01.md) | AGENTS.md template Token Economy section + reference doc | high | 8 |
+| [e81s01](./e81s01.md) | AGENTS.md template Token Economy section + reference doc | high | 9 |

--- a/specs/epics-wiki/e81.okf.md
+++ b/specs/epics-wiki/e81.okf.md
@@ -8,7 +8,7 @@ category: epic
 tier: specialized
 wsjf: 4.5
 bcps: 2
-status: backlog
+status: done
 release: unknown
 codename: ""
 story_count: 1
@@ -19,7 +19,7 @@ references:
 
 # Agent code economy — 8-rules knowledge distillation
 
-**Epic:** e81 | **WSJF:** 4.5 | **BCP:** 2 | **Status:** backlog
+**Epic:** e81 | **WSJF:** 4.5 | **BCP:** 2 | **Status:** done
 **Release:** unknown | **Tier:** specialized
 
-1 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/e81-agents-code-economy/epic.yaml` for full specifications.
+1 stories. See `/Users/danielvm/Developer/bigpowers/specs/epics/archive/e81-agents-code-economy/epic.yaml` for full specifications.

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -1,12 +1,15 @@
-active_flow: null
+active_flow: fix_bug
 active_epic: 'null'
 active_story: null
-bug_id: null
+bug_id: BUG-2026-08-06-pi-drops-skills-frontmatter
 bigpowers_version: 2.87.2
-bug_cycle: null
+bug_cycle:
+  current_step: 3
+  completed_steps: [1, 2]
+  bug_file: specs/bugs/BUG-2026-08-06-pi-drops-skills-frontmatter.md
 handoff:
-  next_skill: 'null'
-  context: BUG-2026-07-30T000000 (update/install paths fetch latest version) resolved and verified.
+  next_skill: develop-tdd
+  context: BUG-2026-08-06-pi-drops-skills-frontmatter — RCA verified (pi startsWith('---') gate). Proceeding with fix: move story tags inside frontmatter in 16 skills, extend validate-skill-yaml.py to source scan + delimiter rule, remove stray .agents/skills/SKILL.md.
   epic: null
 epic_cycle: null
 metrics:

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -4,12 +4,12 @@ active_story: null
 bug_id: BUG-2026-08-06-pi-drops-skills-frontmatter
 bigpowers_version: 2.87.2
 bug_cycle:
-  current_step: 3
-  completed_steps: [1, 2]
+  current_step: 5
+  completed_steps: [1, 2, 3, 4]
   bug_file: specs/bugs/BUG-2026-08-06-pi-drops-skills-frontmatter.md
 handoff:
-  next_skill: develop-tdd
-  context: "BUG-2026-08-06-pi-drops-skills-frontmatter — RCA verified (pi startsWith('---') gate). Proceeding with fix: move story tags inside frontmatter in 16 skills, extend validate-skill-yaml.py to source scan + delimiter rule, remove stray .agents/skills/SKILL.md."
+  next_skill: release-branch
+  context: "BUG-2026-08-06-pi-drops-skills-frontmatter — fix landed on branch fix/pi-skills-frontmatter-delimiter, PR #109 open, CI pending. validate-fix green (validator 162/162, compliance 98/98, golden 38/38)."
   epic: null
 epic_cycle: null
 metrics:

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -9,7 +9,7 @@ bug_cycle:
   bug_file: specs/bugs/BUG-2026-08-06-pi-drops-skills-frontmatter.md
 handoff:
   next_skill: develop-tdd
-  context: BUG-2026-08-06-pi-drops-skills-frontmatter — RCA verified (pi startsWith('---') gate). Proceeding with fix: move story tags inside frontmatter in 16 skills, extend validate-skill-yaml.py to source scan + delimiter rule, remove stray .agents/skills/SKILL.md.
+  context: "BUG-2026-08-06-pi-drops-skills-frontmatter — RCA verified (pi startsWith('---') gate). Proceeding with fix: move story tags inside frontmatter in 16 skills, extend validate-skill-yaml.py to source scan + delimiter rule, remove stray .agents/skills/SKILL.md."
   epic: null
 epic_cycle: null
 metrics:

--- a/specs/traceability-matrix.json
+++ b/specs/traceability-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-05T16:09:57.942794+00:00",
+  "generated_at": "2026-08-06T15:57:11.262756+00:00",
   "matrix_version": "1.0",
   "stories": [
     {
@@ -1315,7 +1315,7 @@
         },
         {
           "file": "skills/craft-skill/SKILL.md",
-          "line": 1,
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -1441,7 +1441,7 @@
         },
         {
           "file": "skills/plan-work/SKILL.md",
-          "line": 1,
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -1621,7 +1621,7 @@
         },
         {
           "file": "skills/gate-trace/SKILL.md",
-          "line": 2,
+          "line": 3,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -1825,13 +1825,13 @@
       "links": [
         {
           "file": "skills/plan-work/SKILL.md",
-          "line": 2,
+          "line": 3,
           "confidence": "high",
           "method": "explicit_tag"
         },
         {
           "file": "skills/develop-tdd/SKILL.md",
-          "line": 4,
+          "line": 5,
           "confidence": "high",
           "method": "explicit_tag"
         }
@@ -1849,13 +1849,13 @@
       "links": [
         {
           "file": "skills/request-review/SKILL.md",
-          "line": 1,
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
         {
           "file": "skills/request-review/SKILL.md",
-          "line": 2,
+          "line": 3,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -2089,13 +2089,13 @@
       "links": [
         {
           "file": "skills/validate-fix/SKILL.md",
-          "line": 3,
+          "line": 4,
           "confidence": "high",
           "method": "explicit_tag"
         },
         {
           "file": "skills/develop-tdd/SKILL.md",
-          "line": 5,
+          "line": 6,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -2251,7 +2251,7 @@
         },
         {
           "file": "skills/plan-work/SKILL.md",
-          "line": 3,
+          "line": 4,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -2296,6 +2296,12 @@
           "line": 10,
           "confidence": "high",
           "method": "explicit_tag"
+        },
+        {
+          "file": "GSD_WORKFLOW_ANALYSIS_VS_BIGPOWERS.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
         },
         {
           "file": ".windsurf/rules/scope-work.md",
@@ -2712,7 +2718,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 88
+      "link_count": 89
     },
     {
       "id": "e45s10",
@@ -2989,7 +2995,7 @@
         },
         {
           "file": "skills/craft-skill/SKILL.md",
-          "line": 2,
+          "line": 3,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -3085,6 +3091,12 @@
         },
         {
           "file": "specs/bugs/BUG-2026-07-06-craft-skill-sync-oversized.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/bugs/BUG-2026-08-06-pi-drops-skills-frontmatter.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -3192,7 +3204,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 46
+      "link_count": 47
     },
     {
       "id": "e45s13",
@@ -3397,7 +3409,7 @@
         },
         {
           "file": "skills/deepen-architecture/SKILL.md",
-          "line": 2,
+          "line": 3,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -3517,7 +3529,7 @@
         },
         {
           "file": "skills/deploy/SKILL.md",
-          "line": 1,
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -3649,7 +3661,7 @@
       "links": [
         {
           "file": "skills/request-review/SKILL.md",
-          "line": 3,
+          "line": 4,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -3919,7 +3931,7 @@
         },
         {
           "file": "skills/audit-code/SKILL.md",
-          "line": 2,
+          "line": 3,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -4231,6 +4243,12 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260726-082552.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-124253.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -4758,6 +4776,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-125318.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/audit-cleancode-20260727-131841.md",
           "line": 0,
           "confidence": "medium",
@@ -5233,6 +5257,12 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260728-113556.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-123246.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -6426,6 +6456,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-122059.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-200055.md",
           "line": 0,
           "confidence": "medium",
@@ -6613,6 +6649,12 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260702-223359.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-122400.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -7314,6 +7356,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-122231.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/audit-cleancode-20260706-132858.md",
           "line": 0,
           "confidence": "medium",
@@ -7932,7 +7980,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 682
+      "link_count": 688
     },
     {
       "id": "e45s19",
@@ -9529,13 +9577,13 @@
         },
         {
           "file": "skills/deepen-architecture/SKILL.md",
-          "line": 1,
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
         {
           "file": "skills/audit-code/SKILL.md",
-          "line": 3,
+          "line": 4,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -9841,6 +9889,12 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260726-082552.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-124253.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -10368,6 +10422,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-125318.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/audit-cleancode-20260727-131841.md",
           "line": 0,
           "confidence": "medium",
@@ -10843,6 +10903,12 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260728-113556.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-123246.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -12036,6 +12102,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-122059.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-200055.md",
           "line": 0,
           "confidence": "medium",
@@ -12223,6 +12295,12 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260702-223359.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-122400.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -12924,6 +13002,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-122231.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/audit-cleancode-20260706-132858.md",
           "line": 0,
           "confidence": "medium",
@@ -13530,7 +13614,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 668
+      "link_count": 674
     },
     {
       "id": "e45s32",
@@ -13813,7 +13897,7 @@
         },
         {
           "file": "skills/plan-work/SKILL.md",
-          "line": 4,
+          "line": 5,
           "confidence": "high",
           "method": "explicit_tag"
         }
@@ -13831,7 +13915,7 @@
       "links": [
         {
           "file": "skills/develop-tdd/SKILL.md",
-          "line": 6,
+          "line": 7,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -13885,7 +13969,7 @@
       "links": [
         {
           "file": "skills/plan-work/SKILL.md",
-          "line": 5,
+          "line": 6,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -13963,7 +14047,7 @@
       "links": [
         {
           "file": "skills/run-evals/SKILL.md",
-          "line": 1,
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -14089,7 +14173,7 @@
         },
         {
           "file": "skills/diagnose-stall/SKILL.md",
-          "line": 1,
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -14886,6 +14970,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/GOLDEN-2026-08-06.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/GOLDEN-2026-07-07.okf.md",
           "line": 0,
           "confidence": "medium",
@@ -14947,6 +15037,12 @@
         },
         {
           "file": "specs/verifications/reports/audit-2026-07-07.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/reports/audit-2026-08-06.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15150,7 +15246,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 56
+      "link_count": 58
     },
     {
       "id": "e48s03",
@@ -15396,6 +15492,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/bugs/BUG-2026-08-06-pi-drops-skills-frontmatter.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/bugs/BUG-001.okf.md",
           "line": 0,
           "confidence": "medium",
@@ -15505,6 +15607,12 @@
         },
         {
           "file": "specs/bugs/BUG-2026-07-02T103911.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/bugs/BUG-2026-08-05-cycle-time-toolchain.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -15852,6 +15960,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/bugs/BUG-2026-08-05-cycle-time-toolchain.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/bugs/BUG-2026-07-03-validate-specs-no-real-parser.md",
           "line": 0,
           "confidence": "medium",
@@ -16104,7 +16218,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 157
+      "link_count": 160
     },
     {
       "id": "e48s04",
@@ -16290,6 +16404,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/GOLDEN-2026-08-06.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/GOLDEN-2026-07-07.okf.md",
           "line": 0,
           "confidence": "medium",
@@ -16351,6 +16471,12 @@
         },
         {
           "file": "specs/verifications/reports/audit-2026-07-07.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/reports/audit-2026-08-06.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -16783,6 +16909,12 @@
         },
         {
           "file": "specs/bugs/BUG-2026-07-06-verify-work-runner-scripts-oversized.okf.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/bugs/BUG-2026-08-05-cycle-time-toolchain.okf.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -17424,7 +17556,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 204
+      "link_count": 207
     },
     {
       "id": "e48s06",
@@ -19099,25 +19231,25 @@
         },
         {
           "file": "skills/fix-bug/SKILL.md",
-          "line": 1,
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
         {
           "file": "skills/quick-fix/SKILL.md",
-          "line": 1,
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
         {
           "file": "skills/develop-tdd/SKILL.md",
-          "line": 3,
+          "line": 4,
           "confidence": "high",
           "method": "explicit_tag"
         },
         {
           "file": "skills/audit-code/SKILL.md",
-          "line": 1,
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -19459,6 +19591,12 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260726-082552.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-124253.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -19986,6 +20124,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-125318.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/audit-cleancode-20260727-131841.md",
           "line": 0,
           "confidence": "medium",
@@ -20461,6 +20605,12 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260728-113556.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-123246.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -21654,6 +21804,12 @@
           "method": "file_heuristic"
         },
         {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-122059.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
           "file": "specs/verifications/reports/audit-cleancode-20260702-200055.md",
           "line": 0,
           "confidence": "medium",
@@ -21841,6 +21997,12 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260702-223359.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-122400.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -22537,6 +22699,12 @@
         },
         {
           "file": "specs/verifications/reports/audit-cleancode-20260726-190959.md",
+          "line": 0,
+          "confidence": "medium",
+          "method": "file_heuristic"
+        },
+        {
+          "file": "specs/verifications/reports/audit-cleancode-20260806-122231.md",
           "line": 0,
           "confidence": "medium",
           "method": "file_heuristic"
@@ -23400,7 +23568,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 722
+      "link_count": 728
     },
     {
       "id": "e51s05",
@@ -23580,13 +23748,13 @@
           "method": "file_heuristic"
         },
         {
-          "file": "specs/epics/e81-agents-code-economy/e81s01-tasks.yaml",
+          "file": "specs/epics/archive/e53-establish-migration-baseline/e53s02-tasks.yaml",
           "line": 0,
           "confidence": "low",
           "method": "task_reference"
         },
         {
-          "file": "specs/epics/archive/e53-establish-migration-baseline/e53s02-tasks.yaml",
+          "file": "specs/epics/archive/e81-agents-code-economy/e81s01-tasks.yaml",
           "line": 0,
           "confidence": "low",
           "method": "task_reference"
@@ -26875,7 +27043,7 @@
         },
         {
           "file": "skills/craft-skill/SKILL.md",
-          "line": 3,
+          "line": 4,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -27343,25 +27511,25 @@
         },
         {
           "file": "skills/enforce-first/SKILL.md",
-          "line": 1,
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
         {
           "file": "skills/validate-fix/SKILL.md",
-          "line": 1,
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
         {
           "file": "skills/gate-trace/SKILL.md",
-          "line": 1,
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
         {
           "file": "skills/develop-tdd/SKILL.md",
-          "line": 1,
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -27823,13 +27991,13 @@
         },
         {
           "file": "skills/smoke-test/SKILL.md",
-          "line": 1,
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
         {
           "file": "skills/validate-contracts/SKILL.md",
-          "line": 1,
+          "line": 2,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -28015,7 +28183,7 @@
         },
         {
           "file": "skills/develop-tdd/SKILL.md",
-          "line": 2,
+          "line": 3,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -28093,7 +28261,7 @@
         },
         {
           "file": "skills/validate-fix/SKILL.md",
-          "line": 2,
+          "line": 3,
           "confidence": "high",
           "method": "explicit_tag"
         },
@@ -28359,28 +28527,34 @@
       "epic_title": "Agent code economy \u2014 8-rules knowledge distillation",
       "bcp": 0,
       "wsjf": 4.5,
-      "status": "backlog",
+      "status": "done",
       "links": [
         {
-          "file": "specs/epics/e81-agents-code-economy/e81s01-tasks.yaml",
+          "file": "specs/verifications/AUDIT-e81-e81s01.md",
           "line": 11,
           "confidence": "high",
           "method": "explicit_tag"
         },
         {
-          "file": "specs/epics/e81-agents-code-economy/e81s01-tasks.yaml",
+          "file": "specs/epics/archive/e81-agents-code-economy/e81s01-tasks.yaml",
+          "line": 11,
+          "confidence": "high",
+          "method": "explicit_tag"
+        },
+        {
+          "file": "specs/epics/archive/e81-agents-code-economy/e81s01-tasks.yaml",
           "line": 25,
           "confidence": "high",
           "method": "explicit_tag"
         },
         {
-          "file": "specs/epics/e81-agents-code-economy/epic.yaml",
+          "file": "specs/epics/archive/e81-agents-code-economy/epic.yaml",
           "line": 1,
           "confidence": "high",
           "method": "explicit_tag"
         },
         {
-          "file": "specs/epics/e81-agents-code-economy/epic.yaml",
+          "file": "specs/epics/archive/e81-agents-code-economy/epic.yaml",
           "line": 40,
           "confidence": "high",
           "method": "explicit_tag"
@@ -28410,7 +28584,7 @@
           "method": "file_heuristic"
         }
       ],
-      "link_count": 8
+      "link_count": 9
     }
   ],
   "summary": {
@@ -28681,12 +28855,13 @@
       "e80s02",
       "e80s03",
       "e80s04",
-      "e80s05"
+      "e80s05",
+      "e81s01"
     ],
-    "stale_count": 115,
+    "stale_count": 116,
     "oracle_stats": {
-      "high": 907,
-      "medium": 3497,
+      "high": 908,
+      "medium": 3525,
       "low": 79
     }
   }


### PR DESCRIPTION
## Problem

pi (v0.82.0) reports `description is required` at startup for 16 skills (audit-code, plan-work, develop-tdd, fix-bug, …). Reporter's issue: #108.

**Root cause (verified in pi source via opensrc):** pi's frontmatter extractor (`src/utils/frontmatter.ts`) requires the opening delimiter `---` to be the **first characters of SKILL.md**:

```ts
if (!normalized.startsWith("---")) {
    return { yamlString: null, body: normalized };
}
```

16 source `skills/*/SKILL.md` files placed `# story:` / `<!-- story: -->` traceability tags **above** the delimiter → pi sees no frontmatter → no `description` → skill silently dropped. In-repo this was masked because the generated `.pi/skills/` copies (via `srp-engine.py`) strip the tags; every external install (symlinked sources) hits it.

## Fix

1. **16 SKILL.md sources**: move leading story tags **inside** the frontmatter block as `# story:` YAML comments (converted `<!-- -->` form). Valid YAML for pi, PyYAML, and the bundled `simple_yaml.py` fallback; `trace-stories.sh` greps the whole tree so traceability is unaffected; generated artifacts stay byte-identical (no churn).
2. **`validate-skill-yaml.py`** now scans **sources + generated copies** with a new R1 rule: *file must start with `---` at byte 0*. Wired into the `sync-skills.sh` post-generation guard → regression-proof.
3. **`skill-common.sh`**: `parse_frontmatter` / `parse_frontmatter_okf` now skip comment lines (story tags inside frontmatter no longer leak into `skills-lock.json` descriptions or the search index).
4. Removed stray `.agents/skills/SKILL.md` (empty name/description — the 17th warning).

## Verification

- Validator: **162/162** (81 sources + 81 generated), RED→GREEN proven (16 failures → 0)
- Generated `.pi/`, `.cursor/`, `.gemini/` trees byte-identical after sync
- `trace-stories.sh --strict` PASS, `check-skill-links` PASS, `check-skill-size` PASS
- `npm run compliance`: 98/98 PASS
- Golden suite: **38/38 PASS**
- Bug file: `specs/bugs/BUG-2026-08-06-pi-drops-skills-frontmatter.md`