### PR TITLE
fix(install): uninstall menu removes symlinks for all 18 tools and local installs

### DIFF
--- a/scripts/lib/install-helpers.js
+++ b/scripts/lib/install-helpers.js
@@ -404,23 +404,23 @@ function installLocal(tool, repoRoot) {
 
 function uninstallTool(toolId, repoRoot) {
   const homeDir = require('os').homedir();
+  // installLocal() resolves its own targets from process.cwd() at call time
+  // (bin/setup.js never passes a mode/cwd into uninstallTool), so the
+  // interactive Uninstall menu — which offers no global/local choice — must
+  // clean whichever scope was actually installed into. Previously this
+  // function only ever touched homeDir: a local install (`bigpowers install`
+  // → Local) was reported as "removed" but every local symlink survived.
+  const cwd = process.cwd();
 
   switch (toolId) {
     case 'claude': {
-      const skillsDir = path.join(homeDir, '.claude', 'skills');
-      if (fs.existsSync(skillsDir)) {
-        for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
-          if (!entry.isSymbolicLink()) continue;
-          const target = fs.readlinkSync(path.join(skillsDir, entry.name));
-          if (target.startsWith(repoRoot)) {
-            removeSymlink(path.join(skillsDir, entry.name));
-          }
-        }
-      }
+      removeRepoRootedSkillLinks(path.join(homeDir, '.claude', 'skills'), repoRoot);
       const hooksDir = path.join(homeDir, '.claude', 'hooks');
       removeSymlink(path.join(hooksDir, 'block-dangerous-git.sh'));
       removeSymlink(path.join(hooksDir, 'rtk-rewrite.sh'));
       removeSymlink(path.join(hooksDir, 'lib'));
+      // installLocal('claude') only links skills/ (no hooks) into cwd/.claude/skills
+      removeRepoRootedSkillLinks(path.join(cwd, '.claude', 'skills'), repoRoot);
       break;
     }
     case 'gemini':
@@ -434,18 +434,12 @@ function uninstallTool(toolId, repoRoot) {
       ]) {
         removeSymlink(path.join(homeDir, '.gemini', 'hooks', hookFile));
       }
+      // installLocal('gemini') links repoRoot/.gemini/extensions/bigpowers into cwd
+      removeSymlink(path.join(cwd, '.gemini', 'extensions', 'bigpowers'));
       break;
     case 'pi': {
-      const skillsDir = path.join(homeDir, '.pi', 'agent', 'skills');
-      if (fs.existsSync(skillsDir)) {
-        for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
-          if (!entry.isSymbolicLink()) continue;
-          const target = fs.readlinkSync(path.join(skillsDir, entry.name));
-          if (target.startsWith(repoRoot)) {
-            removeSymlink(path.join(skillsDir, entry.name));
-          }
-        }
-      }
+      removeRepoRootedSkillLinks(path.join(homeDir, '.pi', 'agent', 'skills'), repoRoot);
+      removeRepoRootedSkillLinks(path.join(cwd, '.pi', 'agent', 'skills'), repoRoot);
       break;
     }
     case 'hermes': {
@@ -460,6 +454,17 @@ function uninstallTool(toolId, repoRoot) {
         }
       }
       removeSymlink(path.join(homeDir, '.hermes', 'hooks', 'session-log'));
+      // installLocal('hermes') renders skills into cwd/.hermes/skills (no hook locally)
+      const localSkillsDir = path.join(cwd, '.hermes', 'skills');
+      if (fs.existsSync(localSkillsDir)) {
+        for (const entry of fs.readdirSync(localSkillsDir, { withFileTypes: true })) {
+          if (!entry.isSymbolicLink()) continue;
+          const target = fs.readlinkSync(path.join(localSkillsDir, entry.name));
+          if (target.startsWith(repoRoot) || target.includes('.hermes/skills')) {
+            removeSymlink(path.join(localSkillsDir, entry.name));
+          }
+        }
+      }
       break;
     }
     case 'zcode': {
@@ -474,6 +479,8 @@ function uninstallTool(toolId, repoRoot) {
         }
       }
       removeSymlink(path.join(homeDir, '.zcode', 'AGENTS.md'));
+      removeManagedSkillLinks(path.join(cwd, '.zcode', 'skills'), repoRoot);
+      removeSymlink(path.join(cwd, '.zcode', 'AGENTS.md'));
       break;
     }
     case 'mimo': {
@@ -488,6 +495,8 @@ function uninstallTool(toolId, repoRoot) {
         }
       }
       removeSymlink(path.join(homeDir, '.mimocode', 'AGENTS.md'));
+      removeManagedSkillLinks(path.join(cwd, '.mimocode', 'skills'), repoRoot);
+      removeSymlink(path.join(cwd, '.mimocode', 'AGENTS.md'));
       break;
     }
     case 'antigravity':
@@ -502,10 +511,20 @@ function uninstallTool(toolId, repoRoot) {
           }
         }
       }
+      // installLocal('antigravity') renders into cwd/.agents/skills and — only
+      // if absent — symlinks cwd/AGENTS.md. Skip the local skills dir entirely
+      // when cwd === repoRoot: that's this repo's own tracked .agents/skills
+      // source tree (the installer's rendered-skill INPUT), not an install
+      // target, and must never be touched by uninstall.
+      if (cwd !== repoRoot) {
+        removeManagedSkillLinks(path.join(cwd, '.agents', 'skills'), repoRoot);
+      }
+      removeSymlink(path.join(cwd, 'AGENTS.md'));
       break;
     }
     case 'cursor':
       removeSymlink(path.join(homeDir, '.cursor', 'rules'));
+      removeSymlink(path.join(cwd, '.cursor', 'rules'));
       break;
     case 'codex':
       {
@@ -518,7 +537,60 @@ function uninstallTool(toolId, repoRoot) {
         }
       }
       removeSymlink(path.join(homeDir, '.codex', 'hooks', 'pre-tool-git-guard.sh'));
+      removeSymlink(path.join(homeDir, '.codex', 'AGENTS.md'));
+      // installLocal('codex') only symlinks cwd/.codex/AGENTS.md (no skills/hooks locally)
+      removeSymlink(path.join(cwd, '.codex', 'AGENTS.md'));
       break; // story: e65s02
+    case 'qwen':
+      removeManagedSkillLinks(path.join(homeDir, '.qwen', 'skills'), repoRoot);
+      removeSymlink(path.join(homeDir, '.qwen', 'QWEN.md'));
+      removeSymlink(path.join(homeDir, '.qwen', 'hooks', 'pre-tool-git-guard.sh'));
+      break; // story: e68s02
+    case 'codebuddy':
+      removeManagedSkillLinks(path.join(homeDir, '.codebuddy', 'skills'), repoRoot);
+      removeSymlink(path.join(homeDir, '.codebuddy', 'AGENTS.md'));
+      removeSymlink(path.join(homeDir, '.codebuddy', 'hooks', 'pre-tool-git-guard.sh'));
+      break; // story: e72s02
+    case 'cline':
+      removeManagedSkillLinks(path.join(homeDir, '.cline', 'skills'), repoRoot);
+      break; // story: e66s02
+    case 'kilo':
+    case 'kilocode': {
+      const rulesDir = path.join(homeDir, '.kilocode', 'rules');
+      if (fs.existsSync(rulesDir)) {
+        for (const f of fs.readdirSync(rulesDir)) {
+          if (!f.endsWith('.md')) continue;
+          removeSymlink(path.join(rulesDir, f));
+        }
+      }
+      removeManagedFile(path.join(homeDir, '.kilocode', 'AGENTS.md'));
+      break; // story: e67s02
+    }
+    case 'trae':
+      removeManagedSkillLinks(path.join(homeDir, '.trae', 'skills'), repoRoot);
+      removeSymlink(path.join(homeDir, '.trae', 'AGENTS.md'));
+      removeSymlink(path.join(homeDir, '.trae', 'hooks', 'pre-tool-git-guard.sh'));
+      break; // story: e70s02
+    case 'windsurf': {
+      const rulesDir = path.join(homeDir, '.codeium', 'windsurf', 'rules');
+      if (fs.existsSync(rulesDir)) {
+        for (const f of fs.readdirSync(rulesDir)) {
+          if (!f.endsWith('.md')) continue;
+          removeSymlink(path.join(rulesDir, f));
+        }
+      }
+      removeManagedFile(path.join(homeDir, '.codeium', 'windsurf', 'AGENTS.md'));
+      removeSymlink(path.join(homeDir, '.codeium', 'windsurf', 'hooks', 'pre-tool-git-guard.sh'));
+      break; // story: e73s02
+    }
+    case 'opencode':
+      removeManagedSkillLinks(path.join(homeDir, '.config', 'opencode', 'skills'), repoRoot);
+      removeSymlink(path.join(homeDir, '.config', 'opencode', 'AGENTS.md'));
+      break; // story: e62s02
+    case 'copilot':
+      removeManagedSkillLinks(path.join(homeDir, '.copilot', 'skills'), repoRoot);
+      removeManagedFile(path.join(homeDir, '.copilot', 'AGENTS.md'));
+      break; // story: e71s02
   }
 }
 
@@ -526,6 +598,61 @@ function removeSymlink(p) {
   try {
     const stat = fs.lstatSync(p);
     if (stat.isSymbolicLink()) {
+      fs.unlinkSync(p);
+      return true;
+    }
+  } catch {}
+  return false;
+}
+
+// Strict variant of removeManagedSkillLinks: only removes symlinks whose
+// target starts with THIS repoRoot exactly (no 'bigpowers' substring match).
+// Used for claude/pi, where a looser match could delete symlinks pointing at
+// an unrelated bigpowers checkout elsewhere on disk (e.g. a second clone).
+function removeRepoRootedSkillLinks(skillsDir, repoRoot) {
+  if (!fs.existsSync(skillsDir)) return;
+  for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+    if (!entry.isSymbolicLink()) continue;
+    const linkPath = path.join(skillsDir, entry.name);
+    let target;
+    try {
+      target = fs.readlinkSync(linkPath);
+    } catch {
+      continue;
+    }
+    if (target.startsWith(repoRoot)) {
+      removeSymlink(linkPath);
+    }
+  }
+}
+
+// Remove bigpowers-managed skill symlinks from a tool's skills dir. Only touches
+// symlinks that resolve back into the repo (installGlobal creates them via
+// linkRenderedSkills → linkDir), leaving any user-authored entries alone.
+function removeManagedSkillLinks(skillsDir, repoRoot) {
+  if (!fs.existsSync(skillsDir)) return;
+  for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+    if (!entry.isSymbolicLink()) continue;
+    const linkPath = path.join(skillsDir, entry.name);
+    let target;
+    try {
+      target = fs.readlinkSync(linkPath);
+    } catch {
+      continue;
+    }
+    if (target.startsWith(repoRoot) || target.includes('bigpowers')) {
+      removeSymlink(linkPath);
+    }
+  }
+}
+
+// Remove a file the installer placed as a plain copy (kilo/windsurf/copilot use
+// fs.copyFileSync for AGENTS.md, so removeSymlink would skip it). Also handles
+// the symlink case so it's safe on either install shape.
+function removeManagedFile(p) {
+  try {
+    const stat = fs.lstatSync(p);
+    if (stat.isSymbolicLink() || stat.isFile()) {
       fs.unlinkSync(p);
       return true;
     }

--- a/scripts/test-install-helpers.js
+++ b/scripts/test-install-helpers.js
@@ -87,6 +87,116 @@ try {
   uninstallTool('cursor', ROOT);
   assert.ok(!fs.existsSync(rulesDst), 'uninstallTool(cursor) must remove rules symlink');
 
+  // Regression: every tool the uninstall menu offers must have a real uninstall
+  // path. Before this, qwen/codebuddy/cline/kilo/trae/windsurf/opencode/copilot
+  // had install cases but no uninstall case — uninstall reported success while
+  // leaving every symlink in place.
+  installGlobal({ id: 'qwen', name: 'Qwen Code' }, ROOT);
+  const qwenSkills = path.join(tmpHome, '.qwen', 'skills');
+  const qwenSample = fs.existsSync(qwenSkills)
+    && fs.readdirSync(qwenSkills).find((n) => {
+      try { return fs.lstatSync(path.join(qwenSkills, n)).isSymbolicLink(); } catch { return false; }
+    });
+  assert.ok(qwenSample, 'qwen install must create at least one skill symlink');
+  uninstallTool('qwen', ROOT);
+  assert.ok(
+    !fs.existsSync(path.join(qwenSkills, qwenSample)),
+    'uninstallTool(qwen) must remove repo-rooted skill symlinks'
+  );
+
+  // copilot writes AGENTS.md as a plain copy (not a symlink); uninstall must
+  // still remove it via removeManagedFile.
+  installGlobal({ id: 'copilot', name: 'Copilot' }, ROOT);
+  const copilotAgents = path.join(tmpHome, '.copilot', 'AGENTS.md');
+  const copilotHadAgents = fs.existsSync(copilotAgents);
+  uninstallTool('copilot', ROOT);
+  if (copilotHadAgents) {
+    assert.ok(!fs.existsSync(copilotAgents), 'uninstallTool(copilot) must remove copied AGENTS.md');
+  }
+  const copilotSkills = path.join(tmpHome, '.copilot', 'skills');
+  if (fs.existsSync(copilotSkills)) {
+    const leftover = fs.readdirSync(copilotSkills).find((n) => {
+      try { return fs.lstatSync(path.join(copilotSkills, n)).isSymbolicLink(); } catch { return false; }
+    });
+    assert.ok(!leftover, 'uninstallTool(copilot) must remove skill symlinks');
+  }
+
+  // Regression: uninstallTool() only ever touched homeDir. The interactive
+  // Uninstall menu (bin/setup.js handleUninstall) never asks global-vs-local
+  // and calls uninstallTool(toolId, ROOT) unconditionally — so a *local*
+  // install (`bigpowers install` → Local) was reported "removed" while every
+  // local symlink survived, for every tool. Verify local install/uninstall
+  // round-trips for tools spanning each install shape: skill-symlink dir
+  // (pi, claude), single linked dir (cursor, gemini), and a linked file
+  // (codex AGENTS.md).
+  const { installLocal } = require('../scripts/lib/install-helpers.js');
+  const savedCwd = process.cwd();
+  const tmpCwd = mkdtempSync(path.join(os.tmpdir(), 'bp-install-helpers-local-'));
+  try {
+    process.chdir(tmpCwd);
+
+    installLocal({ id: 'pi', name: 'pi' }, ROOT);
+    const localPiSkills = path.join(tmpCwd, '.pi', 'agent', 'skills');
+    const localPiSample = fs.readdirSync(localPiSkills).find((n) => {
+      try { return fs.lstatSync(path.join(localPiSkills, n)).isSymbolicLink(); } catch { return false; }
+    });
+    assert.ok(localPiSample, 'local pi install must create at least one skill symlink');
+    uninstallTool('pi', ROOT);
+    assert.ok(
+      !fs.existsSync(path.join(localPiSkills, localPiSample)),
+      'uninstallTool(pi) must also remove LOCAL (cwd) skill symlinks, not just global'
+    );
+
+    installLocal({ id: 'claude', name: 'Claude Code' }, ROOT);
+    const localClaudeSkills = path.join(tmpCwd, '.claude', 'skills');
+    const localClaudeSample = fs.readdirSync(localClaudeSkills).find((n) => {
+      try { return fs.lstatSync(path.join(localClaudeSkills, n)).isSymbolicLink(); } catch { return false; }
+    });
+    assert.ok(localClaudeSample, 'local claude install must create at least one skill symlink');
+    uninstallTool('claude', ROOT);
+    assert.ok(
+      !fs.existsSync(path.join(localClaudeSkills, localClaudeSample)),
+      'uninstallTool(claude) must also remove LOCAL (cwd) skill symlinks, not just global'
+    );
+
+    installLocal({ id: 'cursor', name: 'Cursor' }, ROOT);
+    const localCursorRules = path.join(tmpCwd, '.cursor', 'rules');
+    assert.ok(fs.lstatSync(localCursorRules).isSymbolicLink(), 'local cursor install must symlink .cursor/rules');
+    uninstallTool('cursor', ROOT);
+    assert.ok(!fs.existsSync(localCursorRules), 'uninstallTool(cursor) must remove LOCAL .cursor/rules symlink');
+
+    installLocal({ id: 'gemini', name: 'Gemini' }, ROOT);
+    const localGeminiExt = path.join(tmpCwd, '.gemini', 'extensions', 'bigpowers');
+    assert.ok(fs.lstatSync(localGeminiExt).isSymbolicLink(), 'local gemini install must symlink extensions/bigpowers');
+    uninstallTool('gemini', ROOT);
+    assert.ok(!fs.existsSync(localGeminiExt), 'uninstallTool(gemini) must remove LOCAL extensions/bigpowers symlink');
+
+    installLocal({ id: 'codex', name: 'Codex' }, ROOT);
+    const localCodexAgents = path.join(tmpCwd, '.codex', 'AGENTS.md');
+    assert.ok(fs.lstatSync(localCodexAgents).isSymbolicLink(), 'local codex install must symlink AGENTS.md');
+    uninstallTool('codex', ROOT);
+    assert.ok(!fs.existsSync(localCodexAgents), 'uninstallTool(codex) must remove LOCAL AGENTS.md symlink');
+  } finally {
+    process.chdir(savedCwd);
+    rmSync(tmpCwd, { recursive: true, force: true });
+  }
+
+  // Guard against future drift: assert the menu's supported set matches the
+  // uninstall switch. Any id in SUPPORTED_IDS with no uninstall case regresses
+  // this bug (silent no-op reported as success).
+  const helpersSrc = fs.readFileSync(path.join(ROOT, 'scripts', 'lib', 'install-helpers.js'), 'utf8');
+  const uninstallBody = helpersSrc.slice(helpersSrc.indexOf('function uninstallTool'));
+  const setupText = fs.readFileSync(path.join(ROOT, 'bin/setup.js'), 'utf8');
+  const supportedLine = setupText.match(/const SUPPORTED_IDS = new Set\(\[([^\]]*)\]\)/);
+  assert.ok(supportedLine, 'SUPPORTED_IDS must be declarable from bin/setup.js');
+  const supportedIds = supportedLine[1].match(/'([^']+)'/g).map((s) => s.replace(/'/g, ''));
+  for (const id of supportedIds) {
+    assert.ok(
+      new RegExp(`case '${id}':`).test(uninstallBody),
+      `uninstallTool must handle '${id}' (listed in SUPPORTED_IDS) — else uninstall silently no-ops`
+    );
+  }
+
   const installPaths = [
     path.join(ROOT, 'scripts', 'install.sh'),
     ...fs.readdirSync(path.join(ROOT, 'scripts', 'lib'))

--- a/specs/bugs/BUG-2026-08-07-interactive-uninstall-silent-noop.md
+++ b/specs/bugs/BUG-2026-08-07-interactive-uninstall-silent-noop.md
@@ -1,0 +1,107 @@
+---
+bug_id: BUG-2026-08-07-interactive-uninstall-silent-noop
+status: fixed
+severity: high
+scope: installer
+title: "Interactive menu Uninstall reports success while leaving symlinks in place"
+---
+
+# BUG-2026-08-07-interactive-uninstall-silent-noop: Interactive menu Uninstall reports success while leaving symlinks in place
+
+## Problem
+
+`bigpowers install` → existing install detected → **Uninstall** → select tools → confirm
+prints `✓ <tool> — removed` for every selected tool and ends with `Uninstall complete.`,
+but for a majority of tool/mode combinations no file is actually removed.
+
+**Reproduce:** `bigpowers install`, choose `Uninstall`, select any of qwen / codebuddy /
+cline / kilo / trae / windsurf / opencode / copilot (any install mode), or select *any*
+tool after a **Local** install. Output claims success; the symlinks/files remain on disk.
+
+**Expected:** Uninstall removes exactly what install created, for every tool the menu
+offers, in whichever mode (global or local) was actually installed.
+
+## Root Cause Analysis
+
+`bin/setup.js:handleUninstall()` calls `uninstallTool(toolId, ROOT)` in a try/catch and
+prints `✓ removed` whenever the call doesn't throw. `uninstallTool()` in
+`scripts/lib/install-helpers.js` never throws for an unhandled case — a `switch` with no
+matching `case` just falls through silently. Two independent gaps triggered this:
+
+### Gap 1 — 8 of 18 menu tools had no uninstall case at all
+
+`installGlobal()` has a `case` for every id in `bin/setup.js`'s `SUPPORTED_IDS` (18 ids).
+`uninstallTool()` only had cases for 10: `claude, gemini, pi, hermes, zcode, mimo,
+antigravity/agy, cursor, codex`. The uninstall menu still offers all 18 (it filters by
+`SUPPORTED_IDS`, not by "has an uninstall case"), so selecting `qwen`, `codebuddy`,
+`cline`, `kilo`/`kilocode`, `trae`, `windsurf`, `opencode`, or `copilot` fell through the
+switch, did nothing, and reported `✓ removed`.
+
+Also found in the same pass: the existing `codex` case removed a hook path install never
+creates and never removed the `~/.codex/AGENTS.md` symlink install *does* create.
+
+### Gap 2 — uninstall never looks at a local install at all
+
+`installLocal()` (used when the user picks the **Local** install mode) writes symlinks
+under `process.cwd()` — e.g. `./.claude/skills`, `./.pi/agent/skills`,
+`./.cursor/rules`, `./.codex/AGENTS.md`. `uninstallTool()` only ever read
+`os.homedir()`-rooted paths; it has no `cwd` awareness whatsoever. `handleUninstall()`
+never asks global-vs-local before calling it. Confirmed by direct repro (before fix):
+
+```
+local pi skills linked before uninstall: 81
+local pi skills remaining after uninstallTool(pi): 81   <- unchanged
+```
+
+This affects every tool that supports local install (`claude, gemini, pi, hermes, zcode,
+mimo, antigravity/agy, cursor, codex` — 9 of the 10 originally-handled ids), independent
+of Gap 1.
+
+## Fix
+
+`scripts/lib/install-helpers.js`:
+- Added the 8 missing uninstall cases, each mirroring exactly what `installGlobal`
+  creates for that tool (skill symlinks, `AGENTS.md`/`QWEN.md`, rules `*.md`, git-guard
+  hooks). Added two helpers: `removeManagedSkillLinks` (repo-rooted OR
+  `bigpowers`-substring match, matching the existing zcode/mimo/antigravity convention)
+  and `removeManagedFile` (kilo/windsurf/copilot write `AGENTS.md` as a plain **copy**,
+  not a symlink — the symlink-only remover silently skipped it).
+- Fixed `codex` to also remove `~/.codex/AGENTS.md`.
+- Added local-path cleanup to all 9 originally-handled cases, resolving `cwd =
+  process.cwd()` inside `uninstallTool()` (mirroring how `installLocal()` resolves its
+  own targets) so the same call now cleans whichever scope — global, local, or both —
+  actually has bigpowers symlinks. Added a stricter `removeRepoRootedSkillLinks` helper
+  for `claude`/`pi` specifically, since their original matching was `startsWith(repoRoot)`
+  only; reusing the broader helper there would let uninstall delete symlinks pointing at
+  an unrelated bigpowers checkout elsewhere on disk (e.g. a second clone) — kept that
+  narrower.
+- `antigravity`/`agy` local cleanup explicitly skips touching `cwd/.agents/skills` when
+  `cwd === repoRoot`: that path is this repo's own tracked skill-source tree (the
+  installer's rendered-skill *input*), not an install target, and must never be deleted
+  by uninstall.
+
+`scripts/test-install-helpers.js`:
+- Round-trip tests for `qwen` (symlinked skills) and `copilot` (copied `AGENTS.md`).
+- A **drift guard**: parses `SUPPORTED_IDS` out of `bin/setup.js` and asserts every id
+  has a matching `case` in `uninstallTool` — verified by mutation test to fail cleanly
+  the moment a case is removed.
+- Local install/uninstall round-trip for `pi`, `claude` (skill-symlink dirs), `cursor`,
+  `gemini` (single linked dir), `codex` (linked file) — spanning every install shape.
+  Verified by mutation test (`git stash` the source fix, rerun): fails immediately
+  (`uninstallTool(qwen) must remove repo-rooted skill symlinks`) without the fix,
+  confirming the guard is load-bearing, not vacuous.
+
+## Verify
+
+```bash
+node scripts/test-install-helpers.js
+# → test-install-helpers: ALL PASS
+```
+
+Also checked and found **not** a gap: `scripts/test-install-helpers.sh` (the wrapper for
+this selftest) is already wired into CI via the `install-helpers` gate in
+`scripts/lib/golden-suite-gates.sh`, which `scripts/run-verification-gates.sh` runs, which
+`.github/workflows/golden-suite.yml` runs on every push. An earlier pass through this
+investigation incorrectly flagged CI wiring as missing — it was a grep miss (searched
+`run-verification-gates.sh` and `.github/workflows/` directly, not the gate list file the
+runner sources).

--- a/specs/bugs/BUG-2026-08-07-interactive-uninstall-silent-noop.okf.md
+++ b/specs/bugs/BUG-2026-08-07-interactive-uninstall-silent-noop.okf.md
@@ -1,0 +1,21 @@
+---
+okf_kind: concept
+okf_version: "0.1"
+type: Bug
+id: "BUG-2026-08-07-interactive-uninstall-silent-noop"
+title: "Interactive menu Uninstall reports success while leaving symlinks in place"
+category: bug
+tier: extended
+severity: high
+status: fixed
+generator: scripts/sync-bugs-registry.sh
+references:
+    - specs/bugs/BUG-2026-08-07-interactive-uninstall-silent-noop.md
+---
+
+# Interactive menu Uninstall reports success while leaving symlinks in place
+
+**Bug:** BUG-2026-08-07-interactive-uninstall-silent-noop | **Severity:** high | **Status:** fixed | **Scope:** installer
+**Tier:** extended
+
+See `specs/bugs/BUG-2026-08-07-interactive-uninstall-silent-noop.md` for full investigation and fix details.

--- a/specs/bugs/registry.yaml
+++ b/specs/bugs/registry.yaml
@@ -476,3 +476,9 @@ bugs:
     scope: skills / install
     title: "pi drops 16 skills as 'description is required' — story tags before frontmatter delimiter break parsing"
     file: bugs/BUG-2026-08-06-pi-drops-skills-frontmatter.md
+  - id: BUG-2026-08-07-interactive-uninstall-silent-noop
+    status: fixed
+    severity: high
+    scope: installer
+    title: "Interactive menu Uninstall reports success while leaving symlinks in place"
+    file: bugs/BUG-2026-08-07-interactive-uninstall-silent-noop.md

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -1,15 +1,20 @@
-active_flow: null
+active_flow: fix_bug
 active_epic: 'null'
 active_story: null
-bug_id: null
+bug_id: BUG-2026-08-07-interactive-uninstall-silent-noop
 bigpowers_version: 2.87.3
-bug_cycle: null
+bug_cycle:
+  current_step: 5
+  completed_steps:
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
 handoff:
-  next_skill: 'null'
-  context: "BUG-2026-08-06-pi-drops-skills-frontmatter RESOLVED — merged as 3d4f0cf3 (#108), released in v2.87.3. Story tags now live inside SKILL.md frontmatter; validator scans sources + generated copies with a starts-with-'---' rule."
-  next_skill: release-branch
-  context: 'BUG-2026-08-06-pi-drops-skills-frontmatter — fix landed on branch fix/pi-skills-frontmatter-delimiter,
-    PR #109 open, CI pending. validate-fix green (validator 162/162, compliance 98/98, golden 38/38).'
+  next_skill: null
+  context: 'BUG-2026-08-07-interactive-uninstall-silent-noop — released via PR on
+    danielvm-git/interactive-menu-uninstall-bug-0ea2f7'
   epic: null
 epic_cycle: null
 metrics:
@@ -25,6 +30,11 @@ metrics:
       calls: 1
       total_seconds: 1052.0
       avg_seconds: 1052.0
+    release-branch:
+      calls: 0
+      total_seconds: 0
+      avg_seconds: 0
+      _start: '2026-08-07T11:24:34Z'
 release:
   ci_verified: true
   last_commit: 3daf6225


### PR DESCRIPTION
## Summary
<!-- bigpowers-provenance: agent-generated -->

- **Gap 1**: Added uninstall cases for 8 missing tools (`qwen`, `codebuddy`, `cline`, `kilo`, `trae`, `windsurf`, `opencode`, `copilot`) — these had `installGlobal()` entries but no `uninstallTool()` case, so the menu silently no-oped while printing `✓ removed`
- **Gap 2**: Added local (`cwd`) path cleanup to all `uninstallTool()` cases — `installLocal()` writes symlinks under `process.cwd()`, but `uninstallTool()` never looked at `cwd`, leaving every local install untouched regardless of which tool was selected
- Fixed `codex` case to also remove `~/.codex/AGENTS.md` (install created it; uninstall missed it)
- Added `removeRepoRootedSkillLinks`, `removeManagedSkillLinks`, and `removeManagedFile` helpers for the three distinct removal shapes
- Guard: `antigravity`/`agy` skips `cwd/.agents/skills` when `cwd === repoRoot` (tracked source tree, not an install target)

## Test plan
- [x] `node scripts/test-install-helpers.js` → `ALL PASS`
- [x] Global round-trips for `qwen` (symlinked skills) and `copilot` (plain-copied `AGENTS.md`)
- [x] Local install/uninstall round-trips for `pi`, `claude` (skill-symlink dirs), `cursor`, `gemini` (linked dirs), `codex` (linked file)
- [x] Drift guard: parses `SUPPORTED_IDS` from `bin/setup.js` and asserts every id has a matching `case` in `uninstallTool` — mutation-tested to fail immediately when a case is missing
- [x] `bash scripts/trace-stories.sh --strict` → exit 0
- [x] Traceability gate: pass

Closes BUG-2026-08-07-interactive-uninstall-silent-noop