### PR TITLE
fix(packaging): ship wire-ci CI templates in the npm tarball

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,7 +3,8 @@
 node_modules
 *.test.js
 specs/
-docs/
+docs/*
+!docs/templates/
 .DS_Store
 .env
 .env.local

--- a/scripts/test-install-helpers.js
+++ b/scripts/test-install-helpers.js
@@ -230,6 +230,7 @@ try {
       '.cursor/rules',
       '.pi/skills',
       'skills/audit-code/SKILL.md',
+      'docs/templates/ci/github/test-build-release-node.yml',
     ];
     const isIgnored = (p) =>
       npmignore.some((pat) => {
@@ -240,6 +241,30 @@ try {
       assert.ok(
         !isIgnored(p),
         `.npmignore must not exclude installer-referenced path: ${p} (BUG-2026-08-07)`
+      );
+    }
+  }
+
+  // story: #113 — wire-ci templates must actually ship in the npm tarball.
+  // The .npmignore pattern check above is necessary but not sufficient (it
+  // cannot model gitignore negation); prove it with a real pack listing.
+  {
+    const { execSync } = require('child_process');
+    const packOut = execSync('npm pack --dry-run 2>&1', {
+      cwd: ROOT,
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    for (const tpl of [
+      'docs/templates/ci/github/test-build-release-node.yml',
+      'docs/templates/ci/github/test-build-release-rust.yml',
+      'docs/templates/ci/github/test-build-release-python.yml',
+      'docs/templates/ci/github/test-build-release-go.yml',
+      'docs/templates/AGENTS.md',
+    ]) {
+      assert.ok(
+        packOut.includes(tpl),
+        `npm tarball must include ${tpl} (wire-ci templates, #113)`
       );
     }
   }


### PR DESCRIPTION
## Summary

`.npmignore` excluded `docs/` wholesale, so the npm package dropped `docs/templates/ci/github/*.yml` — the exact files `wire-ci`'s verify gate and self-test require. The templates exist in the repo but never reached installed users, so every `wire-ci` run emitted `SKIP — no bundled template` and `bash scripts/wire-ci.sh --self-test` failed against the package.

## Change

- `.npmignore`: `docs/` → `docs/*` + `!docs/templates/` — ships the 20K `docs/templates/` (the four CI templates + the `AGENTS.md` Reach template that `seed-conventions` and `verify-install.sh` reference at runtime) while still excluding the 1.3 MB of docs prose/images.
- `scripts/test-install-helpers.js`: extend the existing BUG-2026-08-07 `.npmignore` regression guard with a real `npm pack --dry-run` assertion that all four CI templates and `docs/templates/AGENTS.md` are present in the tarball — a pattern check alone cannot model gitignore negation.

## Verification

- `bash scripts/wire-ci.sh --self-test` → PASS (was FAIL against the package).
- `bash scripts/run-skill-verify.sh wire-ci` → 3 PASS, 0 FAIL (was 2 FAIL).
- `npm pack --dry-run` lists all four `docs/templates/ci/github/*.yml` files.
- `bash scripts/test-install-helpers.sh` → ALL PASS.

Closes #113.
