### PR TITLE
fix(ci): run npm ci before verification gates so omp-extension smoke resolves typebox

### DIFF
--- a/.github/workflows/golden-suite.yml
+++ b/.github/workflows/golden-suite.yml
@@ -53,6 +53,13 @@ jobs:
       - name: Install Python deps
         run: python3 -m pip install --user -r requirements.txt
 
+      # The omp-extension gate executes scripts/omp-smoke.ts, which imports
+      # extensions/omp-hooks.ts -> typebox. Plain-node ESM resolution needs
+      # node_modules; without this the gate fails with ERR_MODULE_NOT_FOUND.
+      # Full install (no --omit=dev): typebox is a devDependency.
+      - name: Install Node deps
+        run: npm ci
+
       - name: Run verification gates (G-08/G-10 anti-vacuity)
         run: bash scripts/run-verification-gates.sh
 

--- a/specs/benchmarks/reports/GOLDEN-2026-09-05.yaml
+++ b/specs/benchmarks/reports/GOLDEN-2026-09-05.yaml
@@ -1,5 +1,5 @@
-timestamp: "2026-09-05T13:26:33Z"
-git_commit: "0e071af3e003fef676fa2e7de8e12c68c981a7e7"
+timestamp: "2026-09-06T00:13:58Z"
+git_commit: "9b8453ce9b153277ba67fa30f330b325acab299c"
 suite: "golden-combined"
 mode: "daily"
 deterministic:
@@ -11,7 +11,7 @@ deterministic:
 gates:
   - name: compliance
     exit_code: 0
-    duration_seconds: 107.67
+    duration_seconds: 127.30
     status: pass
   - name: g04-selftest
     exit_code: 0
@@ -19,155 +19,155 @@ gates:
     status: pass
   - name: g06-migrate-version
     exit_code: 0
-    duration_seconds: 53.20
+    duration_seconds: 9.76
     status: pass
   - name: g07-negative-path
     exit_code: 0
-    duration_seconds: .11
+    duration_seconds: .07
     status: pass
   - name: g08-anti-vacuity
     exit_code: 0
-    duration_seconds: .87
+    duration_seconds: .09
     status: pass
   - name: g09-yaml-roundtrip
     exit_code: 0
-    duration_seconds: 1.34
+    duration_seconds: .11
     status: pass
   - name: g10-trace-anti-vacuity
     exit_code: 0
-    duration_seconds: .87
+    duration_seconds: .11
     status: pass
   - name: g11-gitignore-venv
     exit_code: 0
-    duration_seconds: .12
+    duration_seconds: .09
     status: pass
   - name: g12-status-selftest
     exit_code: 0
-    duration_seconds: 1.92
+    duration_seconds: .60
     status: pass
   - name: g12-status-consistency
     exit_code: 0
-    duration_seconds: 1.13
+    duration_seconds: .22
     status: pass
   - name: g15-compliance-runner-selftest
     exit_code: 0
-    duration_seconds: .06
+    duration_seconds: .04
     status: pass
   - name: g15-compliance-runner
     exit_code: 0
-    duration_seconds: .19
+    duration_seconds: .11
     status: pass
   - name: g13-script-orphans-selftest
     exit_code: 0
-    duration_seconds: 64.61
+    duration_seconds: 54.18
     status: pass
   - name: g13-script-orphans
     exit_code: 0
-    duration_seconds: 51.82
+    duration_seconds: 52.42
     status: pass
   - name: workflow-diagrams-fresh
     exit_code: 0
-    duration_seconds: .75
+    duration_seconds: .08
     status: pass
   - name: reference-nav-fresh
     exit_code: 0
-    duration_seconds: .70
+    duration_seconds: .06
     status: pass
   - name: g14-adapter-dispatch-selftest
     exit_code: 0
-    duration_seconds: 1.09
+    duration_seconds: .12
     status: pass
   - name: g14-adapter-dispatch
     exit_code: 0
-    duration_seconds: .71
+    duration_seconds: .08
     status: pass
   - name: g16-spec-version-gap-selftest
     exit_code: 0
-    duration_seconds: 2.12
+    duration_seconds: .17
     status: pass
   - name: g16-spec-version-gap
     exit_code: 0
-    duration_seconds: 1.06
+    duration_seconds: .09
     status: pass
   - name: target-contracts
     exit_code: 0
-    duration_seconds: 2.46
+    duration_seconds: .21
     status: pass
   - name: install-hub
     exit_code: 0
-    duration_seconds: 8.67
+    duration_seconds: 7.68
     status: pass
   - name: adapter-render
     exit_code: 0
-    duration_seconds: 4.11
+    duration_seconds: 3.37
     status: pass
   - name: adapters
     exit_code: 0
-    duration_seconds: 2.87
+    duration_seconds: 2.49
     status: pass
   - name: tombstone-mechanism
     exit_code: 0
-    duration_seconds: 2.73
+    duration_seconds: 1.80
     status: pass
   - name: trace-strict
     exit_code: 0
-    duration_seconds: 10.95
+    duration_seconds: 36.06
     status: pass
   - name: trace-matrix-size
     exit_code: 0
-    duration_seconds: .03
+    duration_seconds: .02
     status: pass
   - name: setup-no-pyyaml
     exit_code: 0
-    duration_seconds: 3.47
+    duration_seconds: 2.54
     status: pass
   - name: install-distribute-only
     exit_code: 0
-    duration_seconds: 64.42
+    duration_seconds: 48.00
     status: pass
   - name: completeness-critic-scope
     exit_code: 0
-    duration_seconds: .23
+    duration_seconds: .21
     status: pass
   - name: epics-wiki-zero-stories
     exit_code: 0
-    duration_seconds: 3.92
+    duration_seconds: 4.28
     status: pass
   - name: golden-g11-worktree-venv
     exit_code: 0
-    duration_seconds: .13
+    duration_seconds: .12
     status: pass
   - name: install-helpers
     exit_code: 0
-    duration_seconds: 2.25
+    duration_seconds: 10.82
     status: pass
   - name: project-runtime
     exit_code: 0
-    duration_seconds: .07
+    duration_seconds: .06
     status: pass
   - name: omp-extension
     exit_code: 0
-    duration_seconds: .43
+    duration_seconds: .24
     status: pass
   - name: import-boundaries
     exit_code: 0
-    duration_seconds: .38
+    duration_seconds: .26
     status: pass
   - name: skill-catalog
     exit_code: 0
-    duration_seconds: 2.10
+    duration_seconds: 1.97
     status: pass
   - name: specs-parse
     exit_code: 0
-    duration_seconds: 3.78
+    duration_seconds: 1.01
     status: pass
   - name: story-verify-selftest
     exit_code: 0
-    duration_seconds: 1.14
+    duration_seconds: .14
     status: pass
   - name: story-verify
     exit_code: 0
-    duration_seconds: 271.07
+    duration_seconds: 267.55
     status: pass
 agent_stories:
   total: 0

--- a/specs/bugs/BUG-2026-09-05-golden-gate-missing-node-deps.md
+++ b/specs/bugs/BUG-2026-09-05-golden-gate-missing-node-deps.md
@@ -1,0 +1,116 @@
+---
+bug_id: BUG-2026-09-05-golden-gate-missing-node-deps
+status: open
+severity: high
+scope: ci
+title: "golden-suite omp-extension gate fails: CI never installs node deps, so smoke's typebox import is unresolvable"
+issue: https://github.com/danielvm-git/bigpowers/issues/119
+related: BUG-2026-09-05-pi-omp-extension-load-crash
+---
+
+# BUG-2026-09-05 (II): omp-extension golden gate needs node_modules; CI never installs it
+
+## Problem
+
+- **Actual**: CI run `33981866073` (main @ `9b8453ce`, Golden Anti-Vacuity Suite)
+  fails `verification-gates`: 39/40 gates pass, `[omp-extension] FAIL (.26s, exit 1)`.
+  Root error inside the gate:
+
+  ```text
+  Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'typebox'
+  imported from .../extensions/omp-hooks.ts
+  ```
+
+- **Expected**: `verification-gates` green; the `omp-extension` gate (the runtime
+  load smoke added in a4875651 for #119) executes and passes.
+
+- **Reproduce**:
+  1. `gh run view 33981866073 --repo danielvm-git/bigpowers --log-failed`
+  2. Locally: `rm -rf node_modules && bash scripts/validate-omp-extension.sh` →
+     runtime load smoke FAIL with `ERR_MODULE_NOT_FOUND: typebox`.
+  3. `npm ci && bash scripts/validate-omp-extension.sh` → PASS.
+
+## Root Cause Analysis
+
+a4875651 (#119 fix, released 2.88.1) did three coupled things:
+
+1. Ported `extensions/omp-hooks.ts` from the nonexistent `pi.zod` to
+   `import { Type } from "typebox"` — correct for real pi (pi bundles TypeBox and
+   virtualises `typebox` for extensions via jiti aliases), so npm consumers are fine.
+2. Added `typebox ^1.3.7` to **devDependencies** (package-lock: 1.3.27).
+3. Made `scripts/validate-omp-extension.sh` execute `node scripts/omp-smoke.ts`
+   as a deterministic runtime-load regression gate (registered in
+   `scripts/lib/golden-suite-gates.sh` as `omp-extension`), run by
+   `bash scripts/run-verification-gates.sh`.
+
+The missing coupling: **`.github/workflows/golden-suite.yml` never installs node
+dependencies.** The `verification-gates` job does checkout → setup-node →
+python deps → gates. Every other gate is bash/python and needs no node_modules,
+so the suite historically ran dependency-free. The new smoke runs under plain
+Node ESM (NOT pi's aliased loader), so `import { Type } from "typebox"` must
+resolve from `node_modules` — which does not exist on the runner → exit 1.
+
+Why it was missed at a4875651: the fix was verified locally (node_modules present,
+smoke passed) and against pi's real loader — both environments have TypeBox. CI,
+the only environment without node_modules, was not exercised before merge.
+
+`docs-site.yml` and `publish.yml` already run `npm ci` — golden-suite.yml is the
+outlier now that one gate genuinely needs Node packages.
+
+**Security impact: NONE** — availability/CI defect only.
+
+## Fix Plan
+
+### Step 1 — RED (already captured)
+- CI evidence: run 33981866073, `[omp-extension] FAIL`, gate log above.
+- Local evidence: pre-`npm ci` failure reproduced; post-`npm ci` green
+  (81 commands, bigpowers_skill tool, session_start + tool_call handlers).
+
+### Step 2 — GREEN (minimal fix)
+Add one step to the `verification-gates` job in `.github/workflows/golden-suite.yml`,
+after "Install Python deps" and before "Run verification gates":
+
+```yaml
+      - name: Install Node deps
+        run: npm ci
+```
+
+Notes:
+- Full `npm ci` (NOT `--omit=dev`) — `typebox` is a devDependency.
+- Lockfile-pinned (`package-lock.json`, typebox 1.3.27) → deterministic.
+- Keep the `# story: e51s04` tag in the workflow header (traceability).
+
+Considered and rejected:
+- Moving the runtime smoke behind a "skip if no node_modules" guard → makes the
+  gate vacuous in CI; violates the anti-vacuity doctrine this suite exists to
+  enforce (G-08/G-10).
+- Making the smoke import via pi's loader to pick up bundled TypeBox → adds
+  `@earendil-works/pi-coding-agent` as a devDependency and the same `npm ci`
+  requirement, for no behavior gain.
+
+### Step 3 — validate-fix
+1. `npm ci && bash scripts/validate-omp-extension.sh` → exit 0.
+2. `bash scripts/run-verification-gates.sh` → 40/40 PASS locally.
+3. Preflight: `npm run compliance && bash scripts/run-verification-gates.sh &&
+   bash scripts/sync-skills.sh && bash scripts/trace-stories.sh --strict`.
+4. Push branch + PR; `gh pr checks` green on the PR (this is the environment
+   that actually lacked node_modules — local green alone is NOT sufficient;
+   that is exactly how this bug shipped).
+
+### Step 4 — release-branch
+Merge to main; confirm the next push-triggered golden-suite run is 40/40 green.
+
+## Files to change
+
+- `.github/workflows/golden-suite.yml` — add `npm ci` step to verification-gates job.
+
+## Lessons (add to BUG-2026-09-05-pi-omp-extension-load-crash.md on close)
+
+The #119 fix's validation matrix omitted the only environment that lacks
+node_modules (CI runner). Rule going forward: any new CI gate that executes
+node code must either declare its dependencies in the workflow (npm ci) or
+prove it needs none.
+
+## Commit message (proposed)
+
+`fix(ci): run npm ci before verification gates so omp-extension smoke resolves typebox`

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -1,25 +1,22 @@
 active_flow: fix_bug
 active_epic: null
 active_story: null
-bug_id: BUG-2026-09-05-pi-omp-extension-load-crash
+bug_id: BUG-2026-09-05-golden-gate-missing-node-deps
 bigpowers_version: 2.88.1
 bug_cycle:
-  current_step: 5
-  completed_steps:
-  - 1
-  - 2
-  - 3
-  - 4
-  bug_file: specs/bugs/BUG-2026-09-05-pi-omp-extension-load-crash.md
-  validation: 'All gates green (compliance, golden suite incl. omp-extension, trace --strict). Real pi
-    0.85.1 loads packed extension: 81 commands + bigpowers_skill tool + 2 handlers, 0 errors.'
+  current_step: 1
+  completed_steps: []
+  bug_file: specs/bugs/BUG-2026-09-05-golden-gate-missing-node-deps.md
+  note: 'Predecessor BUG-2026-09-05-pi-omp-extension-load-crash RESOLVED — merged a4875651 (PR #119), released 2.88.1.'
 handoff:
-  next_skill: develop-tdd
-  context: 'BUG-2026-09-05 (#119): pi install npm:bigpowers crashes pi at startup — extensions/omp-hooks.ts
-    calls pi.setLabel() during load (action method → throws "runtime not initialized"). RCA complete (verified
-    against pi 0.85.1 source via opensrc + docs/extensions.md). Fix: remove line 241 setLabel call; harden
-    scripts/omp-smoke.ts to model load-phase guard; promote dead omp.extensions → pi.extensions in package.json
-    + validate-omp-extension.sh. Steps 1-2 done in bug file; at step 3 develop-tdd.'
+  next_skill: investigate-bug
+  context: 'CI run 33981866073 red on main (9b8453ce): golden suite verification-gates 39/40 —
+    [omp-extension] FAIL: ERR_MODULE_NOT_FOUND typebox. The #119 fix added a runtime smoke gate
+    (scripts/omp-smoke.ts → imports extensions/omp-hooks.ts → import { Type } from "typebox") but
+    golden-suite.yml never installs node deps. RCA in specs/bugs/BUG-2026-09-05-golden-gate-missing-node-deps.md.
+    Fix: add "npm ci" step to verification-gates job (full install — typebox is a devDependency).
+    Local repro: pre-npm-ci FAIL / post-npm-ci PASS (validate-omp-extension.sh). Steps 1-2 evidence
+    already captured in bug file; proceed to develop-tdd (Step 3 green) → validate-fix → release-branch.'
   epic: null
 epic_cycle: null
 metrics:


### PR DESCRIPTION
## Context

CI run [33981866073](https://github.com/danielvm-git/bigpowers/actions/runs/33981866073) failed `verification-gates` on `main` (39/40): `[omp-extension] FAIL (.26s, exit 1)`.

Follow-up to the #119 fix (a4875651 / v2.88.1): that PR hardened `scripts/validate-omp-extension.sh` to execute `node scripts/omp-smoke.ts` as a runtime regression gate. The smoke imports `extensions/omp-hooks.ts`, which does `import { Type } from "typebox"`. Under plain Node ESM (not pi's aliased loader) that import must resolve from `node_modules` — which does not exist on the CI runner, because `golden-suite.yml` never installed node deps (every other gate is bash/python only).

## Fix

Add one step to the `verification-gates` job:

```yaml
      - name: Install Node deps
        run: npm ci
```

Full `npm ci` (no `--omit=dev`) — `typebox` is a devDependency. Precedent: `docs-site.yml` and `publish.yml` already run `npm ci`.

Rejected: skipping the smoke when deps are absent (vacuous gate — violates the anti-vacuity doctrine this suite enforces); importing via pi's loader (same install requirement, no gain).

## Verification

- **RED**: CI run 33981866073 (`ERR_MODULE_NOT_FOUND: Cannot find package 'typebox'`); reproduced locally pre-`npm ci`.
- **GREEN locally**: post-`npm ci`, `bash scripts/run-verification-gates.sh` → **40/40 PASS** incl. `omp-extension` (81 commands + `bigpowers_skill` tool + 2 handlers, 0 load errors).
- **Preflight**: `npm run compliance` ✓, gates ✓, `sync-skills.sh` ✓, `trace-stories.sh --strict` ✓.
- The PR itself is the only remaining unknown: CI is the one environment that lacked node_modules, so `gh pr checks` green on this PR (and the next push-triggered golden suite on main) is the true validation.

RCA + rejected alternatives + lesson: `specs/bugs/BUG-2026-09-05-golden-gate-missing-node-deps.md`
