### PR TITLE
fix(pi): prevent duplicate Bigpowers slash commands

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,7 +36,7 @@ Discovered via fork audit on 2026-09-01.
 
 XcluEzy7 built a native [oh-my-pi](https://github.com/oh-my-pi) OMP plugin that:
 
-- Discovers every skill in `skills/` at runtime and registers each as a slash command.
+- Discovers every skill in `skills/` at runtime for dynamic tool invocation.
 - Exposes a unified `bigpowers_skill` LLM tool with `list`/`get`/`run` operations.
 - Ports bigpowers' git-safety pre-tool-use hook into OMP's `tool_call` event API,
   blocking dangerous patterns and enforcing Conventional Commits.

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ bigpowers has been shaped by contributors who extended it in their own forks.
 See [CONTRIBUTORS.md](CONTRIBUTORS.md) for the full list.
 
 - **[Kevin Oberlies (favilo)](https://github.com/favilo/bigpowers)** — Jujutsu VCS support across lifecycle skills + `project-runtime.sh` configurable settings library.
-- **[XcluEzy7](https://github.com/XcluEzy7/bigpowers)** — OMP plugin extension (`extensions/omp-hooks.ts`): native skill discovery, slash commands, and git-safety hooks for the oh-my-pi runtime.
+- **[XcluEzy7](https://github.com/XcluEzy7/bigpowers)** — OMP plugin extension (`extensions/omp-hooks.ts`): native skill discovery, unified skill tooling, and git-safety hooks for the oh-my-pi runtime.
 
 ---
 

--- a/extensions/omp-hooks.ts
+++ b/extensions/omp-hooks.ts
@@ -1,7 +1,8 @@
 // story: e82s03
 // extensions/omp-hooks.ts
-// bigpowers — Single OMP extension entry exposing every source skill as a
-// slash command, a bigpowers_skill LLM tool, and safety policy guards.
+// bigpowers — Single OMP extension entry exposing source skills through the
+// bigpowers_skill LLM tool and enforcing safety policy guards. Pi prompt
+// templates own slash-command registration so each workflow appears once.
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { execSync } from "node:child_process";
@@ -246,18 +247,6 @@ export default function bigpowers(pi: ExtensionAPI) {
 
   // Discover skills from skills/ in the installed plugin package root.
   const skills = discoverSkills(join(pluginRoot(), "skills"));
-
-  // ----- Slash commands --------------------------------------------------
-
-  for (const skill of skills) {
-    pi.registerCommand(skill.name, {
-      description: skill.description,
-      handler: async (args, _ctx) => {
-        const prompt = buildSkillPrompt(skill, args);
-        await injectSkillPrompt(pi, prompt);
-      },
-    });
-  }
 
   // ----- bigpowers_skill tool --------------------------------------------
 

--- a/scripts/omp-smoke.ts
+++ b/scripts/omp-smoke.ts
@@ -1,7 +1,7 @@
 // story: e82s03
 // Runtime smoke for extensions/omp-hooks.ts.
-// Imports the extension, registers a fake ExtensionAPI, calls registered hooks,
-// and asserts the slash-command handler awaits injection.
+// Imports the extension, registers a fake ExtensionAPI, and verifies the
+// extension leaves commands to prompt templates while skill-tool injection works.
 //
 // Load-phase contract (BUG-2026-09-05, #119): pi installs throwing stubs for
 // ACTION methods during extension loading and only binds real implementations
@@ -10,6 +10,7 @@
 // fails here exactly as it does in real pi, instead of silently passing.
 // See pi 0.85.1 src/core/extensions/loader.ts (createExtensionRuntime).
 
+import { readFileSync } from "node:fs";
 import bigpowers from "../extensions/omp-hooks.ts";
 
 type AnyObj = Record<string, unknown>;
@@ -82,22 +83,25 @@ await bigpowers(pi as unknown as never);
 // are callable from here on (handlers, tool executions).
 loading = false;
 
+const packageManifest = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as { pi?: { prompts?: string[] } };
+const promptTemplates = packageManifest.pi?.prompts ?? [];
+
+if (commands.size !== 0) {
+  throw new Error(`extension registered ${commands.size} duplicate workflow commands`);
+}
+if (!promptTemplates.includes("./.pi/prompts")) {
+  throw new Error("package does not declare the canonical Pi prompt templates");
+}
+
 console.log(JSON.stringify({
   commands: commands.size,
+  promptTemplates,
   tool: tools[0]?.name,
   events: [...events.keys()],
-  firstCommand: [...commands.keys()].slice(0, 5),
   sendUserMessageAwaitable: typeof pi.sendUserMessage === "function",
 }));
-
-// Exercise the /survey-context handler end-to-end.
-const handler = commands.get("survey-context")?.handler;
-if (!handler) throw new Error("survey-context command not registered");
-await handler("", {});
-
-// Verify a nonexistent command is not present.
-const fallback = commands.get("nonexistent-skill-for-test")?.handler;
-if (fallback) throw new Error("unexpected command registered");
 
 // Test bigpowers_skill run path.
 const skillTool = tools[0];

--- a/scripts/validate-omp-extension.sh
+++ b/scripts/validate-omp-extension.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # story: e82s03
-# OMP extension integrity guard — validates the extension entry is wired
-# correctly and all source skills are discoverable via skills/<name>/SKILL.md.
+# OMP extension integrity guard — validates the extension entry is wired,
+# leaves slash commands to Pi prompt templates, and discovers all source skills.
 # Run before merging any branch that touches extensions/.
 set -euo pipefail
 
@@ -43,18 +43,30 @@ else
   fi
 fi
 
-# ── 3. Extension source contains required symbols ──────────────────────────
-echo "--- [OMP] required runtime symbols in extension ---"
+# ── 3. Extension owns tools/hooks; prompt templates own slash commands ─────
+echo "--- [OMP] separated runtime responsibilities ---"
 if [[ -n "$EXT_PATH" && -f "$EXT_PATH" ]]; then
-  for sym in "registerCommand" "registerTool" "tool_call"; do
+  for sym in "registerTool" "tool_call"; do
     if grep -q "$sym" "$EXT_PATH" 2>/dev/null; then
       pass "symbol '$sym' found in extension source"
     else
       fail "symbol '$sym' NOT found in extension source"
     fi
   done
+  if grep -q 'pi\.registerCommand' "$EXT_PATH" 2>/dev/null; then
+    fail "extension registers commands already supplied by Pi prompt templates"
+  else
+    pass "extension leaves slash-command registration to Pi prompt templates"
+  fi
 else
   fail "Cannot scan extension symbols — file not resolved"
+fi
+
+PROMPT_COUNT=$(node -e "const p = require('./package.json'); console.log(p.pi?.prompts?.length || 0)")
+if [[ "$PROMPT_COUNT" -eq 1 ]]; then
+  pass "pi.prompts has exactly 1 canonical prompt-template entry"
+else
+  fail "pi.prompts has $PROMPT_COUNT entries (expected 1)"
 fi
 
 # ── 4. Skill discovery root is skills/ ────────────────────────────────────

--- a/specs/bugs/BUG-2026-09-05-golden-gate-missing-node-deps.okf.md
+++ b/specs/bugs/BUG-2026-09-05-golden-gate-missing-node-deps.okf.md
@@ -1,0 +1,21 @@
+---
+okf_kind: concept
+okf_version: "0.1"
+type: Bug
+id: "BUG-2026-09-05-golden-gate-missing-node-deps"
+title: "golden-suite omp-extension gate fails: CI never installs node deps, so smoke's typebox import is unresolvable"
+category: bug
+tier: extended
+severity: high
+status: resolved
+generator: scripts/sync-bugs-registry.sh
+references:
+    - specs/bugs/BUG-2026-09-05-golden-gate-missing-node-deps.md
+---
+
+# golden-suite omp-extension gate fails: CI never installs node deps, so smoke's typebox import is unresolvable
+
+**Bug:** BUG-2026-09-05-golden-gate-missing-node-deps | **Severity:** high | **Status:** resolved | **Scope:** ci
+**Tier:** extended
+
+See `specs/bugs/BUG-2026-09-05-golden-gate-missing-node-deps.md` for full investigation and fix details.

--- a/specs/bugs/BUG-2026-09-05-pi-omp-extension-load-crash.okf.md
+++ b/specs/bugs/BUG-2026-09-05-pi-omp-extension-load-crash.okf.md
@@ -1,0 +1,21 @@
+---
+okf_kind: concept
+okf_version: "0.1"
+type: Bug
+id: "BUG-2026-09-05-pi-omp-extension-load-crash"
+title: "extensions/omp-hooks.ts calls pi.setLabel() during load → pi aborts at startup for every package consumer (#119)"
+category: bug
+tier: extended
+severity: critical
+status: open
+generator: scripts/sync-bugs-registry.sh
+references:
+    - specs/bugs/BUG-2026-09-05-pi-omp-extension-load-crash.md
+---
+
+# extensions/omp-hooks.ts calls pi.setLabel() during load → pi aborts at startup for every package consumer (#119)
+
+**Bug:** BUG-2026-09-05-pi-omp-extension-load-crash | **Severity:** critical | **Status:** open | **Scope:** extensions / pi
+**Tier:** extended
+
+See `specs/bugs/BUG-2026-09-05-pi-omp-extension-load-crash.md` for full investigation and fix details.

--- a/specs/bugs/BUG-2026-09-09-pi-duplicate-slash-commands.md
+++ b/specs/bugs/BUG-2026-09-09-pi-duplicate-slash-commands.md
@@ -1,0 +1,86 @@
+---
+bug_id: BUG-2026-09-09-pi-duplicate-slash-commands
+status: resolved
+severity: medium
+scope: extensions / pi
+title: "Pi shows every Bigpowers slash command twice (#121)"
+issue: https://github.com/danielvm-git/bigpowers/issues/121
+files_changed: "extensions/omp-hooks.ts, scripts/omp-smoke.ts, scripts/validate-omp-extension.sh, README.md, CONTRIBUTORS.md"
+approach: "Keep Pi prompt templates as the canonical slash-command provider and remove redundant extension command registration"
+risk_level: low
+commit_message: "fix(pi): prevent duplicate Bigpowers slash commands"
+---
+
+# BUG-2026-09-09: Pi shows every Bigpowers slash command twice (#121)
+
+## Problem
+
+- **Actual:** Installing Bigpowers 2.88.1 or newer as a Pi package makes every
+  Bigpowers workflow appear twice in slash-command autocomplete.
+- **Expected:** Each workflow appears once while native skill discovery, explicit
+  slash invocation, the `bigpowers_skill` tool, and Git safety guards remain available.
+- **Reproduce:** Install Bigpowers as a Pi package, start Pi, type `/`, and inspect
+  entries such as `/commit-message` or `/grill-me`.
+
+**Security impact: NONE** — this is a command-discovery usability defect. No security
+exploit path was identified.
+
+## Root Cause Analysis
+
+The Pi package already supplies one prompt template per workflow. Pi exposes those
+prompt templates as slash commands. A later extension integration independently began
+registering one slash command per source skill under the same names. Pi retains both
+providers in autocomplete, so all workflow commands appear twice.
+
+The prompt-template surface predates the extension and is the documented Pi command
+mechanism. It also works without requiring extension execution. The extension still
+has distinct responsibilities: exposing the unified skill tool and enforcing Git
+safety policy. Removing only its duplicate command registrations preserves those
+responsibilities and avoids removing an established package artifact.
+
+This is a regression introduced when extension command registration was added. Risk is
+**Low** because the fix removes one redundant route while retaining the documented
+slash-command route and all non-command extension behavior.
+
+## TDD Fix Plan
+
+1. **RED:** Update the extension runtime smoke test to require zero extension-provided
+   workflow commands while confirming prompt templates remain declared by the package.
+   The current extension fails because it registers every source skill as a command.
+   **GREEN:** Remove per-skill slash-command registration from the extension.
+   **verify:** `node scripts/omp-smoke.ts`
+
+2. **RED:** Update the extension integrity gate to reject workflow command registration
+   while still requiring the skill tool and Git safety hook.
+   **GREEN:** Align extension comments and validation expectations with the separated
+   responsibilities.
+   **verify:** `bash scripts/validate-omp-extension.sh`
+
+**REFACTOR:** Remove command-only prompt construction and injection helpers if no
+remaining extension path uses them; retain shared behavior required by the skill tool.
+
+## Acceptance Criteria
+
+- [x] Pi receives one slash-command provider per Bigpowers workflow.
+- [x] Generated Pi prompt templates remain available.
+- [x] Native Pi skill discovery remains available.
+- [x] The `bigpowers_skill` tool still supports list, get, and run.
+- [x] Git safety hooks remain registered.
+- [x] Extension smoke and integrity tests pass.
+- [x] Full repository verification passes.
+
+## Resolution
+
+Removed per-skill command registration from the extension while retaining generated Pi
+prompt templates as the canonical slash-command provider. The extension continues to
+register `bigpowers_skill`, session notification, and Git safety hooks. The runtime
+smoke now asserts zero extension commands, one prompt-template manifest entry, and a
+working `bigpowers_skill run` path.
+
+Focused validation:
+
+- `node scripts/omp-smoke.ts` — pass
+- `bash scripts/validate-omp-extension.sh` — pass
+- `bash -n scripts/validate-omp-extension.sh` — pass
+- `git diff --check` — pass
+- `npm run compliance && bash scripts/run-verification-gates.sh && bash scripts/sync-skills.sh && bash scripts/trace-stories.sh --strict` — pass; deterministic golden suite 40/40

--- a/specs/bugs/BUG-2026-09-09-pi-duplicate-slash-commands.okf.md
+++ b/specs/bugs/BUG-2026-09-09-pi-duplicate-slash-commands.okf.md
@@ -1,0 +1,21 @@
+---
+okf_kind: concept
+okf_version: "0.1"
+type: Bug
+id: "BUG-2026-09-09-pi-duplicate-slash-commands"
+title: "Pi shows every Bigpowers slash command twice (#121)"
+category: bug
+tier: extended
+severity: medium
+status: resolved
+generator: scripts/sync-bugs-registry.sh
+references:
+    - specs/bugs/BUG-2026-09-09-pi-duplicate-slash-commands.md
+---
+
+# Pi shows every Bigpowers slash command twice (#121)
+
+**Bug:** BUG-2026-09-09-pi-duplicate-slash-commands | **Severity:** medium | **Status:** resolved | **Scope:** extensions / pi
+**Tier:** extended
+
+See `specs/bugs/BUG-2026-09-09-pi-duplicate-slash-commands.md` for full investigation and fix details.

--- a/specs/bugs/registry.yaml
+++ b/specs/bugs/registry.yaml
@@ -500,3 +500,25 @@ bugs:
     scope: cli / install
     title: "Package installs provision skills but never scripts/ — lifecycle skills' script calls and verify gates fail in every consumer project (#116)"
     file: bugs/BUG-2026-08-31-pi-scripts-provisioning.md
+  - id: BUG-2026-09-05-golden-gate-missing-node-deps
+    status: resolved
+    severity: high
+    scope: ci
+    title: "golden-suite omp-extension gate fails: CI never installs node deps, so smoke's typebox import is unresolvable"
+    file: bugs/BUG-2026-09-05-golden-gate-missing-node-deps.md
+  - id: BUG-2026-09-05-pi-omp-extension-load-crash
+    status: open
+    severity: critical
+    scope: extensions / pi
+    title: "extensions/omp-hooks.ts calls pi.setLabel() during load → pi aborts at startup for every package consumer (#119)"
+    file: bugs/BUG-2026-09-05-pi-omp-extension-load-crash.md
+  - id: BUG-2026-09-09-pi-duplicate-slash-commands
+    status: resolved
+    severity: medium
+    scope: extensions / pi
+    title: "Pi shows every Bigpowers slash command twice (#121)"
+    file: bugs/BUG-2026-09-09-pi-duplicate-slash-commands.md
+    files_changed: "extensions/omp-hooks.ts, scripts/omp-smoke.ts, scripts/validate-omp-extension.sh, README.md, CONTRIBUTORS.md"
+    approach: "Keep Pi prompt templates as the canonical slash-command provider and remove redundant extension command registration"
+    risk_level: "low"
+    commit_message: "fix(pi): prevent duplicate Bigpowers slash commands"

--- a/specs/epics/e82-fork-innovations/epic.yaml
+++ b/specs/epics/e82-fork-innovations/epic.yaml
@@ -27,10 +27,10 @@ source: >
   release-branch), and configurable artifact/specs roots.
 
   XcluEzy7: omp-executable-extension branch — self-contained OMP plugin
-  (extensions/omp-hooks.ts) that registers all bigpowers skills as slash commands
-  and a unified bigpowers_skill tool, and ports the git-safety hook into OMP's
-  tool_call API. Needs rebase onto current skills/ layout; the model-stripping and
-  AGENTS.md parts of that branch are skipped.
+  (extensions/omp-hooks.ts) that exposes all bigpowers skills through a unified
+  bigpowers_skill tool and ports the git-safety hook into OMP's tool_call API.
+  Generated Pi prompt templates remain the sole slash-command provider to avoid
+  duplicate entries. The model-stripping and AGENTS.md parts are skipped.
 
 contributors:
   - handle: favilo
@@ -112,9 +112,10 @@ stories:
     tags: [ADDED]
     requirement_delta: ADDED
     description: >
-      Add extensions/omp-hooks.ts: discovers skills/ at runtime, registers each as
-      a slash command and as a unified bigpowers_skill tool (list/get/run), and ports
-      the git-safety PreToolUse hook into OMP's tool_call hook API. Also add
+      Add extensions/omp-hooks.ts: discovers skills/ at runtime, exposes them through
+      a unified bigpowers_skill tool (list/get/run), and ports the git-safety PreToolUse
+      hook into OMP's tool_call hook API. Keep generated Pi prompt templates as the
+      sole slash-command provider to avoid duplicate autocomplete entries. Also add
       scripts/validate-omp-extension.sh and scripts/omp-smoke.ts for CI integrity.
       Rebase XcluEzy7's implementation against the current skills/ source layout
       (their branch was cut from an older snapshot where skills/ didn't exist at root).


### PR DESCRIPTION
## Summary

- keep generated `.pi/prompts` as the sole Bigpowers slash-command provider
- remove duplicate per-skill `registerCommand()` calls from `omp-hooks`
- retain native Pi skills, the `bigpowers_skill` tool, session notification, and Git safety hooks
- add regression coverage that rejects extension command registration while requiring the canonical prompt manifest
- reconcile the e82 specification, contributor docs, and generated bug registry artifacts

## Why this approach

Prompt templates were Bigpowers' established and documented Pi slash-command mechanism before the OMP extension was added in v2.88.1. Removing extension command registration fixes the regression without removing an existing Pi package surface or making slash commands depend on extension execution.

Closes #121.

## Verification

- `node scripts/omp-smoke.ts`
- `bash scripts/validate-omp-extension.sh`
- `bash -n scripts/validate-omp-extension.sh`
- `bash scripts/validate-specs-yaml.sh`
- `git diff --check`
- `npm run compliance && bash scripts/run-verification-gates.sh && bash scripts/sync-skills.sh && bash scripts/trace-stories.sh --strict`
  - deterministic golden suite: **40/40 passed**
- fresh independent review: **PASS**, no findings
